### PR TITLE
Fix Typo in NoMintWarnBanner

### DIFF
--- a/src/components/NoMintWarnBanner.vue
+++ b/src/components/NoMintWarnBanner.vue
@@ -7,7 +7,7 @@
       <q-separator class="q-mb-sm" />
       <div class="text-h6">You're not connected to any mint yet</div>
       <div class="text-subtitle2">
-        Go to the Settings tab to add a mint bewore using this wallet
+        Go to the Settings tab to add a mint before using this wallet
       </div>
     </q-card-section>
   </q-card>


### PR DESCRIPTION
<img width="620" alt="image" src="https://user-images.githubusercontent.com/264977/232839082-afc201e8-bc59-42ce-af03-57d10033f4ce.png">
