### PR TITLE
chore(js): move token code to file

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "lint": "eslint --ext .js,.vue ./",
     "format": "prettier --write \"**/*.{js,vue,scss,html,md,json}\" --ignore-path .gitignore",
-    "test": "echo \"No test specified\" && exit 0"
+    "test": "echo \"No test specified\" && exit 0",
+    "dev": "quasar dev"
   },
   "dependencies": {
     "@capacitor/clipboard": "^4.1.0",

--- a/src/js/token.js
+++ b/src/js/token.js
@@ -1,0 +1,129 @@
+/**
+ * Functions related to cashu tokens
+ * @typedef {{C: string, amount: number, id: number, secret: number}} Proof
+ * @typedef {{proofs: Proof[], mint: string}} Token
+ */
+
+export default { decode, getProofs, getMint };
+
+/**
+ * Decodes an encoded cashu token
+ * @param {string} encoded_token
+ * @returns {Token}
+ */
+function decode(encoded_token) {
+  if (!encoded_token || encoded_token === "") return "";
+  try {
+    encoded_token = cropPrefixes(encoded_token);
+    if (isV2Token(encoded_token)) return parseV2Token(encoded_token);
+    if (isV3Token(encoded_token)) return parseV3Token(encoded_token);
+
+    throw new Error("Unknown token format");
+  } catch (error) {
+    return "";
+  }
+}
+
+/**
+ * Returns a list of proofs from a decoded token
+ * @param {{token: Token[]}} decoded_token
+ * @returns {Proof[]}
+ */
+function getProofs(decoded_token) {
+  if (
+    !(decoded_token.token.length > 0) ||
+    !(decoded_token.token[0].proofs.length > 0)
+  ) {
+    throw new Error("Token format wrong");
+  }
+  return decoded_token.token.map((t) => t.proofs).flat();
+}
+
+/**
+ * @param {{token: Token[]}} decoded_token
+ * @returns {string}
+ */
+function getMint(decoded_token) {
+  /*
+      Returns first mint of a token (very rough way).
+      */
+  if (decoded_token.token != null && decoded_token.token.length > 0) {
+    return decoded_token.token[0].mint;
+  } else {
+    return "";
+  }
+}
+
+/**
+ * @param {string} token
+ * @returns {boolean}
+ */
+function isV2Token(token) {
+  return token.startsWith("eyJwcm9");
+}
+
+/**
+ *
+ * @param {string} token
+ * @returns {boolean}
+ */
+function isV3Token(token) {
+  return token.startsWith("cashuA");
+}
+
+/**
+ * @param {string} encoded_token
+ * @returns {{token: Token[]}}
+ */
+function parseV3Token(encoded_token) {
+  let prefix = "cashuA";
+  let token_parsed = encoded_token.slice(prefix.length);
+  let tokenJson = getTokenJSON(token_parsed);
+  if (
+    !(tokenJson.token.length > 0) ||
+    !(tokenJson.token[0].proofs.length > 0)
+  ) {
+    throw new Error("No proofs in encoded token");
+  }
+  return tokenJson;
+}
+
+/**
+ * @param {string} encoded_token
+ * @returns {{token: Token[]}}
+ */
+function parseV2Token(encoded_token) {
+  let tokenV2 = getTokenJSON(encoded_token);
+  let newToken = {
+    token: [
+      {
+        proofs: tokenV2.proofs,
+        mint: tokenV2.mints[0].url,
+      },
+    ],
+  };
+  return newToken;
+}
+
+/**
+ * @param {string} token
+ * @returns {{token: Token[]}}
+ */
+function getTokenJSON(token) {
+  return JSON.parse(atob(token));
+}
+
+/**
+ *
+ * @param {string} token
+ * @returns {string}
+ */
+function cropPrefixes(token) {
+  let uriPrefixes = ["web+cashu://", "cashu:", "cashu://"];
+  uriPrefixes.forEach((prefix) => {
+    if (token.startsWith(prefix)) {
+      token = token.slice(prefix.length);
+    }
+  });
+  return token;
+}

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -841,6 +841,7 @@ import { uint8ToBase64 } from "src/js/base64";
 import * as _ from "underscore";
 import { getShortUrl } from "src/js/wallet-helpers";
 import { shortenString } from "src/js/string-utils";
+import token from "src/js/token";
 // Vue components
 import BalanceView from "components/BalanceView.vue";
 import SettingsView from "components/SettingsView.vue";
@@ -1045,68 +1046,14 @@ export default {
   },
   methods: {
     // TOKEN METHODS
-
     decodeToken: function (encoded_token) {
-      try {
-        // crop prefixes
-        let UriPrefixes = ["web+cashu://", "cashu:", "cashu://"];
-        UriPrefixes.forEach((prefix) => {
-          if (encoded_token.startsWith(prefix)) {
-            encoded_token = encoded_token.slice(prefix.length);
-          }
-        });
-
-        // v2 token
-        if (encoded_token.startsWith("eyJwcm9")) {
-          let tokenV2 = JSON.parse(atob(encoded_token));
-          let newToken = {
-            token: [
-              {
-                proofs: tokenV2.proofs,
-                mint: tokenV2.mints[0].url,
-              },
-            ],
-          };
-          return newToken;
-        }
-        // v3 token
-        let prefix = "cashuA";
-        if (encoded_token.startsWith(prefix)) {
-          let token_parsed = encoded_token.slice(prefix.length);
-          let tokenJson = JSON.parse(atob(token_parsed));
-          if (
-            !(tokenJson.token.length > 0) ||
-            !(tokenJson.token[0].proofs.length > 0)
-          ) {
-            throw new Error("No proofs in encoded token");
-          }
-          return tokenJson;
-        }
-      } catch (error) {
-        return "";
-      }
+      return token.decode(encoded_token);
     },
     getProofs: function (decoded_token) {
-      /*
-      Returns all proofs in a decoded token.
-      */
-      if (
-        !(decoded_token.token.length > 0) ||
-        !(decoded_token.token[0].proofs.length > 0)
-      ) {
-        throw new Error("Token format wrong");
-      }
-      return decoded_token.token.map((t) => t.proofs).flat();
+      return token.getProofs(decoded_token);
     },
     getMint: function (decoded_token) {
-      /*
-      Returns first mint of a token (very rough way).
-      */
-      if (decoded_token.token != null && decoded_token.token.length > 0) {
-        return decoded_token.token[0].mint;
-      } else {
-        return "";
-      }
+      return token.getMint(decoded_token);
     },
     //
     addMint: async function (url, verbose = false) {


### PR DESCRIPTION
This moves the token code from the Vue component into a standalone file.
This also adds some types via [JSDoc](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) to provide some clarity about what these functions should expect.

Would be great to add unit testing around this at some point too, extracting these more "pure business logic" functions away from the Vue code, and testing them in isolation.