### PR TITLE
[UI] slice 10 letters from center of token

### DIFF
--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -57,7 +57,13 @@
                         </q-td> -->
         <q-td key="token" :props="props">
           <div @click="copyText(props.row.token)">
-            {{ shortenString(props.row.token, 10, 40) }}
+            {{
+              props.row.token.slice(0, 8) +
+              "..." +
+              props.row.token.slice(100, 110) +
+              "..." +
+              props.row.token.slice(-8)
+            }}
             <q-tooltip>Click to copy</q-tooltip>
           </div>
         </q-td>


### PR DESCRIPTION
I wanted to have a better fingerprint of the Tokens in the overview for nuts control. So in this PR I would suggest slicing 10 letters from 100 - 110. And using the usual padding for 8 letters in front and at the end.

<img width="355" alt="Screenshot 2023-06-04 at 17 19 30" src="https://github.com/cashubtc/cashu.me/assets/115992990/d04d7c37-0854-4522-b758-1fe45d111aa3">
