### PR TITLE
[UI] improve wallet refresh

### DIFF
--- a/src/boot/base.js
+++ b/src/boot/base.js
@@ -79,6 +79,20 @@ window.windowMixin = {
         ],
       });
     },
+    notifyRefreshed: async function (message, position = "top") {
+      this.$q.notify({
+        timeout: 500,
+        type: "positive",
+        message: message,
+        position: position,
+        actions: [
+          {
+            color: "white",
+            handler: () => {},
+          },
+        ],
+      });
+    },
     notifyError: async function (message, caption = null) {
       this.$q.notify({
         color: "red",

--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -37,6 +37,7 @@
             />
             <span class="text-weight-light" @click="setTab('settings')">
               Mint: <b>{{ getActiveMintUrlShort }}</b>
+              <q-tooltip>Configure mint(s)</q-tooltip>
             </span>
           </div>
         </div>
@@ -46,16 +47,20 @@
         <div class="col-12">
           <q-icon
             name="history"
-            size="1rem"
+            size="1.5rem"
             color="grey"
             class="q-mr-none q-mb-xs cursor-pointer"
             @click="checkPendingTokens()"
-          />
+          >
+            <q-tooltip>Refresh pending</q-tooltip>
+          </q-icon>
+
           <span
             class="text-weight-light cursor-pointer"
             @click="setTab('history')"
           >
             Pending: {{ formatSat(pendingBalance) }} {{ tickerShort }}
+            <q-tooltip>Show history</q-tooltip>
           </span>
         </div>
       </div>
@@ -65,8 +70,8 @@
 <script>
 import { defineComponent, ref } from "vue";
 import { getShortUrl } from "src/js/wallet-helpers";
-import {mapState} from "pinia";
-import {useMintsStore} from "stores/mints";
+import { mapState } from "pinia";
+import { useMintsStore } from "stores/mints";
 export default defineComponent({
   name: "BalanceView",
   mixins: [windowMixin],
@@ -78,10 +83,10 @@ export default defineComponent({
   },
   computed: {
     ...mapState(useMintsStore, [
-      'activeMintUrl',
-      'activeProofs',
-      'mints',
-      'proofs',
+      "activeMintUrl",
+      "activeProofs",
+      "mints",
+      "proofs",
     ]),
     balance: function () {
       return this.activeProofs

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -1963,7 +1963,7 @@ export default {
     },
 
     checkPendingTokens: async function () {
-      const last_n = 10;
+      const last_n = this.historyTokens.length;
       let i = 0;
       for (const token of this.historyTokens) {
         if (i >= last_n) {
@@ -1974,6 +1974,7 @@ export default {
         }
         i += 1;
       }
+      this.notifyRefreshed("Refreshed");
     },
 
     checkTokenSpendable: async function (token, verbose = true) {


### PR DESCRIPTION
PR #50 republished on origin/

Updates, as indicated in https://github.com/cashubtc/cashu.me/issues/45 and mentioned in https://github.com/cashubtc/cashu.me/issues/42 which include:

- increase size of refresh button in balance view and add mouse over
- add mint mouse over in balance view
- give feedback if pending tokens are refreshed with new notification: `notifyRefreshed`
- increase `last_n` in `checkPendingTokens`, because it was not checking all tokens if number of token in history was to high
- linting 

All tests are passing.

<img width="974" alt="refreshed" src="https://github.com/cashubtc/cashu.me/assets/115992990/1fafa8ad-e15b-4b02-95fb-3f08c82cb5b6">


￼