### PR TITLE
[UI] slice 10 letters from center of token for better fingerprint

### DIFF
--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -57,7 +57,13 @@
                         </q-td> -->
         <q-td key="token" :props="props">
           <div @click="copyText(props.row.token)">
-            {{ shortenString(props.row.token, 10, 40) }}
+            {{
+              props.row.token.slice(0, 8) +
+              "..." +
+              props.row.token.slice(100, 110) +
+              "..." +
+              props.row.token.slice(-8)
+            }}
             <q-tooltip>Click to copy</q-tooltip>
           </div>
         </q-td>

--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -60,7 +60,10 @@
             {{
               props.row.token.slice(0, 8) +
               "..." +
-              props.row.token.slice(100, 110) +
+              props.row.token.slice(
+                props.row.token.length / 2,
+                props.row.token.length / 2 + 10
+              ) +
               "..." +
               props.row.token.slice(-8)
             }}


### PR DESCRIPTION
republished #53 

I wanted to have a better fingerprint of the Tokens in the overview for nuts control. So in this PR I would suggest slicing 10 letters by using indexes of half of the token length + 10. Additionally, using the padding of 8 letters in front and at the end.

<img width="355" alt="image" src="https://github.com/cashubtc/cashu.me/assets/115992990/150ef67d-b490-4c75-b52f-a7880d4da929">


