### PR TITLE
[UX|minor]: 74 strip spaces from`mintToAdd`

### DIFF
--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -215,7 +215,7 @@
           v-close-popup
           color="primary"
           icon="check"
-          @click="addMint(mintToAdd, (verbose = true))"
+          @click="addMint(mintToAdd.replace(/\s+/g, ''), (verbose = true))"
           >Add mint</q-btn
         >
         <q-btn v-close-popup flat color="grey" class="q-ml-auto">Cancel</q-btn>

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -215,7 +215,7 @@
           v-close-popup
           color="primary"
           icon="check"
-          @click="addMint(mintToAdd.replace(/\s+/g, ''), (verbose = true))"
+          @click="addMint(mintToAdd, (verbose = true))"
           >Add mint</q-btn
         >
         <q-btn v-close-popup flat color="grey" class="q-ml-auto">Cancel</q-btn>

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -915,7 +915,7 @@ export default {
       },
       addMintDialog: {
         show: false,
-        mintToAdd: "",
+        mintToAdd: "".replace(/\s+/g, ""),
       },
       baseHost: location.protocol + "//" + location.host,
       baseURL: location.protocol + "//" + location.host + location.pathname,


### PR DESCRIPTION
Very minor changeUsing a regex to get rid of all spaces from string of `mintToAdd` as mentioned in #74. Most interesting for trailing whitespaces from copy&paste. 

<img width="523" alt="Screenshot 2023-07-28 at 11 15 35" src="https://github.com/cashubtc/cashu.me/assets/115992990/aff931b0-6fbd-4bd5-926b-aa960f68b326">
<img width="242" alt="Screenshot 2023-07-28 at 11 15 43" src="https://github.com/cashubtc/cashu.me/assets/115992990/530bb8d7-6443-4b61-affd-253626e5c7b4">
