### PR TITLE
small quasar headache

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ access at http://localhost:3000 or serve it behind a reverse proxy.
 ## Install the dependencies
 
 ```bash
+npm install -g @quasar/cli
+quasar ext add @quasar/testing-unit-vitest
+```
+
+```bash
 npm install
 ```
 


### PR DESCRIPTION
info Project commands
   - build quasar build
   - build:pwa quasar build -m pwa
   - dev quasar dev
   - format prettier --write "**/*.{js,vue,scss,html,md,json}" --ignore-path .gitignore
   - lint eslint --ext .js,.vue ./
   - quasar quasar
   - test vitest
   - test:ci vitest run question Which command would you like to run?: dev $ quasar dev

 .d88888b.
d88P" "Y88b
888     888
888     888 888  888  8888b.  .d8888b   8888b.  888d888
888     888 888  888     "88b 88K          "88b 888P"
888 Y8b 888 888  888 .d888888 "Y8888b. .d888888 888
Y88b.Y8b88P Y88b 888 888  888      X88 888  888 888
 "Y888888"   "Y88888 "Y888888  88888P' "Y888888 888
       Y8b

 App • Running "@quasar/testing" Quasar App Extension...
(node:3136161) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension. (Use `node --trace-warnings ...` to show where the warning was created) /repos/cashu/cashu.me/node_modules/@quasar/quasar-app-extension-testing-unit-vitest/dist/index.js:1 export * from './install-quasar-plugin';
^^^^^^

SyntaxError: Unexpected token 'export'
    at internalCompileFunction (node:internal/vm:77:18)
    at wrapSafe (node:internal/modules/cjs/loader:1288:20)