### PR TITLE
Disable webkit scrollbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,10 @@
         "@quasar/icongenie": "^4.0.0",
         "@vueuse/core": "^10.0.2",
         "axios": "^1.3.3",
+        "bech32": "^2.0.0",
         "core-js": "^3.6.5",
         "date-fns": "^3.6.0",
-        "light-bolt11-decoder": "^3.0.0",
+        "light-bolt11-decoder": "^3.1.1",
         "nostr-tools": "^2.5.2",
         "pinia": "^2.0.35",
         "qr-scanner": "^1.4.2",
@@ -4960,6 +4961,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/big-integer": {
       "version": "1.6.52",

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -233,3 +233,7 @@ video {
   box-shadow: 0 1px 5px rgba(0, 0, 0, 0.2), 0 2px 2px rgba(0, 0, 0, 0.14),
     0 3px 1px -2px rgba(0, 0, 0, 0.12);
 }
+
+::-webkit-scrollbar {
+  display: none;
+}


### PR DESCRIPTION
This pull request disables the webkit scrollbar by adding the CSS rule `::-webkit-scrollbar { display: none; }`. This improves the visual appearance of the application by removing the scrollbar.