### PR TITLE
Added warning icon for deleting eCash transaction in transaction history

### DIFF
--- a/public/icons/warning.svg
+++ b/public/icons/warning.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="500" height="500" version="1.1" viewBox="0 0 132.29 132.29" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><g transform="translate(-.46555 1.4955)"><path d="m54.06 18.747-45.934 79.756c-3.777 8.8482-0.42346 18.709 11.798 19.821l92.341 0.15731c11.101-1.3518 16.218-9.5032 13.686-18.248l-46.092-81.329c-8.9142-11.278-18.772-10.221-25.799-0.15731z" fill="#ffd500" stroke="#000" stroke-linecap="square" stroke-linejoin="round" stroke-width="7.3"/><ellipse cx="66.744" cy="97.166" rx="5.9204" ry="5.8991"/><path d="m59.723 44.861 2.8316 38.383c2.222 4.0772 5.1723 3.784 8.652 0.31462l2.9889-38.698c-5.049-5.3958-9.8425-4.6608-14.472 0z" fill="#000105"/></g></svg>

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -280,11 +280,13 @@
             <span class="text-h6">Delete Ecash</span>
           </div>
         </div>
+          <div style="width:100%; display:flex; flex-direction:column; justify-content:center; align-items:center;">
+            <img style="width:80px;" src="/icons/warning.svg">
+          </div>
         <div class="row items-center no-wrap q-my-sm q-py-none">
           <div class="col-12">
             <q-item-label>
-              Are you sure you want to delete this transaction from your
-              history?
+              Deleting a transaction is irreversible and if the token is lost there will be no way of recovering it.
             </q-item-label>
           </div>
         </div>


### PR DESCRIPTION
I added a small SVG File with a warning logo and and changed the text for the warning to be more clear when deleting eCash transactions in transaction history