### PR TITLE
Fix for invisible button in the cyber theme

### DIFF
--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -67,7 +67,7 @@ $themes: (
     primary: #00ff00,
     secondary: #00ff00,
     dark: #000,
-    info: #00ff00,
+    info: #1b1b1b,
     marginal-bg: #000,
     marginal-text: rgb(255, 255, 255),
   ),


### PR DESCRIPTION
In the cyber theme, the info background color is the same as the button font color, so the button that toggles between currencies is not visible.  

Before: 

![before_no_button](https://github.com/cashubtc/cashu.me/assets/12129459/aa364169-f4aa-4c87-94b8-2b03876b2dd4)

After: 

![after](https://github.com/cashubtc/cashu.me/assets/12129459/ca145a3f-dcb9-414d-95aa-ae846b3a67d6)
