### PR TITLE
Fix coin select gte

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -227,10 +227,10 @@ export const useWalletStore = defineStore("wallet", {
 
       proofs = proofs.slice().sort((a, b) => a.amount - b.amount);
       // remember next bigger proof as a fallback
-      const nextBigger = proofs.find((p) => p.amount >= amount);
+      const nextBigger = proofs.find((p) => p.amount > amount);
 
       // go through smaller proofs until sum is bigger than amount
-      const smallerProofs = proofs.filter((p) => p.amount < amount);
+      const smallerProofs = proofs.filter((p) => p.amount <= amount);
       // sort by amount descending
       smallerProofs.sort((a, b) => b.amount - a.amount);
 


### PR DESCRIPTION
This pull request fixes an issue with the coin selection logic in the code. Previously, the logic was not correctly selecting the next bigger proof as a fallback. This PR updates the logic to ensure that the next bigger proof is correctly selected.