### PR TITLE
Update nwc amount to milli-satoshis

### DIFF
--- a/src/stores/nwc.ts
+++ b/src/stores/nwc.ts
@@ -197,7 +197,7 @@ export const useNWCStore = defineStore("nwc", {
 
       const transactions = transactionsHistory.map((invoice) => {
         let type = invoice.amount > 0 ? "incoming" : "outgoing"
-        let amount = Math.abs(invoice.amount)
+        let amount = Math.abs(invoice.amount) * 1000
         let created_at = Math.floor(new Date(invoice.date).getTime() / 1000)
         let settled_at = invoice.status == "paid" ? Math.floor(new Date(invoice.date).getTime() / 1000) : null
         return {
@@ -205,6 +205,7 @@ export const useNWCStore = defineStore("nwc", {
           invoice: invoice.bolt11,
           description: invoice.memo,
           amount: amount,
+          fees_paid: 0,
           created_at: created_at,
           settled_at: settled_at,
         } as nwcTransaction

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -614,7 +614,7 @@ export const useWalletStore = defineStore("wallet", {
           amount: -amount_paid,
           bolt11: this.payInvoiceData.input.request,
           quote: quote.quote,
-          memo: "fixme",
+          memo: "Outgoing invoice",
           date: currentDateStr(),
           status: "paid",
           mint: mintStore.activeMintUrl,


### PR DESCRIPTION
This pull request updates the nwc amount calculation in the useNWCStore function to convert the amount to milli-satoshis. Additionally, it updates the memo field for outgoing invoices in the useWalletStore function to "Outgoing invoice".