### PR TITLE
Add iOS PWA prompt

### DIFF
--- a/src/components/WelcomeDialog.vue
+++ b/src/components/WelcomeDialog.vue
@@ -122,16 +122,6 @@ export default defineComponent({
   watch: {},
   computed: {
     ...mapState(useWalletStore, ["mnemonic"]),
-    hiddenMnemonic() {
-      if (this.hideMnemonic) {
-        return this.mnemonic
-          .split(" ")
-          .map((w) => "*".repeat(w.length))
-          .join(" ");
-      } else {
-        return this.mnemonic;
-      }
-    },
   },
   methods: {
     ...mapActions(useMintsStore, ["restoreFromBackup"]),

--- a/src/components/iOSPWAPrompt.vue
+++ b/src/components/iOSPWAPrompt.vue
@@ -1,0 +1,120 @@
+<template>
+  <transition
+    appear
+    enter-active-class="animated fadeInUp"
+    leave-active-class="animated fadeInDown"
+    mode="out-in"
+  >
+    <div
+      v-if="showIosPWAPrompt"
+      class="pwa-prompt q-pa-md q-mx-auto text-center"
+    >
+      <div class="pwa-prompt-content">
+        <span
+          >Tap <q-icon name="ios_share" size="sm" /> and then
+          <strong>Add to Home Screen</strong></span
+        >
+        <q-btn
+          flat
+          icon="close"
+          @click="closePrompt"
+          size="sm"
+          class="close-btn q-px-sm"
+        />
+      </div>
+
+      <div class="pwa-prompt-arrow"></div>
+    </div>
+  </transition>
+</template>
+<script>
+import { defineComponent } from "vue";
+import { mapActions, mapState } from "pinia";
+import { useSettingsStore } from "stores/settings";
+export default defineComponent({
+  name: "iOSPWAPrompt",
+  mixins: [windowMixin],
+  props: {},
+  data: function () {
+    return {
+      showIosPWAPromptLocal:
+        localStorage.getItem("cashu.showIosPWAPrompt") != "seen",
+      showIosPWAPrompt: false,
+    };
+  },
+  mounted() {
+    if (
+      this.showIosPWAPromptLocal &&
+      this.isOS() &&
+      !this.isInStandaloneMode()
+    ) {
+      this.showIosPWAPrompt = true;
+    }
+  },
+  watch: {},
+  computed: {},
+  methods: {
+    closePrompt() {
+      localStorage.setItem("cashu.showIosPWAPrompt", "seen");
+      this.showIosPWAPrompt = false;
+    },
+    isOS() {
+      const userAgent = window.navigator.userAgent.toLowerCase();
+      return /iphone|ipad|ipod/.test(userAgent);
+      // return /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+    },
+    isInStandaloneMode() {
+      return "standalone" in window.navigator && window.navigator.standalone;
+    },
+  },
+});
+</script>
+<style scoped>
+@keyframes moveUpDown {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
+}
+
+.pwa-prompt {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  z-index: 9999;
+  text-align: center;
+  display: flex;
+  flex-direction: column; /* Add this line */
+  align-items: center; /* Add this line */
+  justify-content: center;
+  animation: moveUpDown 2s infinite; /* Add this line for animation */
+}
+
+.pwa-prompt-content {
+  display: inline-flex;
+  align-items: center;
+  background-color: black;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+}
+
+.pwa-prompt-content q-icon {
+  margin-right: 5px;
+}
+
+.pwa-prompt-arrow {
+  width: 0;
+  height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-top: 10px solid white;
+  margin: 0 auto;
+  text-align: center;
+}
+</style>

--- a/src/components/iOSPWAPrompt.vue
+++ b/src/components/iOSPWAPrompt.vue
@@ -11,7 +11,7 @@
     >
       <div class="pwa-prompt-content">
         <span
-          >Tap <q-icon name="ios_share" size="sm" /> and then
+          >Tap <q-icon name="ios_share" size="sm" /> and
           <strong>Add to Home Screen</strong></span
         >
         <q-btn
@@ -29,8 +29,6 @@
 </template>
 <script>
 import { defineComponent } from "vue";
-import { mapActions, mapState } from "pinia";
-import { useSettingsStore } from "stores/settings";
 export default defineComponent({
   name: "iOSPWAPrompt",
   mixins: [windowMixin],

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -101,7 +101,6 @@
           </q-tab-panel>
         </q-tab-panels>
       </q-expansion-item>
-      <!-- LIGHTNING BUTTONS  -->
 
       <div style="margin-bottom: 0rem">
         <div class="row q-pt-sm">
@@ -121,6 +120,8 @@
           </div>
         </div>
       </div>
+
+      <iOSPWAPrompt />
     </div>
 
     <!-- BOTTOM LIGHTNING BUTTONS -->
@@ -196,9 +197,7 @@ import InvoiceDetailDialog from "components/InvoiceDetailDialog.vue";
 import SendDialog from "components/SendDialog.vue";
 import ReceiveDialog from "components/ReceiveDialog.vue";
 import QrcodeReader from "components/QrcodeReader.vue";
-import P2PKDialog from "components/P2PKDialog.vue";
-import NWCDialog from "components/NWCDialog.vue";
-
+import iOSPWAPrompt from "components/iOSPWAPrompt.vue";
 // pinia stores
 import { mapActions, mapState, mapWritableState } from "pinia";
 import { useMintsStore } from "src/stores/mints";
@@ -231,6 +230,7 @@ export default {
     QrcodeReader,
     SendDialog,
     ReceiveDialog,
+    iOSPWAPrompt,
   },
   data: function () {
     return {
@@ -520,6 +520,8 @@ export default {
           console.log("User dismissed the install prompt");
         }
       });
+
+      // for IOS all this doesn't work so we need to hack it
     },
     registerBroadcastChannel: async function () {
       // uses session storage to identify the tab so we can ignore incoming messages from the same tab

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -510,6 +510,7 @@ export default {
     },
     triggerPwaInstall: function () {
       // Show the install prompt
+      // Note: this doesn't work with IOS, we do it with iOSPWAPrompt
       this.deferredPWAInstallPrompt.prompt();
       // Wait for the user to respond to the prompt
       this.deferredPWAInstallPrompt.userChoice.then((choiceResult) => {
@@ -520,8 +521,6 @@ export default {
           console.log("User dismissed the install prompt");
         }
       });
-
-      // for IOS all this doesn't work so we need to hack it
     },
     registerBroadcastChannel: async function () {
       // uses session storage to identify the tab so we can ignore incoming messages from the same tab


### PR DESCRIPTION
This pull request adds a new component called iOSPWAPrompt.vue, which displays a prompt for iOS users to add the app to their home screen. The component is conditionally rendered based on the user's device and whether they have already seen the prompt. The prompt includes instructions and a close button. Additionally, the iOSPWAPrompt component is imported and used in the main App.vue file.