### PR TITLE
Respect activeMintBalance instead of activeBalance and modify buttons in send dialog

### DIFF
--- a/src/components/PayInvoiceDialog.vue
+++ b/src/components/PayInvoiceDialog.vue
@@ -50,7 +50,6 @@
             unelevated
             rounded
             color="primary"
-            outline
             :disabled="
               payInvoiceData.blocking || payInvoiceData.meltQuote.error != ''
             "

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -125,26 +125,21 @@
               </div>
             </div>
           </transition>
-          <div class="row q-mt-lg">
+          <div v-if="activeMintBalance() > sendData.amount" class="row q-mt-lg">
             <q-btn
               v-if="!sendData.tokens"
               :disable="
                 sendData.amount == null ||
                 sendData.amount <= 0 ||
                 (sendData.p2pkPubkey != '' &&
-                  !isValidPubkey(sendData.p2pkPubkey)) ||
-                activeMintBalance() < sendData.amount
+                  !isValidPubkey(sendData.p2pkPubkey))
               "
               @click="sendTokens"
               color="primary"
               rounded
               type="submit"
-              :label="
-                activeMintBalance() < sendData.amount
-                  ? 'Mint balance too low'
-                  : 'Send'
-              "
-            />
+              >Send</q-btn
+            >
             <div
               v-if="sendData.p2pkPubkey && isValidPubkey(sendData.p2pkPubkey)"
               class="row"
@@ -187,6 +182,14 @@
                 Lock</q-btn
               >
             </transition>
+            <q-btn v-close-popup rounded flat color="grey" class="q-ml-auto"
+              >Close</q-btn
+            >
+          </div>
+          <div v-else class="row q-mt-lg">
+            <q-btn unelevated rounded disabled color="yellow" text-color="black"
+              >Mint balance too low</q-btn
+            >
             <q-btn v-close-popup rounded flat color="grey" class="q-ml-auto"
               >Close</q-btn
             >

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -125,7 +125,10 @@
               </div>
             </div>
           </transition>
-          <div v-if="activeMintBalance() > sendData.amount" class="row q-mt-lg">
+          <div
+            v-if="activeMintBalance() >= sendData.amount"
+            class="row q-mt-lg"
+          >
             <q-btn
               v-if="!sendData.tokens"
               :disable="

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -279,7 +279,7 @@ export const useWalletStore = defineStore("wallet", {
       const mintStore = useMintsStore();
       const spendableProofs = proofsStore.getUnreservedProofs(proofs);
       if (proofsStore.sumProofs(spendableProofs) < amount) {
-        const balance = mintStore.activeBalance;
+        const balance = mintStore.activeMintBalance();
         const unit = mintStore.activeUnit
         notifyWarning(
           "Balance is too low.",

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -282,10 +282,10 @@ export const useWalletStore = defineStore("wallet", {
         const balance = mintStore.activeMintBalance();
         const unit = mintStore.activeUnit
         notifyWarning(
-          "Balance is too low.",
-          `Your balance is ${uIStore.formatCurrency(balance, unit)} and you're trying to pay ${uIStore.formatCurrency(amount, unit)}.`
+          "Balance is too low",
+          `${uIStore.formatCurrency(balance, unit)} is not enough to pay ${uIStore.formatCurrency(amount, unit)}.`
         );
-        throw Error("balance too low.");
+        throw Error("Balance too low");
       }
       return spendableProofs;
     },


### PR DESCRIPTION
This pull request updates the send dialog to respect the `activeMintBalance` instead of `activeBalance` when determining if the mint balance is too low. It also modifies the buttons in the send dialog to disable the "Send" button and display a message when the mint balance is too low.