### PR TITLE
Add link to recovery tool

### DIFF
--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -9,8 +9,11 @@
             <q-item-label caption
               >Your seed phrase can restore your wallet. Keep it safe and
               private. Warning: this wallet does not support seed phrase
-              recovery yet. Use a different Cashu wallet to recover from seed
-              phrase.
+              recovery yet. Use a different Cashu wallet or
+              <a href="https://v2alpha.nutstash.app/" target="blank"
+                >this tool</a
+              >
+              to recover from seed phrase.
             </q-item-label>
             <div class="row q-pt-md">
               <div class="col-12">

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -10,10 +10,10 @@
               >Your seed phrase can restore your wallet. Keep it safe and
               private. Warning: this wallet does not support seed phrase
               recovery yet. Use a different Cashu wallet or
-              <a href="https://v2alpha.nutstash.app/" target="blank"
-                >this tool</a
-              >
-              to recover from seed phrase.
+              <a href="https://v2alpha.nutstash.app/" target="_blank">
+                this tool
+              </a>
+              > to recover from seed phrase.
             </q-item-label>
             <div class="row q-pt-md">
               <div class="col-12">

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -156,6 +156,12 @@ body.body--dark .q-field--error {
   }
 }
 
+a {
+  color: var(--primary-color);
+  text-decoration: underline;
+  font-weight: bold;
+}
+
 a.inherit {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
This pull request adds a link to a recovery tool in the wallet's user interface. Previously, the wallet did not support seed phrase recovery, but now users can use the provided tool or a different Cashu wallet to recover their wallet using the seed phrase. The link is displayed in the user interface and is styled to be easily recognizable.