### PR TITLE
Fix check if info event was already published

### DIFF
--- a/src/stores/nwc.ts
+++ b/src/stores/nwc.ts
@@ -309,7 +309,7 @@ export const useNWCStore = defineStore("nwc", {
         // use NWCKind.NWCInfo as an integer here
         let filterInfoEvent: NDKFilter = { kinds: [NWCKind.NWCInfo], authors: [conn.walletPublicKey] };
         let eventsInfoEvent = await this.ndk.fetchEvents(filterInfoEvent);
-        if (!eventsInfoEvent) {
+        if (eventsInfoEvent.size === 0) {
           await nip47InfoEvent.publish()
           console.log("### published nip47InfoEvent", nip47InfoEvent)
         } else {


### PR DESCRIPTION
Hi, a stacker reported that NWC of cashu.me fails to link with Stacker News, see https://stacker.news/items/645420:

> I'm getting and error trying to connect Cashu.me to Stacker.News using NWC in the wallets sections. The error I'm getting is EOSE received without info event. Does anyone see this? Cashu.me NWC works for other websites like NoStudel and Habla.
>
> The rest of my logs look like this:
>
>> 2m	[nwc]	error	failed to attach: EOSE received without info event
>> 2m	[nwc]	info	closed connection to wss://relay.primal.net
2m	[nwc]	error	EOSE received without info event
2m	[nwc]	ok	connected to wss://relay.primal.net
2m	[nwc]	info	requesting info event from wss://relay.primal.net
3m	[nwc]	error	failed to attach: EOSE received without info event
3m	[nwc]	info	closed connection to wss://relay.primal.net
3m	[nwc]	error	EOSE received without info event

As you can see, it failed to link since the info event was not found.

I looked into the source code and noticed that `ndk.fetchEvents` returns a set and thus is always truthy. This means the info event never gets published.

This PR fixes that.

