### PR TITLE
Fix null assignment for amount field

### DIFF
--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -99,7 +99,7 @@ export default defineComponent({
       console.log("##### showSendTokensDialog");
       this.sendData.tokens = "";
       this.sendData.tokensBase64 = "";
-      this.sendData.amount = "";
+      this.sendData.amount = null;
       this.sendData.memo = "";
       this.sendData.p2pkPubkey = "";
       this.showSendDialog = false;

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -467,7 +467,7 @@ export default {
       console.log("##### showSendTokensDialog");
       this.sendData.tokens = "";
       this.sendData.tokensBase64 = "";
-      this.sendData.amount = "";
+      this.sendData.amount = null;
       this.sendData.memo = "";
       this.showSendTokens = true;
     },

--- a/src/stores/sendTokensStore.ts
+++ b/src/stores/sendTokensStore.ts
@@ -5,11 +5,17 @@ export const useSendTokensStore = defineStore("sendTokensStore", {
     showSendTokens: false,
     showLockInput: false,
     sendData: {
-      amount: 0,
+      amount: null,
       memo: "",
       tokens: "",
       tokensBase64: "",
       p2pkPubkey: "",
+    } as {
+      amount: number | null;
+      memo: string;
+      tokens: string;
+      tokensBase64: string;
+      p2pkPubkey: string;
     },
   }),
   actions: {},


### PR DESCRIPTION
This pull request fixes an issue where the `amount` field was being assigned an empty string instead of `null`. The `amount` field is now correctly assigned `null` in the `sendData` object. This ensures that the `amount` field is properly initialized and avoids any potential issues related to incorrect data types.