### PR TITLE
Compute nsec dynamically

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -31,14 +31,17 @@ export const useNostrStore = defineStore("nostr", {
     nip46signer: {} as NDKNip46Signer,
     privateKeySignerPrivateKey: useLocalStorage<string>("cashu.ndk.privateKeySignerPrivateKey", ""),
     seedSignerPrivateKey: useLocalStorage<string>("cashu.ndk.seedSignerPrivateKey", ""),
-    seedSignerPrivateKeyNsec: useLocalStorage<string>("cashu.ndk.seedSignerPrivateKeyNsec", ""),
+    seedSignerPrivateKeyNsec: "",
     privateKeySigner: {} as NDKPrivateKeySigner,
     signer: {} as NDKSigner,
     mintRecommendations: useLocalStorage<MintRecommendation[]>("cashu.ndk.mintRecommendations", []),
     initialized: false,
   }),
   getters: {
-
+    seedSignerPrivateKeyNsec: (state) => {
+      const sk = hexToBytes(state.seedSignerPrivateKey);
+      return nip19.nsecEncode(sk);
+    }
   },
   actions: {
     initNdkReadOnly: function () {
@@ -166,7 +169,6 @@ export const useNostrStore = defineStore("nostr", {
       const walletPublicKeyHex = getPublicKey(sk) // `pk` is a hex string
       const walletPrivateKeyHex = bytesToHex(sk)
       this.seedSignerPrivateKey = walletPrivateKeyHex;
-      this.seedSignerPrivateKeyNsec = nip19.nsecEncode(sk);
       this.privateKeySigner = new NDKPrivateKeySigner(walletPrivateKeyHex)
       this.signerType = SignerType.SEED;
       this.setSigner(this.privateKeySigner);


### PR DESCRIPTION
This pull request updates the `useNostrStore` to compute the `seedSignerPrivateKeyNsec` dynamically instead of storing it in local storage. The `seedSignerPrivateKeyNsec` is now calculated using the `seedSignerPrivateKey` value and the `nip19.nsecEncode` function. This change ensures that the `seedSignerPrivateKeyNsec` is always up-to-date and eliminates the need to store it separately.