### PR TITLE
NWC make_invoice & lookup_invoice

### DIFF
--- a/src/stores/nwc.ts
+++ b/src/stores/nwc.ts
@@ -12,10 +12,11 @@ import { useLocalStorage } from "@vueuse/core";
 import { bytesToHex } from "@noble/hashes/utils"; // already an installed dependency
 import { nip04, generateSecretKey, getPublicKey } from "nostr-tools";
 import { useMintsStore } from "./mints";
-import { useWalletStore } from "./wallet";
+import { useWalletStore, InvoiceHistory } from "./wallet";
 import { useProofsStore } from "./proofs";
 import { notify, notifyError, notifyWarning } from "../js/notify";
 import { useSettingsStore } from "./settings";
+import { decode as decodeBolt11 } from 'light-bolt11-decoder'
 
 type NWCConnection = {
   walletPublicKey: string;
@@ -29,6 +30,19 @@ type NWCCommand = {
   method: string;
   params: any;
 };
+
+type NWCTransaction = {
+  type: string,
+  invoice: string,
+  description: string | null,
+  preimage: string | null,
+  payment_hash: string | null,
+  amount: number,
+  fees_paid: number | null,
+  created_at: number,
+  settled_at: number | null
+  expires_at: number | null
+}
 
 type NWCResult = {
   result_type: string;
@@ -59,6 +73,7 @@ export const useNWCStore = defineStore("nwc", {
       "get_balance",
       "get_info",
       "list_transactions",
+      "lookup_invoice"
     ],
     relays: useLocalStorage<string[]>(
       "cashu.nwc.relays",
@@ -195,18 +210,6 @@ export const useNWCStore = defineStore("nwc", {
     },
     handleListTransactions: async function (nwcCommand: NWCCommand) {
       console.log("### list_transactions", nwcCommand.method);
-      type nwcTransaction = {
-        type: string;
-        invoice: string;
-        description: string | null;
-        preimage: string | null;
-        payment_hash: string | null;
-        amount: number;
-        fees_paid: number | null;
-        created_at: number;
-        settled_at: number | null;
-        expires_at: number | null;
-      };
       const walletStore = useWalletStore();
       const from = nwcCommand.params.from || 0;
       const until = nwcCommand.params.until || Math.floor(Date.now() / 1000);
@@ -245,24 +248,7 @@ export const useNWCStore = defineStore("nwc", {
       // created_at = unix timestamp of date
       // settled_at = unix timestamp of date if status == "paid" else null
 
-      const transactions = transactionsHistory.map((invoice) => {
-        let type = invoice.amount > 0 ? "incoming" : "outgoing";
-        let amount = Math.abs(invoice.amount) * 1000;
-        let created_at = Math.floor(new Date(invoice.date).getTime() / 1000);
-        let settled_at =
-          invoice.status == "paid"
-            ? Math.floor(new Date(invoice.date).getTime() / 1000)
-            : null;
-        return {
-          type: type,
-          invoice: invoice.bolt11,
-          description: invoice.memo,
-          amount: amount,
-          fees_paid: 0,
-          created_at: created_at,
-          settled_at: settled_at,
-        } as nwcTransaction;
-      });
+      const transactions = transactionsHistory.map(this.mapToNwcTransaction);
 
       return {
         result_type: "list_transactions",
@@ -270,6 +256,62 @@ export const useNWCStore = defineStore("nwc", {
           transactions: transactions,
         },
       };
+    },
+    handleLookupInvoice: async function (nwcCommand: NWCCommand) {
+      let hash = nwcCommand.params.payment_hash
+      if (!hash) {
+        const bolt11 = nwcCommand.params.invoice
+        const decoded = bolt11 ? decodeBolt11(bolt11) : null
+        // @ts-ignore
+        hash = decoded?.sections.find(s => s.name === "payment_hash")?.value
+      }
+      if (!hash) {
+        return {
+          result_type: nwcCommand.method,
+          error: { code: "OTHER", message: "invoice or payment_hash required"}
+        }
+      }
+
+      console.log("### lookup_invoice")
+      const walletStore = useWalletStore()
+      const invoiceHistory = walletStore.invoiceHistory
+
+      for (const inv of invoiceHistory) {
+        const decoded = decodeBolt11( nwcCommand.params.invoice)
+        // @ts-ignore
+        const invHash = decoded.sections.find(s => s.name === "payment_hash")?.value
+        if (invHash === hash) {
+          return {
+            result_type: nwcCommand.method,
+            result: this.mapToNwcTransaction(inv)
+          }
+        }
+      }
+
+      return {
+        result_type: nwcCommand.method,
+        error: {
+          code: "NOT_FOUND", message: "invoice not found"
+        }
+      }
+    },
+    mapToNwcTransaction(invoice: InvoiceHistory): NWCTransaction {
+      let type = invoice.amount > 0 ? "incoming" : "outgoing";
+      let amount = Math.abs(invoice.amount) * 1000;
+      let created_at = Math.floor(new Date(invoice.date).getTime() / 1000);
+      let settled_at =
+        invoice.status == "paid"
+          ? Math.floor(new Date(invoice.date).getTime() / 1000)
+          : null;
+      return {
+        type: type,
+        invoice: invoice.bolt11,
+        description: invoice.memo,
+        amount: amount,
+        fees_paid: 0,
+        created_at: created_at,
+        settled_at: settled_at,
+      } as NWCTransaction;
     },
     // ––––---------- NWC Connection ––––----------
     replyNWC: async function (
@@ -330,7 +372,9 @@ export const useNWCStore = defineStore("nwc", {
       } else if (nwcCommand.method === "make_invoice") {
         result = await this.handleMakeInvoice(nwcCommand)
       } else if (nwcCommand.method == "list_transactions") {
-        result = await this.handleListTransactions(nwcCommand);
+        result = await this.handleListTransactions(nwcCommand)
+      } else if (nwcCommand.method === "lookup_invoice") {
+        result = await this.handleLookupInvoice(nwcCommand)
       } else {
         console.log("### method not supported", nwcCommand.method);
         result = {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -67,7 +67,7 @@ type Invoice = {
   memo: string;
 };
 
-type InvoiceHistory = Invoice & {
+export type InvoiceHistory = Invoice & {
   date: string;
   status: "pending" | "paid";
   mint: string;


### PR DESCRIPTION
## Description

This implements `make_invoice` for NWC. This has been tested as can be seen in the video (but not any further):

https://github.com/user-attachments/assets/35b5344f-92f0-42e4-a1d0-c9ebb5c307d2

I might also add `lookup_invoice` to close #196

update: added `lookup_invoice` in 34db335 but there seems to be something wrong with how invoices are confirmed, see video:


https://github.com/user-attachments/assets/060d1c71-56ab-4fbd-ba43-6f31b0a3298f

As you can see at the end, I create a mint invoice and pay it but if you close the modal before you pay, the invoice doesn't seem to get properly confirmed.

I think this is unrelated to my code.

## Additional context

I have noticed that if I refresh the settings page, it does not subscribe to NWC events. However, it does if I refresh on the index page.