### PR TITLE
Fix mintProofs return type and update cashu-ts to 2.0 rc3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@capacitor/clipboard": "^6.0.0",
         "@capacitor/core": "^6.0.0",
         "@capacitor/ios": "^6.0.0",
-        "@cashu/cashu-ts": "^2.0.0-rc1",
+        "@cashu/cashu-ts": "^2.0.0-rc2",
         "@cashu/crypto": "^0.2.7",
         "@chenfengyuan/vue-qrcode": "^2.0.0",
         "@gandlaf21/bc-ur": "^1.1.12",
@@ -2003,15 +2003,28 @@
       }
     },
     "node_modules/@cashu/cashu-ts": {
-      "version": "2.0.0-rc1",
-      "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-2.0.0-rc1.tgz",
-      "integrity": "sha512-39459l7x/fUMEgOsCdGLLl6rMekO4nbv+wEuavmyElh8hgN8t66wcb29AJvdFTb6K3lPACKF2rs/jAlPYrN7Ng==",
+      "version": "2.0.0-rc2",
+      "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-2.0.0-rc2.tgz",
+      "integrity": "sha512-oRAawH4+FN+L/+bbqbundTV4pIeMO/9X4QnmRjMfXcLWNIjHAsyfPR5BFrPFtfEJea7zTQhoDRCmte1Xp6pTLA==",
       "license": "MIT",
       "dependencies": {
-        "@cashu/crypto": "^0.2.7",
+        "@cashu/crypto": "^0.3.4",
         "@noble/curves": "^1.3.0",
         "@noble/hashes": "^1.3.3",
         "@scure/bip32": "^1.3.3",
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/@cashu/cashu-ts/node_modules/@cashu/crypto": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cashu/crypto/-/crypto-0.3.4.tgz",
+      "integrity": "sha512-mfv1Pj4iL1PXzUj9NKIJbmncCLMqYfnEDqh/OPxAX0nNBt6BOnVJJLjLWFlQeYxlnEfWABSNkrqPje1t5zcyhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
         "buffer": "^6.0.3"
       }
     },
@@ -3106,22 +3119,27 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
-      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/hashes": "1.5.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -3709,13 +3727,14 @@
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.5.0.tgz",
+      "integrity": "sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
+        "@noble/curves": "~1.6.0",
+        "@noble/hashes": "~1.5.0",
+        "@scure/base": "~1.1.7"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -3729,18 +3748,6 @@
       "dependencies": {
         "@noble/hashes": "~1.5.0",
         "@scure/base": "~1.1.8"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@capacitor/clipboard": "^6.0.0",
         "@capacitor/core": "^6.0.0",
         "@capacitor/ios": "^6.0.0",
-        "@cashu/cashu-ts": "^2.0.0-rc2",
+        "@cashu/cashu-ts": "^2.0.0-rc3",
         "@cashu/crypto": "^0.2.7",
         "@chenfengyuan/vue-qrcode": "^2.0.0",
         "@gandlaf21/bc-ur": "^1.1.12",
@@ -2003,9 +2003,9 @@
       }
     },
     "node_modules/@cashu/cashu-ts": {
-      "version": "2.0.0-rc2",
-      "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-2.0.0-rc2.tgz",
-      "integrity": "sha512-oRAawH4+FN+L/+bbqbundTV4pIeMO/9X4QnmRjMfXcLWNIjHAsyfPR5BFrPFtfEJea7zTQhoDRCmte1Xp6pTLA==",
+      "version": "2.0.0-rc3",
+      "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-2.0.0-rc3.tgz",
+      "integrity": "sha512-KXH3Zi9JZe5Ylc6PyfO2OxErjKzu7pwTudYQ/3tsunLmqaTQadtlf2JPTcpGOo/O2yLhleryx7l4JgoitWvgSw==",
       "license": "MIT",
       "dependencies": {
         "@cashu/crypto": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@capacitor/clipboard": "^6.0.0",
     "@capacitor/core": "^6.0.0",
     "@capacitor/ios": "^6.0.0",
-    "@cashu/cashu-ts": "^2.0.0-rc2",
+    "@cashu/cashu-ts": "^2.0.0-rc3",
     "@cashu/crypto": "^0.2.7",
     "@chenfengyuan/vue-qrcode": "^2.0.0",
     "@gandlaf21/bc-ur": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@capacitor/clipboard": "^6.0.0",
     "@capacitor/core": "^6.0.0",
     "@capacitor/ios": "^6.0.0",
-    "@cashu/cashu-ts": "^2.0.0-rc1",
+    "@cashu/cashu-ts": "^2.0.0-rc2",
     "@cashu/crypto": "^0.2.7",
     "@chenfengyuan/vue-qrcode": "^2.0.0",
     "@gandlaf21/bc-ur": "^1.1.12",

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -477,7 +477,7 @@ export const useWalletStore = defineStore("wallet", {
           throw new Error("invoice not paid yet.");
         }
         const counter = this.keysetCounter(keysetId)
-        const { proofs } = await this.wallet.mintProofs(amount, hash, { keysetId, counter, proofsWeHave: mintStore.activeProofs })
+        const proofs = await this.wallet.mintProofs(amount, hash, { keysetId, counter, proofsWeHave: mintStore.activeProofs })
         this.increaseKeysetCounter(keysetId, proofs.length);
 
         // const proofs = await this.mintApi(split, hash, verbose);


### PR DESCRIPTION
Correct the return type of the mintProofs function and update the cashu-ts dependency to version 2.0.0-rc3, which includes various improvements and fixes.