### PR TITLE
Fix missing @cashu/crypto dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@capacitor/core": "^6.0.0",
         "@capacitor/ios": "^6.0.0",
         "@cashu/cashu-ts": "^2.0.0-rc3",
+        "@cashu/crypto": "^0.3.4",
         "@chenfengyuan/vue-qrcode": "^2.0.0",
         "@gandlaf21/bc-ur": "^1.1.12",
         "@nostr-dev-kit/ndk": "^2.8.1",
@@ -1979,7 +1980,7 @@
         "buffer": "^6.0.3"
       }
     },
-    "node_modules/@cashu/cashu-ts/node_modules/@cashu/crypto": {
+    "node_modules/@cashu/crypto": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@cashu/crypto/-/crypto-0.3.4.tgz",
       "integrity": "sha512-mfv1Pj4iL1PXzUj9NKIJbmncCLMqYfnEDqh/OPxAX0nNBt6BOnVJJLjLWFlQeYxlnEfWABSNkrqPje1t5zcyhA==",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@capacitor/core": "^6.0.0",
     "@capacitor/ios": "^6.0.0",
     "@cashu/cashu-ts": "^2.0.0-rc3",
+    "@cashu/crypto": "^0.3.4",
     "@chenfengyuan/vue-qrcode": "^2.0.0",
     "@gandlaf21/bc-ur": "^1.1.12",
     "@nostr-dev-kit/ndk": "^2.8.1",


### PR DESCRIPTION
While rebasing #247 on main (507a9d2), I noticed that `npm install && npm run dev` no longer worked because the `@cashu/crypto` dependency was missing in package.json.

Fixed this by running `npm install @cashu/crypto`.