### PR TITLE
fix click on mint url

### DIFF
--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -92,7 +92,7 @@
 
     <div class="row q-mt-md q-mb-none text-secondary" v-if="activeMintUrl">
       <div class="col-12 cursor-pointer">
-        <span class="text-weight-light" @click="setTab('settings')">
+        <span class="text-weight-light" @click="setTab('mints')">
           Mint: <b>{{ activeMintLabel }}</b>
           <q-tooltip>Configure mint(s)</q-tooltip>
         </span>


### PR DESCRIPTION
previously a click on mint url has hidden all tabs

it seems the intention was to switch to the mints tab

this fxes the fallout of #116 which internally renamed the mints tab from `settings` to `mints`