### PR TITLE
Remove tooltip from mint label

### DIFF
--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -94,7 +94,6 @@
       <div class="col-12 cursor-pointer">
         <span class="text-weight-light" @click="setTab('mints')">
           Mint: <b>{{ activeMintLabel }}</b>
-          <q-tooltip>Configure mint(s)</q-tooltip>
         </span>
       </div>
     </div>


### PR DESCRIPTION
Eliminate the tooltip that provided configuration information for mints to streamline the user interface.