### PR TITLE
Fix Payment Request Error Message Display

### DIFF
--- a/src/stores/payment-request.ts
+++ b/src/stores/payment-request.ts
@@ -79,9 +79,9 @@ export const usePRStore = defineStore("payment-request", {
           }
         }
         if (!foundMint) {
-          notifyError("We do not know the mint in the payment request");
+          notifyError(`This payment requires using the mint: ${request.mints}`);
           throw new Error(
-            `We do not know the mint in the payment request: ${request.mints}`
+            `This payment requires using the mint: ${request.mints}`
           );
         }
       }


### PR DESCRIPTION
# Improve Payment Request Error Message

Updates the error message when a payment request requires a specific mint to be more clear and direct.

Before:
"We do not know the mint in the payment request"

After:
"This payment requires using the mint: [mint-url]"

This change better communicates to users exactly which mint they need to use to complete their payment.

<img width="608" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/a45732a6-cd0c-4991-9281-d08b81cf2b43" />