### PR TITLE
Onboarding process was cancelling mint add from query params

### DIFF
--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -570,8 +570,14 @@ export default {
     if (params.get("mint")) {
       let addMintUrl = params.get("mint");
       await this.setTab("mints");
-      this.showAddMintDialog = true;
       this.addMintData = { url: addMintUrl };
+
+      try {
+        await this.addMint({ url: addMintUrl }, true); // Ensure `addMint` runs
+        console.log(`Mint added successfully: ${addMintUrl}`);
+      } catch (error) {
+        console.error(`Error adding mint: ${error.message}`);
+      }
     }
     if (!localStorage.getItem("cashu.activeMintUrl")) {
       this.setTab("mints");


### PR DESCRIPTION
Before:
Add mint from search query cancelled because onboarding process began.

After:
Mint is attempted to be added before onboarding process. Note: this skips over the user confirming that they want to add this mint.