### PR TITLE
Prevent pull-to-refresh in Safari

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -1,8 +1,9 @@
 // app global css in SCSS form
 
-// prevent pull to refresh on android chrome
+// prevent pull to refresh
+html,
 body {
-  overscroll-behavior-y: contain;
+  overscroll-behavior: none;
 }
 
 // margin for top elements for ios safe area


### PR DESCRIPTION
Closes https://github.com/cashubtc/cashu.me/issues/236

With this change pull-to-refresh will be prevented in both Chrome-based browsers and Safari.
Solution based on [stackoverflow.com/a/78711166](https://stackoverflow.com/a/78711166), [matuzo.at/blog/2022/100daysof-day53](https://www.matuzo.at/blog/2022/100daysof-day53)

I've tested on my iPhone in Safari + PWA install and Android via Android Studio.