### PR TITLE
First pass on converting .vue files to use `lang="ts"`

### DIFF
--- a/src/boot/base.js
+++ b/src/boot/base.js
@@ -48,33 +48,6 @@ window.windowMixin = {
       }
       return text;
     },
-    formatCurrency: function (value, currency, showBalance = false) {
-      if (currency == undefined) {
-        currency = "sat";
-      }
-      if (useUiStore().hideBalance && !showBalance) {
-        return "****";
-      }
-      if (currency == "sat") return this.formatSat(value);
-      if (currency == "msat") return this.fromMsat(value);
-      if (currency == "usd") value = value / 100;
-      if (currency == "eur") value = value / 100;
-      return new Intl.NumberFormat(window.LOCALE, {
-        style: "currency",
-        currency: currency,
-      }).format(value);
-      // + " " +
-      // currency.toUpperCase()
-    },
-    formatSat: function (value) {
-      // convert value to integer
-      value = parseInt(value);
-      return new Intl.NumberFormat(window.LOCALE).format(value) + " sat";
-    },
-    fromMsat: function (value) {
-      value = parseInt(value);
-      return new Intl.NumberFormat(window.LOCALE).format(value) + " msat";
-    },
     notifyApiError: function (error) {
       var types = {
         400: "warning",

--- a/src/boot/base.js
+++ b/src/boot/base.js
@@ -1,5 +1,4 @@
 import { copyToClipboard } from "quasar";
-import { useUiStore } from "stores/ui";
 import { Clipboard } from "@capacitor/clipboard";
 import { SafeArea } from "capacitor-plugin-safe-area";
 
@@ -10,7 +9,6 @@ window.windowMixin = {
   data: function () {
     return {
       g: {
-        offline: !navigator.onLine,
         visibleDrawer: false,
         extensions: [],
         user: null,
@@ -167,14 +165,6 @@ window.windowMixin = {
       this.$q.dark.set(true);
     }
     this.g.allowedThemes = window.allowedThemes ?? ["classic"];
-
-    addEventListener("offline", (event) => {
-      this.g.offline = true;
-    });
-
-    addEventListener("online", (event) => {
-      this.g.offline = false;
-    });
 
     // addEventListener("beforeunload", (event) => {
     //   event.preventDefault();

--- a/src/components/ActivityOrb.vue
+++ b/src/components/ActivityOrb.vue
@@ -19,19 +19,15 @@
     </div>
   </div>
 </template>
-<script>
+<script lang="ts">
 import { defineComponent } from "vue";
 import { mapState, mapWritableState } from "pinia";
 import { useUiStore } from "stores/ui";
 import { useWalletStore } from "../stores/wallet";
 import { useReceiveTokensStore } from "src/stores/receiveTokensStore";
-import { set } from "@vueuse/core";
 
 export default defineComponent({
   name: "ActivityOrb",
-  mixins: [windowMixin],
-  components: {},
-  props: {},
   data: function () {
     return {
       enableSpinner: false,

--- a/src/components/AndroidPWAPrompt.vue
+++ b/src/components/AndroidPWAPrompt.vue
@@ -24,7 +24,7 @@
   </transition>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent } from "vue";
 
 export default defineComponent({

--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -139,19 +139,17 @@ import { defineComponent, ref } from "vue";
 import { getShortUrl } from "src/js/wallet-helpers";
 import { mapState, mapWritableState, mapActions } from "pinia";
 import { useMintsStore } from "stores/mints";
-import { useSettingsStore } from "stores/settings";
 import { useTokensStore } from "stores/tokens";
 import { useUiStore } from "stores/ui";
 import { useWalletStore } from "stores/wallet";
 import { usePriceStore } from "stores/price";
 import ToggleUnit from "components/ToggleUnit.vue";
 import AnimatedNumber from "components/AnimatedNumber.vue";
-import axios from "axios";
-import { map } from "underscore";
+import formatMixin from "src/mixin/formatMixin";
 
 export default defineComponent({
   name: "BalanceView",
-  mixins: [windowMixin],
+  mixins: [windowMixin, formatMixin],
   components: {
     ToggleUnit,
     AnimatedNumber,

--- a/src/components/ChooseMint.vue
+++ b/src/components/ChooseMint.vue
@@ -77,10 +77,11 @@ import { mapActions, mapState, mapWritableState } from "pinia";
 import { useMintsStore } from "stores/mints";
 import { MintClass } from "stores/mints";
 import { title } from "process";
+import formatMixin from "src/mixin/formatMixin";
 
 export default defineComponent({
   name: "ChooseMint",
-  mixins: [windowMixin],
+  mixins: [formatMixin],
   props: {
     rounded: {
       type: Boolean,

--- a/src/components/ChooseMint.vue
+++ b/src/components/ChooseMint.vue
@@ -70,7 +70,7 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent } from "vue";
 import { getShortUrl } from "src/js/wallet-helpers";
 import { mapActions, mapState, mapWritableState } from "pinia";
@@ -98,18 +98,21 @@ export default defineComponent({
   },
   data: function () {
     return {
-      chosenMint: null,
+      chosenMint: {
+        url: "",
+        shorturl: "",
+      },
     };
   },
   mounted() {
     this.chosenMint = {
-      url: this.activeMintUrl,
+      url: this.activeMintUrl.value,
       shorturl: getShortUrl(this.activeMintUrl),
     };
   },
   watch: {
     chosenMint: async function () {
-      this.activeMintUrl = this.chosenMint.url;
+      await this.activateMintUrl(this.chosenMint.url);
     },
   },
   computed: {

--- a/src/components/ChooseMint.vue
+++ b/src/components/ChooseMint.vue
@@ -69,18 +69,32 @@
     </div>
   </div>
 </template>
-
 <script lang="ts">
 import { defineComponent } from "vue";
 import { getShortUrl } from "src/js/wallet-helpers";
 import { mapActions, mapState, mapWritableState } from "pinia";
 import { useMintsStore } from "stores/mints";
 import { MintClass } from "stores/mints";
-import { title } from "process";
 import formatMixin from "src/mixin/formatMixin";
+
+interface ChosenMint {
+  url: string;
+  shorturl: string;
+}
 
 export default defineComponent({
   name: "ChooseMint",
+
+  setup() {
+    const mintsStore = useMintsStore();
+    const { activeMintUrl } = mintsStore;
+
+    return {
+      activeMintUrl,
+      mintsStore,
+    };
+  },
+
   mixins: [formatMixin],
   props: {
     rounded: {
@@ -98,21 +112,20 @@ export default defineComponent({
   },
   data: function () {
     return {
-      chosenMint: {
-        url: "",
-        shorturl: "",
-      },
+      chosenMint: null as ChosenMint | null,
     };
   },
   mounted() {
     this.chosenMint = {
-      url: this.activeMintUrl.value,
-      shorturl: getShortUrl(this.activeMintUrl),
+      url: this.activeMintUrl || "",
+      shorturl: getShortUrl(this.activeMintUrl || ""),
     };
   },
   watch: {
     chosenMint: async function () {
-      await this.activateMintUrl(this.chosenMint.url);
+      if (this.chosenMint) {
+        this.mintsStore.activeMintUrl = this.chosenMint.url;
+      }
     },
   },
   computed: {
@@ -126,7 +139,7 @@ export default defineComponent({
     getBalance: function () {
       return this.activeProofs
         .flat()
-        .reduce((sum, el) => (sum += el.amount), 0);
+        .reduce((sum: any, el: { amount: any }) => (sum += el.amount), 0);
     },
   },
   methods: {

--- a/src/components/EssentialLink.vue
+++ b/src/components/EssentialLink.vue
@@ -11,7 +11,7 @@
   </q-item>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent } from "vue";
 
 export default defineComponent({

--- a/src/components/FullscreenHeader.vue
+++ b/src/components/FullscreenHeader.vue
@@ -16,14 +16,11 @@
     </q-toolbar>
   </q-header>
 </template>
-<script>
-import { defineComponent, ref } from "vue";
+<script lang="ts">
+import { defineComponent } from "vue";
 
 export default defineComponent({
   name: "FullscreenHeader",
-  mixins: [windowMixin],
-  props: {},
-  components: {},
   setup() {
     return {};
   },

--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -3,7 +3,7 @@
     <q-list>
       <q-item
         v-for="token in paginatedTokens"
-        :key="token.id"
+        :key="token.paymentRequest?.id"
         clickable
         v-ripple
         class="q-px-md"
@@ -102,24 +102,23 @@
     </div>
   </div>
 </template>
-<script>
+<script lang="ts">
 import * as _ from "underscore";
 import { defineComponent } from "vue";
 import { shortenString } from "src/js/string-utils";
 import { formatDistanceToNow, parseISO } from "date-fns";
-import { useTokensStore } from "src/stores/tokens";
+import { HistoryToken, useTokensStore } from "src/stores/tokens";
 import { mapState, mapWritableState, mapActions } from "pinia";
 import { useReceiveTokensStore } from "src/stores/receiveTokensStore";
 import { useWalletStore } from "src/stores/wallet";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import token from "../js/token";
 import { notify } from "src/js/notify";
-import mixin from "src/mixin/formatMixin";
+import formatMixin from "src/mixin/formatMixin";
 
 export default defineComponent({
   name: "HistoryTable",
-  mixins: [windowMixin, mixin],
-  props: {},
+  mixins: [formatMixin],
   data: function () {
     return {
       currentPage: 1,
@@ -161,21 +160,21 @@ export default defineComponent({
   },
   methods: {
     ...mapActions(useWalletStore, ["checkTokenSpendable"]),
-    formattedDate(date_str) {
+    formattedDate(date_str: string) {
       const date = parseISO(date_str); // Convert string to date object
       return formatDistanceToNow(date, { addSuffix: false }); // "6 hours ago"
     },
-    shortenString: function (s) {
+    shortenString: function (s: string) {
       return shortenString(s, 20, 10);
     },
-    handlePageChange(page) {
+    handlePageChange(page: number) {
       this.currentPage = page;
     },
-    receiveToken(tokenStr) {
+    receiveToken(tokenStr: string) {
       this.receiveData.tokensBase64 = tokenStr;
       this.showReceiveTokens = true;
     },
-    showTokenDialog: function (historyToken) {
+    showTokenDialog: function (historyToken: HistoryToken) {
       if (historyToken.token === undefined) {
         notify("Old token not found");
         return;
@@ -183,7 +182,11 @@ export default defineComponent({
       const tokensBase64 = historyToken.token;
       console.log("##### showTokenDialog");
       const tokenObj = token.decode(tokensBase64);
-      this.sendData.tokens = token.getProofs(tokenObj);
+      if (tokenObj) {
+        this.sendData.tokens = JSON.stringify(token.getProofs(tokenObj));
+      } else {
+        notify("Token decoding failed");
+      }
       this.sendData.tokensBase64 = _.clone(tokensBase64);
       this.sendData.paymentRequest = historyToken.paymentRequest;
       this.sendData.historyAmount = historyToken.amount;

--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -114,10 +114,11 @@ import { useWalletStore } from "src/stores/wallet";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import token from "../js/token";
 import { notify } from "src/js/notify";
+import mixin from "src/mixin/formatMixin";
 
 export default defineComponent({
   name: "HistoryTable",
-  mixins: [windowMixin],
+  mixins: [windowMixin, mixin],
   props: {},
   data: function () {
     return {

--- a/src/components/InvoiceDetailDialog.vue
+++ b/src/components/InvoiceDetailDialog.vue
@@ -175,10 +175,10 @@ import { useWorkersStore } from "src/stores/workers";
 import { useMintsStore } from "src/stores/mints";
 import { useSettingsStore } from "../stores/settings";
 import NumericKeyboard from "components/NumericKeyboard.vue";
-
+import formatMixin from "src/mixin/formatMixin";
 export default defineComponent({
   name: "InvoiceDetailDialog",
-  mixins: [windowMixin],
+  mixins: [windowMixin, formatMixin],
   components: {
     ChooseMint,
     VueQrcode,

--- a/src/components/InvoicesTable.vue
+++ b/src/components/InvoicesTable.vue
@@ -92,12 +92,11 @@ import { shortenString } from "src/js/string-utils";
 import { mapWritableState, mapActions } from "pinia";
 import { useUiStore } from "src/stores/ui";
 import { useWalletStore } from "src/stores/wallet";
-import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
 import { formatDistanceToNow, parseISO } from "date-fns";
-
+import formatMixin from "src/mixin/formatMixin";
 export default defineComponent({
   name: "InvoicesTable",
-  mixins: [windowMixin],
+  mixins: [windowMixin, formatMixin],
   props: {},
   data: function () {
     return {

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -103,10 +103,11 @@
   </q-drawer>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent, ref } from "vue";
 import EssentialLink from "components/EssentialLink.vue";
 import { useUiStore } from "src/stores/ui";
+import onlineMixin from "src/mixin/onlineMixin";
 
 const linksList = [
   {
@@ -143,7 +144,7 @@ const linksList = [
 
 export default defineComponent({
   name: "MainHeader",
-  mixins: [windowMixin],
+  mixins: [onlineMixin],
   components: {
     EssentialLink,
   },
@@ -151,7 +152,7 @@ export default defineComponent({
     const leftDrawerOpen = ref(false);
     const uiStore = useUiStore();
     const countdown = ref(0);
-    let countdownInterval;
+    let countdownInterval: NodeJS.Timeout;
 
     const toggleLeftDrawer = () => {
       leftDrawerOpen.value = !leftDrawerOpen.value;

--- a/src/components/MintSettings.vue
+++ b/src/components/MintSettings.vue
@@ -524,21 +524,20 @@ import { mapActions, mapState, mapWritableState } from "pinia";
 import { useMintsStore, MintClass } from "src/stores/mints";
 import { useWalletStore } from "src/stores/wallet";
 import { useCameraStore } from "src/stores/camera";
-import { map } from "underscore";
-import { currentDateStr } from "src/js/utils";
 import { useSettingsStore } from "src/stores/settings";
 import { useNostrStore } from "src/stores/nostr";
 import { useP2PKStore } from "src/stores/p2pk";
 import { useWorkersStore } from "src/stores/workers";
 import { useSwapStore } from "src/stores/swap";
 import { useUiStore } from "src/stores/ui";
-import { notifyError, notifyWarning } from "src/js/notify";
+import { notifyError } from "src/js/notify";
 import MintDetailsDialog from "src/components/MintDetailsDialog.vue";
 import { EventBus } from "../js/eventBus";
+import formatMixin from "src/mixin/formatMixin";
 
 export default defineComponent({
   name: "MintSettings",
-  mixins: [windowMixin],
+  mixins: [windowMixin, formatMixin],
   components: { MintDetailsDialog },
   props: {},
   setup() {

--- a/src/components/NoMintWarnBanner.vue
+++ b/src/components/NoMintWarnBanner.vue
@@ -40,7 +40,7 @@
     </q-card-section>
   </q-card>
 </template>
-<script>
+<script lang="ts">
 import { defineComponent, ref } from "vue";
 import { getShortUrl } from "src/js/wallet-helpers";
 import { useUiStore } from "src/stores/ui";
@@ -50,7 +50,6 @@ import { EventBus } from "../js/eventBus";
 
 export default defineComponent({
   name: "NoMintWarnBanner",
-  mixins: [windowMixin],
   props: {
     proofs: Array,
     activeProofs: Array,
@@ -69,19 +68,19 @@ export default defineComponent({
       "receiveData",
     ]),
     balance: function () {
-      return this.activeProofs
+      return (this.activeProofs ?? [])
         .map((t) => t)
         .flat()
-        .reduce((sum, el) => (sum += el.amount), 0);
+        .reduce((sum, el: any) => (sum += el.amount), 0);
     },
     getActiveMintUrlShort: function () {
       return getShortUrl(this.activeMintUrl);
     },
     getBalance: function () {
-      var balance = this.activeProofs
+      var balance = (this.activeProofs ?? [])
         .map((t) => t)
         .flat()
-        .reduce((sum, el) => (sum += el.amount), 0);
+        .reduce((sum, el: any) => (sum += el.amount), 0);
       return balance;
     },
   },
@@ -94,8 +93,8 @@ export default defineComponent({
       this.showReceiveEcashDrawer = true;
     },
     handleAddMintClick: function () {
-      this.expandHistory = true;
-      this.tab = "mints";
+      this.expandHistory.value = true;
+      this.tab.value = "mints";
       EventBus.emit("scrollToAddMintDiv");
     },
   },

--- a/src/components/NumericKeyboard.vue
+++ b/src/components/NumericKeyboard.vue
@@ -39,7 +39,7 @@
   </transition>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent } from "vue";
 import { useUiStore } from "../stores/ui";
 import { mapWritableState } from "pinia";
@@ -60,7 +60,7 @@ export default defineComponent({
     ...mapWritableState(useSettingsStore, ["useNumericKeyboard"]),
   },
   methods: {
-    addDigit(digit) {
+    addDigit(digit: string) {
       const current = this.modelValue || "0";
       const newVal = current === "0" ? digit : current + digit;
       this.$emit("update:modelValue", newVal);
@@ -77,7 +77,7 @@ export default defineComponent({
       }
     },
     closeKeyboard() {
-      this.useNumericKeyboard = false;
+      this.useNumericKeyboard.value = false;
       this.showNumericKeyboard = false;
       notify(
         "Keyboard disabled. You can re-enable the keyboard in the settings.",

--- a/src/components/NumericKeyboard.vue
+++ b/src/components/NumericKeyboard.vue
@@ -77,12 +77,7 @@ export default defineComponent({
       }
     },
     closeKeyboard() {
-      this.useNumericKeyboard.value = false;
       this.showNumericKeyboard = false;
-      notify(
-        "Keyboard disabled. You can re-enable the keyboard in the settings.",
-        "bottom"
-      );
     },
     emitDone() {
       this.$emit("done");

--- a/src/components/PayInvoiceDialog.vue
+++ b/src/components/PayInvoiceDialog.vue
@@ -257,11 +257,11 @@ import { useWalletStore } from "src/stores/wallet";
 import { useUiStore } from "src/stores/ui";
 import { useCameraStore } from "src/stores/camera";
 import { useMintsStore } from "src/stores/mints";
-import { useSettingsStore } from "src/stores/settings";
 import { usePriceStore } from "src/stores/price";
 import { mapActions, mapState, mapWritableState } from "pinia";
 import ChooseMint from "components/ChooseMint.vue";
 import ToggleUnit from "components/ToggleUnit.vue";
+import formatMixin from "src/mixin/formatMixin";
 
 // import * as bolt11Decoder from "light-bolt11-decoder";
 import * as _ from "underscore";
@@ -269,7 +269,7 @@ import { Scan as ScanIcon } from "lucide-vue-next";
 
 export default defineComponent({
   name: "PayInvoiceDialog",
-  mixins: [windowMixin],
+  mixins: [windowMixin, formatMixin],
   components: {
     ChooseMint,
     ToggleUnit,

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -263,10 +263,11 @@ import {
   notify,
 } from "../js/notify";
 import MintSettings from "./MintSettings.vue";
+import formatMixin from "src/mixin/formatMixin";
 
 export default defineComponent({
   name: "ReceiveTokenDialog",
-  mixins: [windowMixin],
+  mixins: [windowMixin, formatMixin],
   components: {
     TokenInformation,
     NfcIcon,

--- a/src/components/RestoreView.vue
+++ b/src/components/RestoreView.vue
@@ -172,10 +172,11 @@ import { useRestoreStore } from "src/stores/restore";
 import { useWalletStore } from "src/stores/wallet";
 import { useUiStore } from "src/stores/ui";
 import { notifyError, notifySuccess } from "src/js/notify";
+import formatMixin from "src/mixin/formatMixin";
 
 export default defineComponent({
   name: "RestoreView",
-  mixins: [windowMixin],
+  mixins: [windowMixin, formatMixin],
   data() {
     return {
       mnemonicError: "",

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -475,9 +475,11 @@ import {
   notifyWarning,
 } from "src/js/notify.ts";
 import { getEncodedTokenV3 } from "@cashu/cashu-ts/dist/lib/es5/utils";
+import formatMixin from "src/mixin/formatMixin";
+
 export default defineComponent({
   name: "SendTokenDialog",
-  mixins: [windowMixin],
+  mixins: [windowMixin, formatMixin],
   components: {
     ChooseMint,
     TokenInformation,

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -476,10 +476,11 @@ import {
 } from "src/js/notify.ts";
 import { getEncodedTokenV3 } from "@cashu/cashu-ts/dist/lib/es5/utils";
 import formatMixin from "src/mixin/formatMixin";
+import onlineMixin from "src/mixin/onlineMixin";
 
 export default defineComponent({
   name: "SendTokenDialog",
-  mixins: [windowMixin, formatMixin],
+  mixins: [windowMixin, formatMixin, onlineMixin],
   components: {
     ChooseMint,
     TokenInformation,

--- a/src/components/ToggleUnit.vue
+++ b/src/components/ToggleUnit.vue
@@ -7,14 +7,12 @@
     :label="activeUnitLabelAdopted"
   />
 </template>
-<script>
+<script lang="ts">
 import { defineComponent } from "vue";
-import { getShortUrl } from "src/js/wallet-helpers";
 import { mapActions, mapState } from "pinia";
 import { useMintsStore } from "stores/mints";
 export default defineComponent({
   name: "ToggleUnit",
-  mixins: [windowMixin],
   props: {
     balanceView: {
       type: Boolean,

--- a/src/components/TokenInformation.vue
+++ b/src/components/TokenInformation.vue
@@ -45,7 +45,7 @@
     </div>
   </div>
 </template>
-<script>
+<script lang="ts">
 import { defineComponent } from "vue";
 import { getShortUrl } from "src/js/wallet-helpers";
 import { mapActions, mapState } from "pinia";
@@ -56,7 +56,7 @@ import formatMixin from "src/mixin/formatMixin";
 
 export default defineComponent({
   name: "TokenInformation",
-  mixins: [windowMixin, formatMixin],
+  mixins: [formatMixin],
   props: {
     encodedToken: String,
     showAmount: Boolean,
@@ -76,10 +76,19 @@ export default defineComponent({
       "addMintBlocking",
     ]),
     proofsToShow: function () {
-      return token.getProofs(token.decode(this.encodedToken));
+      const decodedToken = this.encodedToken
+        ? token.decode(this.encodedToken)
+        : null;
+      if (decodedToken) {
+        return token.getProofs(decodedToken);
+      }
+      return [];
     },
     sumProofs: function () {
-      let proofs = token.getProofs(token.decode(this.encodedToken));
+      let decodedToken = this.encodedToken
+        ? token.decode(this.encodedToken)
+        : null;
+      let proofs = decodedToken ? token.getProofs(decodedToken) : [];
       return proofs.flat().reduce((sum, el) => (sum += el.amount), 0);
     },
     displayUnit: function () {
@@ -87,39 +96,53 @@ export default defineComponent({
       return display;
     },
     tokenUnit: function () {
-      return token.getUnit(token.decode(this.encodedToken));
+      const decodedToken = this.encodedToken
+        ? token.decode(this.encodedToken)
+        : null;
+      if (decodedToken) {
+        return token.getUnit(decodedToken);
+      }
+      return "";
     },
     tokenMintUrl: function () {
-      let mint = token.getMint(token.decode(this.encodedToken));
+      const decodedToken = this.encodedToken
+        ? token.decode(this.encodedToken)
+        : null;
+      let mint = decodedToken ? token.getMint(decodedToken) : "";
       return getShortUrl(mint);
     },
     displayMemo: function () {
-      return token.getMemo(token.decode(this.encodedToken));
+      const decodedToken = this.encodedToken
+        ? token.decode(this.encodedToken)
+        : null;
+      return decodedToken ? token.getMemo(decodedToken) : "";
     },
   },
   methods: {
     ...mapActions(useP2PKStore, ["isLocked", "isLockedToUs"]),
-    getProofsMint: function (proofs) {
+    getProofsMint: function (proofs: any[]) {
       // unique keyset IDs of proofs
       let uniqueIds = [...new Set(proofs.map((p) => p.id))];
       // mints that have any of the keyset IDs
-      let mints_keysets = this.mints.filter((m) =>
+      let mints_keysets = this.mints.filter((m: { keysets: any[] }) =>
         m.keysets.some((r) => uniqueIds.indexOf(r) >= 0)
       );
       // what we put into the JSON
-      let mints = mints_keysets.map((m) => [{ url: m.url, ids: m.keysets }][0]);
+      let mints = mints_keysets.map(
+        (m: { url: any; keysets: any }) => [{ url: m.url, ids: m.keysets }][0]
+      );
       if (mints.length == 0) {
         return "";
       } else {
         return getShortUrl(mints[0].url);
       }
     },
-    mintKnownToUs: function (proofs) {
+    mintKnownToUs: function (proofs: any[]) {
       // unique keyset IDs of proofs
       let uniqueIds = [...new Set(proofs.map((p) => p.id))];
       // mints that have any of the keyset IDs
       return (
-        this.mints.filter((m) =>
+        this.mints.filter((m: { keysets: any[] }) =>
           m.keysets.some((r) => uniqueIds.indexOf(r.id) >= 0)
         ).length > 0
       );

--- a/src/components/TokenInformation.vue
+++ b/src/components/TokenInformation.vue
@@ -52,10 +52,11 @@ import { mapActions, mapState } from "pinia";
 import { useMintsStore } from "stores/mints";
 import { useP2PKStore } from "src/stores/p2pk";
 import token from "src/js/token";
+import formatMixin from "src/mixin/formatMixin";
 
 export default defineComponent({
   name: "TokenInformation",
-  mixins: [windowMixin],
+  mixins: [windowMixin, formatMixin],
   props: {
     encodedToken: String,
     showAmount: Boolean,

--- a/src/components/iOSPWAPrompt.vue
+++ b/src/components/iOSPWAPrompt.vue
@@ -22,12 +22,10 @@
     </div>
   </transition>
 </template>
-<script>
+<script lang="ts">
 import { defineComponent } from "vue";
 export default defineComponent({
   name: "iOSPWAPrompt",
-  mixins: [windowMixin],
-  props: {},
   data: function () {
     return {
       showIosPWAPromptLocal:

--- a/src/mixin/formatMixin.ts
+++ b/src/mixin/formatMixin.ts
@@ -1,0 +1,43 @@
+import { useUiStore } from "stores/ui";
+
+declare global {
+  interface Window {
+    LOCALE: string;
+    windowMixin: any;
+    allowedThemes?: string[];
+    Capacitor?: any;
+  }
+}
+
+window.LOCALE = "en";
+
+const formatMixin = {
+  methods: {
+    formatCurrency(
+      value: number,
+      currency: string = "sat",
+      showBalance: boolean = false
+    ): string {
+      if (useUiStore().hideBalance && !showBalance) {
+        return "****";
+      }
+      if (currency === "sat") return this.formatSat(value);
+      if (currency === "msat") return this.fromMsat(value);
+      if (currency === "usd" || currency === "eur") value = value / 100;
+      return new Intl.NumberFormat(window.LOCALE, {
+        style: "currency",
+        currency: currency,
+      }).format(value);
+    },
+    formatSat(value: number): string {
+      value = parseInt(value.toString());
+      return new Intl.NumberFormat(window.LOCALE).format(value) + " sat";
+    },
+    fromMsat(value: number): string {
+      value = parseInt(value.toString());
+      return new Intl.NumberFormat(window.LOCALE).format(value) + " msat";
+    },
+  },
+};
+
+export default formatMixin;

--- a/src/mixin/formatMixin.ts
+++ b/src/mixin/formatMixin.ts
@@ -4,8 +4,6 @@ declare global {
   interface Window {
     LOCALE: string;
     windowMixin: any;
-    allowedThemes?: string[];
-    Capacitor?: any;
   }
 }
 

--- a/src/mixin/onlineMixin.ts
+++ b/src/mixin/onlineMixin.ts
@@ -1,0 +1,26 @@
+import { defineComponent } from "vue";
+
+const onlineMixin = defineComponent({
+  data() {
+    return {
+      g: {
+        offline: !navigator.onLine,
+      },
+    };
+  },
+  created() {
+    addEventListener("offline", this.updateOfflineStatus);
+    addEventListener("online", this.updateOfflineStatus);
+  },
+  beforeUnmount() {
+    removeEventListener("offline", this.updateOfflineStatus);
+    removeEventListener("online", this.updateOfflineStatus);
+  },
+  methods: {
+    updateOfflineStatus() {
+      this.g.offline = !navigator.onLine;
+    },
+  },
+});
+
+export default onlineMixin;

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
+import { ref } from "vue";
 
 const defaultNostrRelays = [
   "wss://relay.damus.io",

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,6 +1,5 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
-import { ref } from "vue";
 
 const defaultNostrRelays = [
   "wss://relay.damus.io",


### PR DESCRIPTION
This is the first pass at this [issue](https://github.com/cashubtc/cashu.me/issues/273). From a first pass I started splitting out the global mixin, and am only injecting where the new `formatMixin` and `isOnlineMixin` are necessary. 

* small fix for keyboard close on lightning invoice creation for example was throwing the notification that the keyboard was disable which did not make sense. 
* split out the global `windowMixin` to be modular and in ts with the new mixins (in a mixin folder in project)
* first pass on converting the `.vue` files in main project to use `lang="ts"` - a bit much IMO to do everything in one pass as there are likely to be many significant changes in idiom (I tried on this [branch](https://github.com/nodlAndHodl/cashu.me/tree/feat/update-vue-to-ts) and had many issues and it seemed very sweeping in changeset) 