### PR TITLE
Allow encoding and decoding cahsu tokens as emoji

### DIFF
--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -321,8 +321,13 @@ export default defineComponent({
         navigator.clipboard.readText
       );
     },
+    isTokenPeanut: function () {
+      return this.receiveData.tokensBase64.match(
+        /^.([\uFE00-\uFE0F]|[\uE0100-\uE01EF]+)$/
+      );
+    },
     tokenDecodesCorrectly: function () {
-      if (this.receiveData.tokensBase64.startsWith("🥜"))
+      if (this.isTokenPeanut)
         return this.decodePeanut(this.receiveData.tokensBase64) !== undefined;
       return this.decodeToken(this.receiveData.tokensBase64) !== undefined;
     },
@@ -381,7 +386,7 @@ export default defineComponent({
     ]),
     // TOKEN METHODS
     decodePeanut: function (peanut) {
-      if (!peanut.startsWith("🥜")) return undefined;
+      if (!this.isTokenPeanut) return undefined;
       try {
         const decoded = Array.from(peanut)
           .slice(1)

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -322,6 +322,8 @@ export default defineComponent({
       );
     },
     tokenDecodesCorrectly: function () {
+      if (this.receiveData.tokensBase64.startsWith("🥜"))
+        return this.decodePeanut(this.receiveData.tokensBase64) !== undefined;
       return this.decodeToken(this.receiveData.tokensBase64) !== undefined;
     },
     knowThisMint: function () {
@@ -378,6 +380,35 @@ export default defineComponent({
       "pasteToParseDialog",
     ]),
     // TOKEN METHODS
+    decodePeanut: function (peanut) {
+      if (!peanut.startsWith("🥜")) return undefined;
+      try {
+        const decoded = Array.from(peanut)
+          .slice(1)
+          .map((char) => {
+            const codePoint = char.codePointAt(0);
+
+            // Handle Variation Selectors (VS1-VS16): U+FE00 to U+FE0F
+            if (codePoint >= 0xfe00 && codePoint <= 0xfe0f) {
+              const byteValue = codePoint - 0xfe00; // Maps FE00->0, FE01->1, ..., FE0F->15
+              return String.fromCharCode(byteValue);
+            }
+
+            // Handle Variation Selectors Supplement (VS17-VS256): U+E0100 to U+E01EF
+            if (codePoint >= 0xe0100 && codePoint <= 0xe01ef) {
+              const byteValue = codePoint - 0xe0100 + 16; // Maps E0100->16, E0101->17, ..., E01EF->255
+              return String.fromCharCode(byteValue);
+            }
+
+            throw new Error("Invalid code point: " + codePoint);
+          })
+          .join("");
+        this.receiveData.tokensBase64 = decoded;
+        return this.decodeToken(decoded);
+      } catch (error) {
+        return undefined;
+      }
+    },
     getProofs: function (decoded_token) {
       return token.getProofs(decoded_token);
     },

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -327,6 +327,14 @@
                 >Copy</q-btn
               >
               <q-btn
+                class="q-mx-sm"
+                size="md"
+                flat
+                dense
+                @click="copyText(encodeToPeanut(sendData.tokensBase64))"
+                >🥜</q-btn
+              >
+              <q-btn
                 class="q-mr-sm"
                 color="grey"
                 size="md"
@@ -675,6 +683,25 @@ export default defineComponent({
     //     this.notifyError("No valid key");
     //   }
     // },
+    encodeToPeanut: function (token) {
+      return (
+        "🥜" +
+        Array.from(token)
+          .map((char) => {
+            const byteValue = char.charCodeAt(0);
+            // For byte values 0-15, use Variation Selectors (VS1-VS16): U+FE00 to U+FE0F
+            if (byteValue >= 0 && byteValue <= 15) {
+              return String.fromCodePoint(0xfe00 + byteValue);
+            }
+
+            // For byte values 16-255, use Variation Selectors Supplement (VS17-VS256): U+E0100 to U+E01EF
+            if (byteValue >= 16 && byteValue <= 255) {
+              return String.fromCodePoint(0xe0100 + (byteValue - 16));
+            }
+          })
+          .join("")
+      );
+    },
     decodeToken: function (encoded_token) {
       return token.decode(encoded_token);
     },


### PR DESCRIPTION
Calle had a great idea on

nostr:note1rvcyyyjs072j4agp0ky2vkne3rjsqe25r09k9zpn6gs3l86lc00sd2m850

I implemented a simple functionality to encode and decode cashu tokens into emoji quickly