### PR TITLE
Add automatic npub conversion for P2PK

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -691,7 +691,7 @@ export default defineComponent({
       "setTokenPaid",
       "deleteToken",
     ]),
-    ...mapActions(useP2PKStore, ["isValidPubkey"]),
+    ...mapActions(useP2PKStore, ["isValidPubkey", "maybeConvertNpub"]),
     ...mapActions(useCameraStore, ["closeCamera", "showCamera"]),
     ...mapActions(useMintsStore, ["toggleUnit"]),
     // decodeP2PKQR: function (res) {
@@ -952,6 +952,9 @@ export default defineComponent({
       calls send, displays token and kicks off the spendableWorker
       */
       this.showNumericKeyboard = false;
+      this.sendData.p2pkPubkey = this.maybeConvertNpub(
+        this.sendData.p2pkPubkey
+      );
       if (
         this.sendData.p2pkPubkey &&
         this.isValidPubkey(this.sendData.p2pkPubkey)

--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
-import { generateSecretKey, getPublicKey } from "nostr-tools";
+import { generateSecretKey, getPublicKey, nip19 } from "nostr-tools";
 import { bytesToHex } from "@noble/hashes/utils"; // already an installed dependency
 import { WalletProof } from "stores/mints";
 import token from "src/js/token";
@@ -27,7 +27,18 @@ export const useP2PKStore = defineStore("p2pk", {
     haveThisKey: function (key: string) {
       return this.p2pkKeys.filter((m) => m.publicKey == key).length > 0;
     },
+    maybeConvertNpub: function (key: string) {
+      // Check and convert npub to P2PK
+      if (key && key.startsWith("npub1")) {
+        const { type, data } = nip19.decode(key);
+        if (type === "npub" && data.length === 64) {
+          key = "02" + data;
+        }
+      }
+      return key;
+    },
     isValidPubkey: function (key: string) {
+      key = this.maybeConvertNpub(key);
       return key && key.length == 66;
     },
     setPrivateKeyUsed: function (key: string) {


### PR DESCRIPTION
Allows user to enter an npub for P2PK locking.
npub is converted to officially supported 66 character P2PK format automatically on send.
If key is not a valid nip19 npub, original string is used as before