### PR TITLE
Allow import of nsec as a p2pk key

### DIFF
--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -675,7 +675,7 @@
                 >
               </q-item-section>
             </q-item>
-            <q-item>
+            <q-item style="display: inline-block">
               <q-btn
                 class="q-ml-sm q-px-md"
                 color="primary"
@@ -684,6 +684,17 @@
                 outline
                 @click="generateKeypair"
                 >Generate key</q-btn
+              >
+            </q-item>
+            <q-item style="display: inline-block">
+              <q-btn
+                class="q-ml-sm q-px-md"
+                color="primary"
+                size="sm"
+                rounded
+                outline
+                @click="importNsec"
+                >Import nsec</q-btn
               >
             </q-item>
             <q-item>
@@ -1494,7 +1505,11 @@ export default defineComponent({
       "unsubscribeNWC",
       "getConnectionString",
     ]),
-    ...mapActions(useP2PKStore, ["generateKeypair", "showKeyDetails"]),
+    ...mapActions(useP2PKStore, [
+      "importNsec",
+      "generateKeypair",
+      "showKeyDetails",
+    ]),
     ...mapActions(useMintsStore, [
       "addMint",
       "removeMint",

--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -52,6 +52,27 @@ export const useP2PKStore = defineStore("p2pk", {
         this.showP2PKDialog = true;
       }
     },
+    importNsec: async function () {
+      const nsec = (await prompt("Enter your nsec")) as string;
+      if (!nsec || !nsec.startsWith("nsec1")) {
+        console.log("input was not an nsec");
+        return;
+      }
+      let sk = nip19.decode(nsec).data as Uint8Array; // `sk` is a Uint8Array
+      let pk = "02" + getPublicKey(sk); // `pk` is a hex string
+      let skHex = bytesToHex(sk);
+      if (this.haveThisKey(pk)) {
+        console.log("nsec already exists in p2pk keystore");
+        return;
+      }
+      const keyPair: P2PKKey = {
+        publicKey: pk,
+        privateKey: skHex,
+        used: false,
+        usedCount: 0,
+      };
+      this.p2pkKeys = this.p2pkKeys.concat(keyPair);
+    },
     generateKeypair: function () {
       let sk = generateSecretKey(); // `sk` is a Uint8Array
       let pk = "02" + getPublicKey(sk); // `pk` is a hex string


### PR DESCRIPTION
This PR completes the integration of NOSTR npub/nsec handling for P2PK.
It allows user to add their NSEC as a P2PK key, which then means they can receive tokens locked to their NPUB.

See also this related PR: https://github.com/cashubtc/cashu.me/pull/358
Which allows users to lock tokens to an NPUB when sending
