### PR TITLE
[BUGFIX] MintWallet Keysets Are Unit-Filtered

### DIFF
--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -229,6 +229,9 @@ export const useMintsStore = defineStore("mints", {
         (p) => unitKeysets.map((k) => k.id).includes(p.id) && !p.reserved
       );
     },
+    mintUnitKeysets(mint: Mint, unit: string): MintKeyset[] {
+      return mint.keysets.filter((k) => k.unit === unit);
+    },
     toggleUnit: function () {
       const units = this.activeMint().units;
       this.activeUnit =

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -180,6 +180,7 @@ export const useWalletStore = defineStore("wallet", {
       if (!storedMint) {
         throw new Error("mint not found");
       }
+      const unitKeysets = mints.mintUnitKeysets(storedMint, unit);
       const mint = new CashuMint(url);
       if (this.mnemonic == "") {
         this.mnemonic = generateMnemonic(wordlist);
@@ -188,7 +189,7 @@ export const useWalletStore = defineStore("wallet", {
       const bip39Seed = mnemonicToSeedSync(mnemonic);
       const wallet = new CashuWallet(mint, {
         keys: storedMint.keys,
-        keysets: storedMint.keysets,
+        keysets: unitKeysets,
         mintInfo: storedMint.info,
         bip39seed: bip39Seed,
         unit: unit,
@@ -514,7 +515,6 @@ export const useWalletStore = defineStore("wallet", {
             {
               counter,
               privkey,
-              keysetId,
               proofsWeHave: mintStore.mintUnitProofs(mint, historyToken.unit),
             }
           );


### PR DESCRIPTION
Instantiating a mint wallet should pass into the `CashuWallet` constructor keysets that are filtered based on the unit.