### PR TITLE
chore: fixed length seed word placeholder

### DIFF
--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1455,7 +1455,7 @@ export default defineComponent({
       if (this.hideMnemonic) {
         return this.mnemonic
           .split(" ")
-          .map((w) => "*".repeat(w.length))
+          .map((w) => "*".repeat(6))
           .join(" ");
       } else {
         return this.mnemonic;

--- a/src/pages/welcome/WelcomeSlide3.vue
+++ b/src/pages/welcome/WelcomeSlide3.vue
@@ -67,7 +67,7 @@ export default {
       if (hideMnemonic.value) {
         return walletStore.mnemonic
           .split(" ")
-          .map((w) => "*".repeat(w.length))
+          .map((w) => "*".repeat(6))
           .join(" ");
       }
       return walletStore.mnemonic;


### PR DESCRIPTION
Instead of replacing a seed word with a placeholder of the same length, it always replaces with a fixed length placeholder (i.e. 6 chars).

Before
![image](https://github.com/user-attachments/assets/a2864c52-8f6f-4e4e-93ee-62d734dcac37)


After

![image](https://github.com/user-attachments/assets/6f39ae5d-14d0-4764-8863-edb1d937839d)
