### PR TITLE
add support for showing balance in more fiat currencies

### DIFF
--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -66,22 +66,28 @@
               <div v-if="bitcoinPrice">
                 <strong v-if="this.activeUnit == 'sat'">
                   <AnimatedNumber
-                    :value="(bitcoinPrice / 100000000) * getTotalBalance"
-                    :format="(val) => formatCurrency(val, 'USD')"
+                    :value="
+                      (currentCurrencyPrice / 100000000) * getTotalBalance
+                    "
+                    :format="(val) => formatCurrency(val, bitcoinPriceCurrency)"
                   />
                 </strong>
                 <strong
                   v-if="this.activeUnit == 'usd' || this.activeUnit == 'eur'"
                 >
                   <AnimatedNumber
-                    :value="(getTotalBalance / 100 / bitcoinPrice) * 100000000"
+                    :value="
+                      (getTotalBalance / 100 / currentCurrencyPrice) * 100000000
+                    "
                     :format="(val) => formatCurrency(val, 'sat')"
                   />
                 </strong>
                 <q-tooltip>
-                  {{ formatCurrency(bitcoinPrice, "USD").slice(1) }}
-                  USD/BTC</q-tooltip
-                >
+                  1 BTC =
+                  {{
+                    formatCurrency(currentCurrencyPrice, bitcoinPriceCurrency)
+                  }}
+                </q-tooltip>
               </div>
             </div>
           </div>
@@ -182,7 +188,12 @@ export default defineComponent({
     ]),
     ...mapState(useTokensStore, ["historyTokens"]),
     ...mapState(useUiStore, ["globalMutexLock"]),
-    ...mapState(usePriceStore, ["bitcoinPrice"]),
+    ...mapState(usePriceStore, [
+      "bitcoinPrice",
+      "bitcoinPrices",
+      "currentCurrencyPrice",
+    ]),
+    ...mapState(useSettingsStore, ["bitcoinPriceCurrency"]),
     ...mapWritableState(useMintsStore, ["activeUnit"]),
     ...mapWritableState(useUiStore, ["hideBalance", "lastBalanceCached"]),
     pendingBalance: function () {
@@ -229,11 +240,11 @@ export default defineComponent({
     };
   },
   mounted() {
-    this.fetchBitcoinPriceUSD();
+    this.fetchBitcoinPrice();
   },
   methods: {
     ...mapActions(useWalletStore, ["checkPendingTokens"]),
-    ...mapActions(usePriceStore, ["fetchBitcoinPriceUSD"]),
+    ...mapActions(usePriceStore, ["fetchBitcoinPrice"]),
     toggleUnit: function () {
       const units = this.activeMint().units;
       this.activeUnit =

--- a/src/components/PayInvoiceDialog.vue
+++ b/src/components/PayInvoiceDialog.vue
@@ -40,9 +40,9 @@
               >
                 ({{
                   formatCurrency(
-                    (bitcoinPrice / 100000000) *
+                    (currentCurrencyPrice / 100000000) *
                       payInvoiceData.meltQuote.response.amount,
-                    "USD",
+                    bitcoinPriceCurrency,
                     true
                   )
                 }})
@@ -367,7 +367,12 @@ export default defineComponent({
       "activeBalance",
       "multiMints",
     ]),
-    ...mapState(usePriceStore, ["bitcoinPrice"]),
+    ...mapState(usePriceStore, [
+      "bitcoinPrice",
+      "bitcoinPrices",
+      "currentCurrencyPrice",
+    ]),
+    ...mapState(useSettingsStore, ["bitcoinPriceCurrency"]),
     canPasteFromClipboard: function () {
       return (
         window.isSecureContext &&

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -35,8 +35,8 @@
             >
               ({{
                 formatCurrency(
-                  (bitcoinPrice / 100000000) * tokenAmount,
-                  "USD",
+                  (currentCurrencyPrice / 100000000) * tokenAmount,
+                  bitcoinPriceCurrency,
                   true
                 )
               }})
@@ -324,7 +324,12 @@ export default defineComponent({
       "scanningCard",
     ]),
     ...mapState(useUiStore, ["tickerShort", "ndefSupported"]),
-    ...mapState(usePriceStore, ["bitcoinPrice"]),
+    ...mapState(usePriceStore, [
+      "bitcoinPrice",
+      "bitcoinPrices",
+      "currentCurrencyPrice",
+    ]),
+    ...mapState(useSettingsStore, ["bitcoinPriceCurrency"]),
     ...mapState(useMintsStore, [
       "activeMintUrl",
       "activeProofs",

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -55,10 +55,10 @@
               >
                 ({{
                   formatCurrency(
-                    (bitcoinPrice / 100000000) *
+                    (currentCurrencyPrice / 100000000) *
                       sendData.amount *
                       activeUnitCurrencyMultiplyer,
-                    "USD",
+                    bitcoinPriceCurrency,
                     true
                   )
                 }})
@@ -674,7 +674,12 @@ export default defineComponent({
       "nfcEncoding",
       "useNumericKeyboard",
     ]),
-    ...mapState(usePriceStore, ["bitcoinPrice"]),
+    ...mapState(usePriceStore, [
+      "bitcoinPrice",
+      "bitcoinPrices",
+      "currentCurrencyPrice",
+    ]),
+    ...mapState(useSettingsStore, ["bitcoinPriceCurrency"]),
     ...mapState(useWorkersStore, ["tokenWorkerRunning"]),
     // TOKEN METHODS
     sumProofs: function () {

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -346,6 +346,10 @@ export default {
         toggle: "الحصول على سعر الصرف من Coinbase",
         description:
           "إذا تم تمكين هذا، سيتم جلب سعر صرف Bitcoin الحالي من coinbase.com وسيتم عرض رصيدك المحول.",
+        currency: {
+          title: "العملة الورقية",
+          description: "اختر العملة الورقية لعرض سعر البيتكوين.",
+        },
       },
     },
     experimental: {

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -351,6 +351,11 @@ export default {
         toggle: "Wechselkurs von Coinbase abrufen",
         description:
           "Wenn aktiviert, wird der aktuelle Bitcoin-Wechselkurs von coinbase.com abgerufen und Ihr umgerechnetes Guthaben angezeigt.",
+        currency: {
+          title: "Fiat-Währung",
+          description:
+            "Wählen Sie die Fiat-Währung für die Bitcoin-Preisanzeige.",
+        },
       },
     },
     experimental: {

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -350,6 +350,11 @@ export default {
         toggle: "Λήψη συναλλαγματικής ισοτιμίας από Coinbase",
         description:
           "Εάν είναι ενεργοποιημένο, η τρέχουσα συναλλαγματική ισοτιμία Bitcoin θα ληφθεί από το coinbase.com και θα εμφανιστεί το μετατραπέν υπόλοιπό σας.",
+        currency: {
+          title: "Νόμισμα Fiat",
+          description:
+            "Επιλέξτε το νόμισμα fiat για την εμφάνιση της τιμής Bitcoin.",
+        },
       },
     },
     experimental: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -345,6 +345,10 @@ export default {
         toggle: "Get exchange rate from Coinbase",
         description:
           "If enabled, the current Bitcoin exchange rate will be fetched from coinbase.com and your converted balance will be displayed.",
+        currency: {
+          title: "Fiat Currency",
+          description: "Choose the fiat currency for Bitcoin price display.",
+        },
       },
     },
     experimental: {

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -364,6 +364,11 @@ export default {
         toggle: "Obtener tasa de cambio de Coinbase",
         description:
           "Si está habilitado, se obtendrá la tasa de cambio actual de Bitcoin de coinbase.com y se mostrará tu saldo convertido.",
+        currency: {
+          title: "Moneda Fiat",
+          description:
+            "Elija la moneda fiat para mostrar el precio de Bitcoin.",
+        },
       },
     },
     experimental: {

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -350,6 +350,11 @@ export default {
         toggle: "Obtenir le taux de change de Coinbase",
         description:
           "Si activé, le taux de change actuel du Bitcoin sera récupéré de coinbase.com et votre solde converti sera affiché.",
+        currency: {
+          title: "Devise Fiat",
+          description:
+            "Choisissez la devise fiat pour l'affichage du prix Bitcoin.",
+        },
       },
     },
     experimental: {

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -348,6 +348,11 @@ export default {
         toggle: "Ottieni tasso di cambio da Coinbase",
         description:
           "Se abilitato, il tasso di cambio attuale di Bitcoin verrà recuperato da coinbase.com e verrà visualizzato il tuo saldo convertito.",
+        currency: {
+          title: "Valuta Fiat",
+          description:
+            "Scegli la valuta fiat per la visualizzazione del prezzo Bitcoin.",
+        },
       },
     },
     experimental: {

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -348,6 +348,10 @@ export default {
         toggle: "Coinbaseから為替レートを取得",
         description:
           "有効にすると、現在のBitcoin為替レートがcoinbase.comから取得され、換算された残高が表示されます。",
+        currency: {
+          title: "法定通貨",
+          description: "Bitcoin価格表示用の法定通貨を選択してください。",
+        },
       },
     },
     experimental: {

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -347,6 +347,10 @@ export default {
         toggle: "Hämta växelkurs från Coinbase",
         description:
           "Om aktiverat kommer aktuell Bitcoin-växelkurs att hämtas från coinbase.com och ditt konverterade saldo kommer att visas.",
+        currency: {
+          title: "Fiat-valuta",
+          description: "Välj fiat-valuta för Bitcoin-prisvisning.",
+        },
       },
     },
     experimental: {

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -346,6 +346,10 @@ export default {
         toggle: "รับอัตราแลกเปลี่ยนจาก Coinbase",
         description:
           "หากเปิดใช้งาน จะดึงอัตราแลกเปลี่ยน Bitcoin ปัจจุบันจาก coinbase.com และแสดงยอดคงเหลือที่แปลงแล้วของคุณ",
+        currency: {
+          title: "สกุลเงินเฟียต",
+          description: "เลือกสกุลเงินเฟียตสำหรับการแสดงราคา Bitcoin",
+        },
       },
     },
     experimental: {

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -349,6 +349,10 @@ export default {
         toggle: "Döviz kurunu Coinbase'den al",
         description:
           "Etkinleştirilirse, güncel Bitcoin döviz kuru coinbase.com'dan alınacak ve dönüştürülmüş bakiyeniz görüntülenecektir.",
+        currency: {
+          title: "Fiat Para Birimi",
+          description: "Bitcoin fiyat gösterimi için fiat para birimini seçin.",
+        },
       },
     },
     experimental: {

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -343,6 +343,10 @@ export default {
         toggle: "从 Coinbase 获取汇率",
         description:
           "如果启用，将从 coinbase.com 获取当前比特币汇率并显示您的转换后余额。",
+        currency: {
+          title: "法定货币",
+          description: "选择用于比特币价格显示的法定货币。",
+        },
       },
     },
     experimental: {

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -14,6 +14,10 @@ export const useSettingsStore = defineStore("settings", {
         "cashu.settings.getBitcoinPrice",
         false
       ),
+      bitcoinPriceCurrency: useLocalStorage<string>(
+        "cashu.settings.bitcoinPriceCurrency",
+        "USD"
+      ),
       checkSentTokens: useLocalStorage<boolean>(
         "cashu.settings.checkSentTokens",
         true


### PR DESCRIPTION
We currently use Coinbase for the exchange rates, but only show fiat rates in USD

This PR changes this and adds support for many more currencies.