### PR TITLE
fix: base64 to hex conversion

### DIFF
--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -505,7 +505,7 @@ export const useMintsStore = defineStore("mints", {
           return BigInt(`0x${id}`) % BigInt(2 ** 31 - 1);
         } else {
           const bin = atob(id);
-          const hex = bytesToHex(new TextEncoder().encode(bin));
+          const hex = bytesToHex(Uint8Array.from(bin, (c) => c.charCodeAt(0)));
           return BigInt(`0x${hex}`) % BigInt(2 ** 31 - 1);
         }
       }


### PR DESCRIPTION
This fixes an issue with the way we convert base64 values to hex. atob returns a byte string, not an utf-8 string.