### PR TITLE
updated type on dialog headers for payment request,receive ecash, sen…

### DIFF
--- a/src/components/CreateInvoiceDialog.vue
+++ b/src/components/CreateInvoiceDialog.vue
@@ -26,10 +26,8 @@
           />
           <div class="col text-center fixed-title-height">
             <q-item-label
-              overline
-              class="q-mt-sm"
+              class="dialog-header q-mt-sm"
               :class="$q.dark.isActive ? 'text-white' : 'text-black'"
-              style="font-size: 1rem"
             >
               {{ $t("InvoiceDetailDialog.title") }}
             </q-item-label>

--- a/src/components/PayInvoiceDialog.vue
+++ b/src/components/PayInvoiceDialog.vue
@@ -28,11 +28,9 @@
           <div class="col text-center fixed-title-height">
             <div>
               <q-item-label
-                overline
-                class="q-mt-sm"
+                class="dialog-header q-mt-sm"
                 :class="$q.dark.isActive ? 'text-white' : 'text-black'"
                 style="
-                  font-size: 1rem;
                   display: inline-block;
                   white-space: normal;
                   word-break: break-word;

--- a/src/components/PaymentRequestDialog.vue
+++ b/src/components/PaymentRequestDialog.vue
@@ -23,11 +23,7 @@
             class="floating-close-btn"
           />
           <div class="col text-center fixed-title-height">
-            <q-item-label
-              overline
-              class="q-mt-sm text-white"
-              style="font-size: 1rem"
-            >
+            <q-item-label class="dialog-header q-mt-sm text-white">
               {{ $t("PaymentRequestDialog.payment_request.caption") }}
             </q-item-label>
           </div>

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -26,10 +26,8 @@
           />
           <div class="col text-center fixed-title-height">
             <q-item-label
-              overline
-              class="q-mt-sm"
+              class="dialog-header q-mt-sm"
               :class="$q.dark.isActive ? 'text-white' : 'text-black'"
-              style="font-size: 1rem"
             >
               {{ $t("ReceiveTokenDialog.title") }}
             </q-item-label>

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -27,10 +27,8 @@
           />
           <div class="col text-center fixed-title-height">
             <q-item-label
-              overline
-              class="q-mt-sm"
+              class="dialog-header q-mt-sm"
               :class="$q.dark.isActive ? 'text-white' : 'text-black'"
-              style="font-size: 1rem"
             >
               {{ $t("SendTokenDialog.title") }}
             </q-item-label>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -10,6 +10,17 @@ body {
     sans-serif;
 }
 
+// Dialog header typography
+// This class provides proper letter-spacing for dialog titles
+// The default Quasar 'overline' class has excessive letter-spacing for headers
+.dialog-header {
+  font-size: 1.2rem; // 16px
+  font-weight: 500; // Medium weight for headers
+  letter-spacing: -0.01em; // Tight letter spacing for better readability on headers
+  text-transform: none; // No uppercase transformation
+  line-height: 1.5; // Good line height for readability
+}
+
 // prevent pull to refresh
 html,
 body {


### PR DESCRIPTION
## Summary
- replace Quasar’s `overline` headline style with a shared `.dialog-header`
- tighten letter spacing and bump weight so dialog titles feel consistent
- update all dialog headers (send/receive/pay/payment request/invoice) to use the new class

## Testing
- [x] visually inspected the dialog headers 