### PR TITLE
fix(nostr): respect verbose flag in backup error notifications

### DIFF
--- a/src/stores/nostrMintBackup.ts
+++ b/src/stores/nostrMintBackup.ts
@@ -146,6 +146,19 @@ export const useNostrMintBackupStore = defineStore("nostrMintBackup", {
         const settingsStore = useSettingsStore();
         const mintsStore = useMintsStore();
 
+        // Check if relays are configured
+        if (
+          !settingsStore.defaultNostrRelays ||
+          settingsStore.defaultNostrRelays.length === 0
+        ) {
+          const errorMsg = "No Nostr relays configured";
+          console.error(errorMsg);
+          if (verbose) {
+            notifyError(`Failed to backup mint list to Nostr: ${errorMsg}`);
+          }
+          throw new Error(errorMsg);
+        }
+
         const currentMints = mintsStore.mints.map((mint) => mint.url);
 
         if (currentMints.length === 0) {
@@ -200,9 +213,13 @@ export const useNostrMintBackupStore = defineStore("nostrMintBackup", {
         console.log("Mint backup published to Nostr:", event.id);
       } catch (error) {
         console.error("Failed to backup mints to Nostr:", error);
-        notifyError(
-          "Failed to backup mint list to Nostr: " + (error as Error).message
-        );
+        // Only show error notification if verbose is true
+        // This prevents showing errors for automatic backups that fail silently
+        if (verbose) {
+          notifyError(
+            "Failed to backup mint list to Nostr: " + (error as Error).message
+          );
+        }
         throw error;
       } finally {
         this.backupInProgress = false;


### PR DESCRIPTION
When adding a mint from the discovery page, users see two notifications in sequence:

1. ✅ "Mint saved successfully" (expected)
2. ❌ "Failed to backup mint list to Nostr: No relay was able to receive the event." (unexpected)

<img width="200" height="500" alt="error" src="https://github.com/user-attachments/assets/8e356e1a-ab42-4c88-a95c-7d216271ad49" />

The mint is successfully saved, but the error notification creates a confusing user experience, making it appear as if something went wrong even though the primary operation (adding the mint) completed successfully.

The issue occurs in `src/stores/nostrMintBackup.ts` in the `backupMintsToNostr()` function. When a mint is added, it triggers an automatic Nostr backup with `verbose=false`, but the error handler always shows an error notification regardless of the `verbose` flag. This means automatic background backup failures display error notifications to users, even though the primary operation (adding the mint) succeeded.

**File**: `src/stores/nostrMintBackup.ts`  
**Function**: `backupMintsToNostr(verbose: boolean = false)`  
**Issue**: Error notification is shown even when `verbose=false`

## Solution

Made error notifications conditional on the `verbose` parameter. Now:

- **Automatic backups** (called with `verbose=false`): Fail silently, errors logged to console only
- **Manual backups** (called with `verbose=true`): Show error notifications when they fail

The fix ensures that automatic background backup failures don't interrupt users with error notifications, while manual backup operations still provide feedback when they fail.
