### PR TITLE
ignore ios/android in eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,6 @@
 /dist
+/android
+/ios
 /src-bex/www
 /src-capacitor
 /src-cordova


### PR DESCRIPTION
Linter is almost unusable because of noise from IOS/Android folders. This PR ignores them.