### PR TITLE
Fix: Allow decimal input for fiat currency amounts

### DIFF
--- a/src/components/CreateInvoiceDialog.vue
+++ b/src/components/CreateInvoiceDialog.vue
@@ -74,10 +74,7 @@
               :force-visible="true"
               :hide-close="true"
               :hide-enter="true"
-              :hide-comma="
-                (activeUnit === 'sat' || activeUnit === 'msat') &&
-                !fiatKeyboardMode
-              "
+              :hide-comma="shouldHideDecimal"
               :model-value="String(invoiceData.amount ?? 0)"
               @update:modelValue="(val: string | number) => (invoiceData.amount = Number(val))"
               @done="requestMintButton"
@@ -147,6 +144,14 @@ export default defineComponent({
       "showNumericKeyboard",
       "showInvoiceDetails",
     ]),
+    shouldHideDecimal(): boolean {
+      // Allow decimals for:
+      // 1. Fiat units (USD, EUR, etc.)
+      // 2. When in fiat keyboard mode (converting to fiat for SAT unit)
+      // Hide decimals only for SAT/mSAT when not in fiat mode
+      const isFiatUnit = this.activeUnit !== 'sat' && this.activeUnit !== 'msat';
+      return !isFiatUnit && !this.fiatKeyboardMode;
+    },
     ...mapWritableState(useUiStore, ["tickerShort", "globalMutexLock"]),
     ...mapWritableState(useUiStore, ["showCreateInvoiceDialog"]),
     ...mapWritableState(useWalletStore, ["invoiceData"]),

--- a/src/components/PayInvoiceDialog.vue
+++ b/src/components/PayInvoiceDialog.vue
@@ -486,10 +486,7 @@
               :force-visible="true"
               :hide-close="true"
               :hide-enter="true"
-              :hide-comma="
-                (activeUnit === 'sat' || activeUnit === 'msat') &&
-                !fiatKeyboardMode
-              "
+              :hide-comma="shouldHideDecimal"
               :model-value="String(payInvoiceData.input.amount ?? 0)"
               @update:modelValue="
                 (val: string | number) =>
@@ -751,6 +748,14 @@ export default defineComponent({
         paidRaw !== null &&
         typeof paidRaw !== "boolean";
       return hasAmount || hasFeeReserve || hasFeePaid || hasPaidTimestamp;
+    },
+    shouldHideDecimal(): boolean {
+      // Allow decimals for:
+      // 1. Fiat units (USD, EUR, etc.)
+      // 2. When in fiat keyboard mode (converting to fiat for SAT unit)
+      // Hide decimals only for SAT/mSAT when not in fiat mode
+      const isFiatUnit = this.activeUnit !== 'sat' && this.activeUnit !== 'msat';
+      return !isFiatUnit && !this.fiatKeyboardMode;
     },
     enoughtotalUnitBalance: function () {
       return (

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -196,10 +196,7 @@
               :force-visible="true"
               :hide-close="true"
               :hide-enter="true"
-              :hide-comma="
-                (activeUnit === 'sat' || activeUnit === 'msat') &&
-                !fiatKeyboardMode
-              "
+              :hide-comma="shouldHideDecimal"
               :model-value="String(sendData.amount ?? 0)"
               @update:modelValue="(val: string | number) => (sendData.amount = Number(val))"
               @done="sendTokens"
@@ -315,6 +312,14 @@ export default defineComponent({
       "showLockInput",
       "sendData",
     ]),
+    shouldHideDecimal(): boolean {
+      // Allow decimals for:
+      // 1. Fiat units (USD, EUR, etc.)
+      // 2. When in fiat keyboard mode (converting to fiat for SAT unit)
+      // Hide decimals only for SAT/mSAT when not in fiat mode
+      const isFiatUnit = this.activeUnit !== 'sat' && this.activeUnit !== 'msat';
+      return !isFiatUnit && !this.fiatKeyboardMode;
+    },
     ...mapWritableState(useCameraStore, ["camera", "hasCamera"]),
     ...mapState(useUiStore, [
       "tickerShort",


### PR DESCRIPTION
- Add shouldHideDecimal computed property to SendTokenDialog, CreateInvoiceDialog, and PayInvoiceDialog
- Explicitly handle fiat units (USD, EUR) to always allow decimal input
- Allow decimals when in fiat keyboard mode for SAT/mSAT units
- Fixes #499: Users can now enter fractional fiat amounts like 0.21