### PR TITLE
Fix: Hide status bar for fullscreen experience on Capacitor builds

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -4,6 +4,13 @@ const config: CapacitorConfig = {
   appId: "me.cashu.wallet",
   appName: "Cashu.me",
   webDir: "dist/pwa/",
+  plugins: {
+    StatusBar: {
+      style: "DARK",
+      backgroundColor: "#000000",
+      overlaysWebView: false,
+    },
+  },
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@capacitor/clipboard": "^6.0.2",
     "@capacitor/core": "^6.2.0",
     "@capacitor/haptics": "^6.0.2",
+    "@capacitor/status-bar": "^6.0.1",
     "@cashu/cashu-ts": "^2.7.4",
     "@cashu/crypto": "^0.3.4",
     "@chenfengyuan/vue-qrcode": "^2.0.0",

--- a/src/boot/base.js
+++ b/src/boot/base.js
@@ -1,6 +1,7 @@
 import { copyToClipboard } from "quasar";
 import { useUiStore } from "stores/ui";
 import { Clipboard } from "@capacitor/clipboard";
+import { StatusBar, Style } from "@capacitor/status-bar";
 import { SafeArea } from "capacitor-plugin-safe-area";
 import { useSettingsStore } from "stores/settings";
 window.LOCALE = "en";
@@ -342,6 +343,15 @@ window.windowMixin = {
     const language = this.$q.localStorage.getItem("cashu.language");
     if (language) {
       this.$i18n.locale = language;
+    }
+
+    // Hide status bar for native Capacitor apps (Android & iOS)
+    if (window.Capacitor && window.Capacitor.isNativePlatform()) {
+      try {
+        StatusBar.hide();
+      } catch (error) {
+        console.log("StatusBar.hide() not available:", error);
+      }
     }
 
     // only for iOS


### PR DESCRIPTION
- Add @capacitor/status-bar dependency
- Hide status bar on native Android and iOS apps using StatusBar.hide()
- Configure StatusBar plugin with dark style and black background
- Fixes #490: Native Capacitor builds now display in true fullscreen