### PR TITLE
Fix keyset rotation handling by merging instead of overwriting keysets

### DIFF
--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -585,8 +585,26 @@ export const useMintsStore = defineStore("mints", {
           // check for keyset id collisions with other mints
           await this.checkForMintKeysetIdCollisions(mint, keysets);
           // store keysets in mint and update local storage
-          // TODO: do not overwrite anykeyset, but append new keysets and update existing ones
-          this.mints.filter((m) => m.url === mint.url)[0].keysets = keysets;
+          // merge new keysets with existing ones instead of overwriting
+          const storedMint = this.mints.find((m) => m.url === mint.url);
+          if (storedMint) {
+            const existingKeysets = storedMint.keysets || [];
+            const mergedKeysets = [...existingKeysets];
+            
+            // Add or update keysets
+            for (const newKeyset of keysets) {
+              const existingIndex = mergedKeysets.findIndex((k) => k.id === newKeyset.id);
+              if (existingIndex !== -1) {
+                // Update existing keyset
+                mergedKeysets[existingIndex] = newKeyset;
+              } else {
+                // Add new keyset
+                mergedKeysets.push(newKeyset);
+              }
+            }
+            
+            storedMint.keysets = mergedKeysets;
+          }
         }
         return keysets;
       } catch (error: any) {


### PR DESCRIPTION
Fixes #493

When a mint rotates its keyset ID (e.g., Minibits), the wallet was losing track of proofs with old keyset IDs. This happened because `fetchMintKeysets()` was overwriting the entire keysets array instead of merging new keysets with existing ones.

## Changes
- Modified `fetchMintKeysets()` in `src/stores/mints.ts` to merge keysets instead of overwriting them
- Old (inactive) keysets are now preserved when fetching new ones
- Existing keysets are updated with new information (e.g., active flag)
- New keysets are added to the collection
- Proofs with old keyset IDs remain valid and spendable

## Testing
The workaround mentioned in the issue (clicking on the mint to refresh keysets) should no longer be necessary. After this fix, proofs with old keyset IDs will automatically remain valid when a mint rotates its keysets.