### PR TITLE
fix: avoid polling when websocket is available for mint quotes

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -1338,6 +1338,22 @@ export const useWalletStore = defineStore("wallet", {
       }
 
       const uIStore = useUiStore();
+      const receivedViaWebsocket = { current: false };
+      const WEBSOCKET_FALLBACK_DELAY_MS = 45000;
+
+      const fallbackTimer = setTimeout(() => {
+        if (receivedViaWebsocket.current) return;
+        if (!kickOffInvoiceChecker) return;
+        console.log(
+          `Websocket fallback: no update after ${WEBSOCKET_FALLBACK_DELAY_MS / 1000}s, adding quote to polling.`
+        );
+        if (useSettingsStore().periodicallyCheckIncomingInvoices) {
+          useInvoicesWorkerStore().addInvoiceToChecker(quote);
+        } else if (useSettingsStore().checkIncomingInvoices) {
+          useWorkersStore().invoiceCheckWorker(quote);
+        }
+      }, WEBSOCKET_FALLBACK_DELAY_MS);
+
       try {
         console.log("mintOnPaid kicking off websocket");
         this.activeWebsocketConnections++;
@@ -1345,6 +1361,8 @@ export const useWalletStore = defineStore("wallet", {
         const unsub = await mintWallet.on.mintQuotePaid(
           quote,
           async (_mintQuoteResponse: MintQuoteBolt11Response) => {
+            receivedViaWebsocket.current = true;
+            clearTimeout(fallbackTimer);
             console.log("Websocket: mint quote paid.");
             let proofs;
             try {
@@ -1376,6 +1394,7 @@ export const useWalletStore = defineStore("wallet", {
           }
         );
       } catch (error) {
+        clearTimeout(fallbackTimer);
         console.error(
           "Error in websocket subscription. Starting invoice checker.",
           error

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -1313,16 +1313,6 @@ export const useWalletStore = defineStore("wallet", {
       if (!mint) {
         throw new Error("mint not found");
       }
-      // add to checker before we try a websocket
-      if (kickOffInvoiceChecker) {
-        if (useSettingsStore().periodicallyCheckIncomingInvoices) {
-          console.log(`Adding quote ${quote} to long-polling checker.`);
-          useInvoicesWorkerStore().addInvoiceToChecker(quote);
-        } else if (useSettingsStore().checkIncomingInvoices) {
-          console.log(`Adding quote ${quote} to old worker checker.`);
-          useWorkersStore().invoiceCheckWorker(quote);
-        }
-      }
 
       if (
         !settingsStore.useWebsockets ||
@@ -1334,11 +1324,22 @@ export const useWalletStore = defineStore("wallet", {
             s.commands.indexOf("bolt11_mint_quote") != -1
         )
       ) {
-        console.log("Websockets not supported.");
+        console.log("Websockets not supported, kicking off invoice checker.");
+        if (kickOffInvoiceChecker) {
+          if (useSettingsStore().periodicallyCheckIncomingInvoices) {
+            console.log(`Adding quote ${quote} to long-polling checker.`);
+            useInvoicesWorkerStore().addInvoiceToChecker(quote);
+          } else if (useSettingsStore().checkIncomingInvoices) {
+            console.log(`Adding quote ${quote} to old worker checker.`);
+            useWorkersStore().invoiceCheckWorker(quote);
+          }
+        }
         return;
       }
+
       const uIStore = useUiStore();
       try {
+        console.log("mintOnPaid kicking off websocket");
         this.activeWebsocketConnections++;
         uIStore.triggerActivityOrb();
         const unsub = await mintWallet.on.mintQuotePaid(
@@ -1375,7 +1376,17 @@ export const useWalletStore = defineStore("wallet", {
           }
         );
       } catch (error) {
-        console.log("Error in websocket subscription", error);
+        console.error(
+          "Error in websocket subscription. Starting invoice checker.",
+          error
+        );
+        if (kickOffInvoiceChecker) {
+          if (useSettingsStore().periodicallyCheckIncomingInvoices) {
+            useInvoicesWorkerStore().addInvoiceToChecker(quote);
+          } else if (useSettingsStore().checkIncomingInvoices) {
+            useWorkersStore().invoiceCheckWorker(quote);
+          }
+        }
       } finally {
         this.activeWebsocketConnections--;
       }


### PR DESCRIPTION
## What is changed?

Fixes duplicate polling for mint quotes when websocket is supported by using websocket-first approach with polling as fallback

fixed #329 