### PR TITLE
fix build warnings from deprecated v-deep

### DIFF
--- a/src/components/AddMintDialog.vue
+++ b/src/components/AddMintDialog.vue
@@ -228,14 +228,17 @@ export default defineComponent({
 }
 
 /* Completely remove all input animations */
-:deep(.mint-input) {
-  /* Disable all transitions on the input and its children except for background-color */
-  * {
-    transition: none !important;
-    animation: none !important;
-  }
+:deep(.mint-input),
+:deep(.mint-input *) {
+  animation: none !important;
+}
 
-  /* Add a smooth transition just for the background-color */
+:deep(.mint-input *) {
+  transition: none !important;
+}
+
+/* Add a smooth transition just for the input background-color */
+:deep(.mint-input) {
   transition: background-color 0.2s ease-in-out !important;
 }
 

--- a/src/components/EditMintDialog.vue
+++ b/src/components/EditMintDialog.vue
@@ -177,14 +177,17 @@ export default defineComponent({
 }
 
 /* Completely remove all input animations */
-:deep(.mint-input) {
-  /* Disable all transitions on the input and its children except for background-color */
-  * {
-    transition: none !important;
-    animation: none !important;
-  }
+:deep(.mint-input),
+:deep(.mint-input *) {
+  animation: none !important;
+}
 
-  /* Add a smooth transition just for the background-color */
+:deep(.mint-input *) {
+  transition: none !important;
+}
+
+/* Add a smooth transition just for the input background-color */
+:deep(.mint-input) {
   transition: background-color 0.2s ease-in-out !important;
 }
 

--- a/src/components/ParseInputComponent.vue
+++ b/src/components/ParseInputComponent.vue
@@ -163,7 +163,7 @@ export default defineComponent({
     font-size: 16px;
   }
 
-  :deep(.q-field__control:befor)e,
+  :deep(.q-field__control:before),
   :deep(.q-field__control:after) {
     display: none !important;
   }

--- a/src/components/ParseInputComponent.vue
+++ b/src/components/ParseInputComponent.vue
@@ -134,7 +134,7 @@ export default defineComponent({
 }
 
 .parse-input {
-  ::v-deep .q-field__control {
+  :deep(.q-field__control) {
     border-radius: 12px;
     background: rgba(255, 255, 255, 0.06);
     min-height: 120px;
@@ -147,28 +147,28 @@ export default defineComponent({
     }
   }
 
-  ::v-deep .q-field__native {
+  :deep(.q-field__native) {
     padding: 0;
     font-size: 16px;
     color: white;
     min-height: 88px;
   }
 
-  &.has-paste-button ::v-deep .q-field__native {
+  &.has-paste-button :deep(.q-field__native) {
     padding: 0 70px 0 0;
   }
 
-  ::v-deep .q-placeholder {
+  :deep(.q-placeholder) {
     color: rgba(255, 255, 255, 0.5);
     font-size: 16px;
   }
 
-  ::v-deep .q-field__control:before,
-  ::v-deep .q-field__control:after {
+  :deep(.q-field__control:befor)e,
+  :deep(.q-field__control:after) {
     display: none !important;
   }
 
-  ::v-deep .q-field__bottom {
+  :deep(.q-field__bottom) {
     display: none;
   }
 }

--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -154,7 +154,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-::v-deep .q-dialog__backdrop {
+:deep(.q-dialog__backdrop) {
   backdrop-filter: blur(8px);
   background: rgba(0, 0, 0, 0.4) !important;
 }

--- a/src/components/ReceiveEcashDrawer.vue
+++ b/src/components/ReceiveEcashDrawer.vue
@@ -262,7 +262,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-::v-deep .q-dialog__backdrop {
+:deep(.q-dialog__backdrop) {
   backdrop-filter: blur(8px);
   background: rgba(0, 0, 0, 0.4) !important;
 }

--- a/src/components/RemoveMintDialog.vue
+++ b/src/components/RemoveMintDialog.vue
@@ -221,14 +221,17 @@ export default defineComponent({
 }
 
 /* Completely remove all input animations */
-:deep(.mint-input) {
-  /* Disable all transitions on the input and its children except for background-color */
-  * {
-    transition: none !important;
-    animation: none !important;
-  }
+:deep(.mint-input),
+:deep(.mint-input *) {
+  animation: none !important;
+}
 
-  /* Add a smooth transition just for the background-color */
+:deep(.mint-input *) {
+  transition: none !important;
+}
+
+/* Add a smooth transition just for the input background-color */
+:deep(.mint-input) {
   transition: background-color 0.2s ease-in-out !important;
 }
 

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -164,7 +164,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-::v-deep .q-dialog__backdrop {
+:deep(.q-dialog__backdrop) {
   backdrop-filter: blur(8px);
   background: rgba(0, 0, 0, 0.4) !important;
 }


### PR DESCRIPTION
fixes build errors caused by deprecated `::v-deep` css, and incorrect nesting.

The warnings are shown in console when running `quasar dev`.

<img width="602" height="473" alt="Screenshot 2026-06-03 at 19 27 33" src="https://github.com/user-attachments/assets/9f5fb0c0-4cc4-4ec9-90f7-2f67af380787" />
