### PR TITLE
fix: skip welcome onboarding if wallet mnemonic already exists

### DIFF
--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -459,6 +459,11 @@ export default {
       this.focusInput("parseDialogInput");
     },
     showWelcomePage: function () {
+      const hasMnemonic = !!localStorage.getItem("cashu.mnemonic");
+      if (hasMnemonic) {
+        useWelcomeStore().showWelcome = false;
+        return;
+      }
       if (!useWelcomeStore().termsAccepted) {
         useWelcomeStore().showWelcome = true;
       }


### PR DESCRIPTION
Fixes #326 - users who bookmarked /welcome or had their localStorage cleared were being shown onboarding again despite having an existing wallet. Now checks for cashu.mnemonic in localStorage before showing the welcome flow.