### PR TITLE
fix: handle non-ISO currency codes in formatCurrency without crashing

### DIFF
--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -107,12 +107,14 @@ export const useUiStore = defineStore("ui", {
       if (currency == "msat") return this.fromMsat(value);
       if (currency == "usd") value = value / 100;
       if (currency == "eur") value = value / 100;
-      return new Intl.NumberFormat(navigator.language, {
-        style: "currency",
-        currency: currency,
-      }).format(value);
-      // + " " +
-      // currency.toUpperCase()
+      try {
+        return new Intl.NumberFormat(navigator.language, {
+          style: "currency",
+          currency: currency,
+        }).format(value);
+      } catch {
+        return new Intl.NumberFormat(navigator.language).format(value) + " " + currency.toUpperCase();
+      }
     },
     toggleDebugConsole() {
       this.showDebugConsole = !this.showDebugConsole;


### PR DESCRIPTION
Fixes #322 - currencies like mlsat and hash threw a RangeError in Intl.NumberFormat since they are not valid ISO 4217 codes. Now falls back to displaying the raw amount with the unit string uppercased.