### PR TITLE
feat: subscribe to all proofs for token state updates

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -1187,7 +1187,7 @@ export const useWalletStore = defineStore("wallet", {
         }
         return false;
       }
-      return true;
+      return spentProofs != undefined && spentProofs.length == proofs.length;
     },
     checkInvoice: async function (
       quote: string,

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -1341,16 +1341,19 @@ export const useWalletStore = defineStore("wallet", {
         this.activeWebsocketConnections++;
         uIStore.triggerActivityOrb();
         const wallet = await this.activeWallet();
+        let isChecking = false;
         const unsub = await wallet.on.proofStateUpdates(
           proofs,
           async (proofState: ProofState) => {
             console.log(`Websocket: proof state updated: ${proofState.state}`);
-            if (proofState.state == CheckStateEnum.SPENT) {
+            if (proofState.state == CheckStateEnum.SPENT && !isChecking) {
+              isChecking = true;
               const tokenSpent = await this.checkTokenSpendable(historyToken);
               if (tokenSpent) {
                 sendTokensStore.showSendTokens = false;
                 unsub();
               }
+              isChecking = false;
             }
           },
           async (error: any) => {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -1338,13 +1338,12 @@ export const useWalletStore = defineStore("wallet", {
           throw new Error("no tokens provided.");
         }
         const proofs = token.getProofs(tokenJson);
-        const oneProof = [proofs[0]];
         this.activeWebsocketConnections++;
         uIStore.triggerActivityOrb();
         const wallet = await this.activeWallet();
         const unsub = await wallet.on.proofStateUpdates(
-          toProofs(oneProof),
-          async (proofState: ProofState & { proof: Proof }) => {
+          proofs,
+          async (proofState: ProofState) => {
             console.log(`Websocket: proof state updated: ${proofState.state}`);
             if (proofState.state == CheckStateEnum.SPENT) {
               const tokenSpent = await this.checkTokenSpendable(historyToken);

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -1343,7 +1343,7 @@ export const useWalletStore = defineStore("wallet", {
         const wallet = await this.activeWallet();
         let isChecking = false;
         const unsub = await wallet.on.proofStateUpdates(
-          proofs,
+          toProofs(proofs),
           async (proofState: ProofState) => {
             console.log(`Websocket: proof state updated: ${proofState.state}`);
             if (proofState.state == CheckStateEnum.SPENT && !isChecking) {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -1348,12 +1348,15 @@ export const useWalletStore = defineStore("wallet", {
             console.log(`Websocket: proof state updated: ${proofState.state}`);
             if (proofState.state == CheckStateEnum.SPENT && !isChecking) {
               isChecking = true;
-              const tokenSpent = await this.checkTokenSpendable(historyToken);
-              if (tokenSpent) {
-                sendTokensStore.showSendTokens = false;
-                unsub();
+              try {
+                const tokenSpent = await this.checkTokenSpendable(historyToken);
+                if (tokenSpent) {
+                  sendTokensStore.showSendTokens = false;
+                  unsub();
+                }
+              } finally {
+                isChecking = false;
               }
-              isChecking = false;
             }
           },
           async (error: any) => {


### PR DESCRIPTION
## Summary
- Subscribes to websocket updates for all proofs in a token instead of just the first one.
- Ensures that any proof being spent triggers an immediate status check of the entire token.