### PR TITLE
fix: await counter advances

### DIFF
--- a/src/stores/__tests__/wallet.test.js
+++ b/src/stores/__tests__/wallet.test.js
@@ -269,12 +269,12 @@ describe("wallet store", () => {
     h.p2pkStore.isValidPubkey.mockReturnValue(false);
   });
 
-  it("manages keyset counters", () => {
+  it("manages keyset counters", async () => {
     const wallet = useWalletStore();
     expect(wallet.keysetCounter("k1")).toBe(0);
-    wallet.increaseKeysetCounter("k1", 4);
+    await wallet.increaseKeysetCounter("k1", 4);
     expect(wallet.keysetCounter("k1")).toBe(4);
-    wallet.increaseKeysetCounter("k2", 3);
+    await wallet.increaseKeysetCounter("k2", 3);
     expect(wallet.keysetCounter("k2")).toBe(3);
   });
 
@@ -458,13 +458,16 @@ describe("wallet store", () => {
     expect(getFeesForProofs).toHaveBeenCalledWith(proofs);
   });
 
-  it("accounts for signed-output errors", () => {
+  it("accounts for signed-output errors", async () => {
     const wallet = useWalletStore();
     wallet.keysetCounters = [{ id: "00aa", counter: 1 }];
 
-    const handled = wallet.handleOutputsHaveAlreadyBeenSignedError("00aa", {
-      message: "outputs have already been signed",
-    });
+    const handled = await wallet.handleOutputsHaveAlreadyBeenSignedError(
+      "00aa",
+      {
+        message: "outputs have already been signed",
+      }
+    );
 
     expect(handled).toBe(true);
     expect(wallet.keysetCounter("00aa")).toBe(11);

--- a/src/stores/restore.ts
+++ b/src/stores/restore.ts
@@ -135,7 +135,7 @@ export const useRestoreStore = defineStore("restore", {
         if (maxLastCounterWithSignature >= 0) {
           const nextCounter = maxLastCounterWithSignature + 1;
           if (nextCounter > walletStore.keysetCounter(keyset.id)) {
-            walletStore
+            await walletStore
               .getOrCreateCounterSource()
               .advanceToAtLeast(keyset.id, nextCounter);
             walletStore.syncCounterToStorage(keyset.id, nextCounter);

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -304,10 +304,10 @@ export const useWalletStore = defineStore("wallet", {
     keysetCounter(id: string): number {
       return this.keysetCounters.find((c) => c.id === id)?.counter ?? 0;
     },
-    increaseKeysetCounter(id: string, by: number) {
+    async increaseKeysetCounter(id: string, by: number) {
       const next = this.keysetCounter(id) + by;
       const src = this.getOrCreateCounterSource();
-      src.advanceToAtLeast(id, next);
+      await src.advanceToAtLeast(id, next);
       this.syncCounterToStorage(id, next);
     },
     createWalletInstance(
@@ -358,7 +358,7 @@ export const useWalletStore = defineStore("wallet", {
       try {
         return await operation();
       } catch (error: any) {
-        const handled = this.handleOutputsHaveAlreadyBeenSignedError(
+        const handled = await this.handleOutputsHaveAlreadyBeenSignedError(
           keysetId,
           error
         );
@@ -1786,7 +1786,7 @@ export const useWalletStore = defineStore("wallet", {
       }
       return this.mnemonic;
     },
-    handleOutputsHaveAlreadyBeenSignedError: function (
+    async handleOutputsHaveAlreadyBeenSignedError(
       keysetId: string,
       error: any
     ) {
@@ -1795,7 +1795,7 @@ export const useWalletStore = defineStore("wallet", {
           `[wallet] outputs already signed for keyset ${keysetId}, advancing counter and trying again`
         );
         const next = this.keysetCounter(keysetId) + 10;
-        this.getOrCreateCounterSource().advanceToAtLeast(keysetId, next);
+        await this.getOrCreateCounterSource().advanceToAtLeast(keysetId, next);
         this.syncCounterToStorage(keysetId, next);
         notify(this.t("wallet.notifications.trying_again"));
         return true;


### PR DESCRIPTION
## Summary

`CounterSource` methods in Cashu-TS are async, so should be awaited. Although the in-memory implementation was practically ok, this PR hardens the calls by awaiting them as intended.

- Await keyset counter advances before syncing stored counter state.
- Await restored-counter hardening after sparse restore results.
- Await signed-output retry counter bumps before retrying the wallet operation.
- Update wallet store tests to use the async counter APIs.

## Validation

- npx vitest run src/stores/__tests__/wallet.test.js