### PR TITLE
fix: account for input fees on swap output proofs in send/melt

### DIFF
--- a/src/stores/__tests__/wallet.test.js
+++ b/src/stores/__tests__/wallet.test.js
@@ -422,21 +422,22 @@ describe("wallet store", () => {
     expect(h.mintsStore.updateMintInfoAndKeys).toHaveBeenCalledTimes(1);
   });
 
-  it("uses the wallet instance directly for fee calculation in send", async () => {
+  it("uses the wallet instance directly for proof selection in send", async () => {
     const wallet = useWalletStore();
     const proofs = [{ id: "00bb", amount: 10, reserved: false, secret: "s1" }];
-    const getFeesForProofs = vi.fn(() => ({ toNumber: () => 0 }));
+    const selectProofsToSend = vi.fn(() => ({ send: proofs, keep: [] }));
     const foreignWallet = {
       mint: { mintUrl: "https://mint-b.example" },
       unit: "sat",
-      selectProofsToSend: vi.fn(() => ({ send: proofs, keep: [] })),
-      getFeesForProofs,
+      selectProofsToSend,
       ops: {
         send: vi.fn(() => ({
           asDeterministic: vi.fn(() => ({
             keyset: vi.fn(() => ({
               proofsWeHave: vi.fn(() => ({
-                run: vi.fn(async () => ({ keep: [], send: [] })),
+                includeFees: vi.fn(() => ({
+                  run: vi.fn(async () => ({ keep: [], send: [] })),
+                })),
               })),
             })),
           })),
@@ -455,7 +456,84 @@ describe("wallet store", () => {
 
     await wallet.send(proofs, foreignWallet, 10, false, true);
 
-    expect(getFeesForProofs).toHaveBeenCalledWith(proofs);
+    // exact-match no-swap shortcut goes through the foreign wallet
+    expect(selectProofsToSend).toHaveBeenCalledWith(
+      expect.any(Array),
+      10,
+      true,
+      true
+    );
+  });
+
+  it("forwards includeFees and raw amount to the swap when no exact match exists", async () => {
+    // Regression test for the "Provided: 103, needed: 104" off-by-input-fees
+    // melt bug. The pre-fix code computed `targetAmount = amount + fees(selected)`
+    // and passed it to the swap WITHOUT `.includeFees(true)`. That made
+    // sendProofs sum to targetAmount, but the mint then charged input fees on
+    // those sendProofs (a different proof count), so the inputs fell short.
+    //
+    // The fix: pass the raw `amount` to the swap and chain `.includeFees(true)`.
+    // cashu-ts then inflates the send outputs so sendProofs sum to
+    // amount + fees(sendProofs) — exactly what melt validation requires.
+    const wallet = useWalletStore();
+    const proofs = [{ id: "00bb", amount: 128, reserved: false, secret: "s1" }];
+
+    // Force the exact-match path to fail so the swap fallback runs.
+    const selectProofsToSend = vi.fn(() => {
+      throw new Error("no exact match");
+    });
+
+    // Capture each step in the swap builder chain.
+    const includeFeesSpy = vi.fn();
+    const sendSpy = vi.fn();
+    const builder = {
+      asDeterministic: vi.fn(),
+      keyset: vi.fn(),
+      proofsWeHave: vi.fn(),
+      includeFees: vi.fn(),
+      run: vi.fn(async () => ({
+        keep: [{ id: "00bb", amount: 23, secret: "keep1" }],
+        send: [
+          { id: "00bb", amount: 64, secret: "send1" },
+          { id: "00bb", amount: 32, secret: "send2" },
+          { id: "00bb", amount: 4, secret: "send3" },
+          { id: "00bb", amount: 4, secret: "send4" },
+        ],
+      })),
+    };
+    // Make every method return the builder for chaining; spy the two we assert on.
+    builder.asDeterministic.mockReturnValue(builder);
+    builder.keyset.mockReturnValue(builder);
+    builder.proofsWeHave.mockReturnValue(builder);
+    builder.includeFees = includeFeesSpy.mockReturnValue(builder);
+
+    const swapWallet = {
+      mint: { mintUrl: "https://mint-b.example" },
+      unit: "sat",
+      selectProofsToSend,
+      ops: {
+        send: sendSpy.mockReturnValue(builder),
+      },
+    };
+
+    h.mintsStore.mints.push({
+      url: "https://mint-b.example",
+      keys: [{ id: "00bb" }],
+      keysets: [{ id: "00bb", unit: "sat", active: true }],
+      info: { name: "mint-b" },
+    });
+
+    vi.spyOn(wallet, "getKeyset").mockReturnValue("00bb");
+    vi.spyOn(wallet, "mintWallet").mockResolvedValue(swapWallet);
+
+    await wallet.send(proofs, swapWallet, 100, false, true);
+
+    // The swap is called with the raw invoice amount, NOT a precomputed
+    // `amount + fees(selectedProofs)` target.
+    expect(sendSpy).toHaveBeenCalledWith(100, expect.any(Array));
+    // .includeFees(true) must be chained so cashu-ts inflates the send
+    // outputs to cover their own input fees.
+    expect(includeFeesSpy).toHaveBeenCalledWith(true);
   });
 
   it("accounts for signed-output errors", () => {

--- a/src/stores/__tests__/wallet.test.js
+++ b/src/stores/__tests__/wallet.test.js
@@ -477,15 +477,9 @@ describe("wallet store", () => {
     // amount + fees(sendProofs) — exactly what melt validation requires.
     const wallet = useWalletStore();
     const proofs = [{ id: "00bb", amount: 128, reserved: false, secret: "s1" }];
-
-    // Throw only when the (new) exact-match flag is set, so the fixed code
-    // falls through to the swap. Non-exact calls (the old code's pre-coinSelect
-    // path) return the input proofs as-is so the swap branch is still reached
-    // via the legacy totalAmount != targetAmount check — letting the
-    // assertions catch the regression cleanly.
     const selectProofsToSend = vi.fn(
       (proofs, _amount, _includeFees, exactMatch) => {
-        if (exactMatch) throw new Error("no exact match");
+        if (exactMatch) return { send: [], keep: proofs };
         return { send: proofs, keep: [] };
       }
     );

--- a/src/stores/__tests__/wallet.test.js
+++ b/src/stores/__tests__/wallet.test.js
@@ -478,10 +478,20 @@ describe("wallet store", () => {
     const wallet = useWalletStore();
     const proofs = [{ id: "00bb", amount: 128, reserved: false, secret: "s1" }];
 
-    // Force the exact-match path to fail so the swap fallback runs.
-    const selectProofsToSend = vi.fn(() => {
-      throw new Error("no exact match");
-    });
+    // Throw only when the (new) exact-match flag is set, so the fixed code
+    // falls through to the swap. Non-exact calls (the old code's pre-coinSelect
+    // path) return the input proofs as-is so the swap branch is still reached
+    // via the legacy totalAmount != targetAmount check — letting the
+    // assertions catch the regression cleanly.
+    const selectProofsToSend = vi.fn(
+      (proofs, _amount, _includeFees, exactMatch) => {
+        if (exactMatch) throw new Error("no exact match");
+        return { send: proofs, keep: [] };
+      }
+    );
+    // Old code calls wallet.getFeesForProofs(selected).toNumber() to compute
+    // targetAmount. Mock a small input fee so it reaches the swap branch.
+    const getFeesForProofs = vi.fn(() => ({ toNumber: () => 1 }));
 
     // Capture each step in the swap builder chain.
     const includeFeesSpy = vi.fn();
@@ -511,6 +521,7 @@ describe("wallet store", () => {
       mint: { mintUrl: "https://mint-b.example" },
       unit: "sat",
       selectProofsToSend,
+      getFeesForProofs,
       ops: {
         send: sendSpy.mockReturnValue(builder),
       },

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -546,17 +546,23 @@ export const useWalletStore = defineStore("wallet", {
         let keepProofs: ProofLike[] = [];
         let sendProofs: ProofLike[] = [];
 
-        // Try to avoid a swap by selecting an exact match.
-        // selectProofsToSend throws if no exact match found.
+        // Try to avoid a swap by selecting an exact match. selectProofsToSend
+        // returns { send: [] } when no subset is found and throws if exact-match
+        // search exceeds MAX_TIMEMS. Fall through to swap in either case.
+        let exactMatch: ProofLike[] = [];
         try {
-          const { send } = wallet.selectProofsToSend(
+          exactMatch = wallet.selectProofsToSend(
             spendableProofs,
             amount,
             includeFees,
             true // exact match
-          );
-          sendProofs = send;
+          ).send;
         } catch {
+          // exact-match search timed out; the swap will handle it
+        }
+        if (exactMatch.length > 0) {
+          sendProofs = exactMatch;
+        } else {
           // we need to swap!
           // get a new wallet with potentially updated keysets / info
           const swapWallet = await this.mintWallet(

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -539,7 +539,9 @@ export const useWalletStore = defineStore("wallet", {
       const keysetId = this.getKeyset(wallet.mint.mintUrl, wallet.unit);
       await uIStore.lockMutex();
       try {
-        const spendableProofs: Proof[] = toProofs(this.spendableProofs(proofs, amount));
+        const spendableProofs: Proof[] = toProofs(
+          this.spendableProofs(proofs, amount)
+        );
 
         let keepProofs: ProofLike[] = [];
         let sendProofs: ProofLike[] = [];

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -530,80 +530,78 @@ export const useWalletStore = defineStore("wallet", {
       invalidate: boolean = false,
       includeFees: boolean = false
     ): Promise<{ keepProofs: ProofLike[]; sendProofs: ProofLike[] }> {
-      /*
-      splits proofs so the user can keep firstProofs, send scndProofs.
-      then sets scndProofs as reserved.
-
-      if invalidate, scndProofs (the one to send) are invalidated
-      */
+      // Returns sendProofs summing to `amount` (plus input fees when
+      // includeFees=true). Tries an offline exact-match first; otherwise
+      // swaps via the mint. Reserves sendProofs in proofsStore on success,
+      // or removes them if `invalidate` is true (caller takes ownership).
       const proofsStore = useProofsStore();
       const uIStore = useUiStore();
-      let proofsToSend: WalletProof[] = [];
       const keysetId = this.getKeyset(wallet.mint.mintUrl, wallet.unit);
       await uIStore.lockMutex();
       try {
-        const spendableProofs = this.spendableProofs(proofs, amount);
-
-        proofsToSend = this.coinSelect(
-          spendableProofs,
-          wallet,
-          amount,
-          includeFees
-        );
-        const totalAmount = sumProofAmounts(proofsToSend);
-        const fees = includeFees
-          ? wallet.getFeesForProofs(proofsToSend).toNumber()
-          : 0;
-        const targetAmount = amount + fees;
+        const spendableProofs: Proof[] = toProofs(this.spendableProofs(proofs, amount));
 
         let keepProofs: ProofLike[] = [];
         let sendProofs: ProofLike[] = [];
 
-        if (totalAmount != targetAmount) {
+        // Try to avoid a swap by selecting an exact match.
+        // selectProofsToSend throws if no exact match found.
+        try {
+          const { send } = wallet.selectProofsToSend(
+            spendableProofs,
+            amount,
+            includeFees,
+            true // exact match
+          );
+          sendProofs = send;
+        } catch {
           // we need to swap!
           // get a new wallet with potentially updated keysets / info
           const swapWallet = await this.mintWallet(
             wallet.mint.mintUrl,
             wallet.unit,
-            true
+            true // update keysets
           );
-          proofsToSend = this.coinSelect(
-            spendableProofs,
-            swapWallet,
-            targetAmount,
-            true
-          );
-          ({ keep: keepProofs, send: sendProofs } =
-            await this.retryOnceOnSignedOutputs(keysetId, async () =>
+          // includeFees=true inflates send outputs so sendProofs sum to
+          // amount + fees(sendProofs): required for melt and includeFees sends.
+          const swapResult = await this.retryOnceOnSignedOutputs(
+            keysetId,
+            async () =>
               swapWallet.ops
-                .send(targetAmount, toProofs(proofsToSend))
+                .send(amount, spendableProofs)
                 .asDeterministic()
                 .keyset(keysetId)
                 .proofsWeHave(spendableProofs)
+                .includeFees(includeFees)
                 .run()
-            ));
+          );
+          // swapResult.keep mixes fresh proofs (new secrets) with any
+          // un-selected passthrough proofs (already in spendableProofs).
+          const spendableSecrets = new Set(
+            spendableProofs.map((p) => p.secret)
+          );
+          const returnedKeepSecrets = new Set(
+            swapResult.keep.map((k) => k.secret)
+          );
+          sendProofs = swapResult.send;
+          keepProofs = swapResult.keep.filter(
+            (k) => !spendableSecrets.has(k.secret)
+          );
+          const swappedProofs = spendableProofs.filter(
+            (p) => !returnedKeepSecrets.has(p.secret)
+          );
           await proofsStore.addProofs(keepProofs);
           await proofsStore.addProofs(sendProofs);
-
-          // make sure we don't delete any proofs that were returned
-          const proofsToSendNotReturned = proofsToSend
-            .filter((p) => !sendProofs.find((s) => s.secret === p.secret))
-            .filter((p) => !keepProofs.find((k) => k.secret === p.secret));
-          await proofsStore.removeProofs(proofsToSendNotReturned);
-        } else if (totalAmount == targetAmount) {
-          keepProofs = [];
-          sendProofs = proofsToSend;
-        } else {
-          throw new Error("could not split proofs.");
+          await proofsStore.removeProofs(swappedProofs);
         }
-
-        await proofsStore.setReserved(sendProofs, true);
+        // Proofs are being sent externally, remove from store
         if (invalidate) {
           await proofsStore.removeProofs(sendProofs);
         }
+        // Finally, reserve sendProofs as nothing above threw.
+        await proofsStore.setReserved(sendProofs, true);
         return { keepProofs, sendProofs };
       } catch (error: any) {
-        await proofsStore.setReserved(proofsToSend, false);
         console.error(error);
         notifyApiError(error);
         throw error;


### PR DESCRIPTION
## Summary

Fixes a `"Provided: N, needed: N+1"` off-by-input-fees rejection from the mint when paying Lightning invoices via a fee-charging mint.

The melt path computed `targetAmount = amount + fees(selectedProofs)` and asked cashu-ts to swap to that target. The swap's fresh sendProofs (a binary split of `targetAmount`) could have a different proof count than the originally-selected inputs, so the mint's input-fee check on those sendProofs fell short, surfacing as the "Provided: 103, needed: 104" rejection on melt.

The fix hands all spendable proofs to cashu-ts and uses `.includeFees(includeFees)` on the swap builder. cashu-ts then inflates the send outputs so `sendProofs.sum() == amount + fees(sendProofs)`, exactly what melt validation requires, and what `includeFeesInSendAmount` semantically means for token sends.

The same change also fixes a related token-send bug: with "include fees in send amount" enabled, the recipient was getting less than the sender intended (for the same proof-count-mismatch reason).

The previous pre-`coinSelect` is replaced with an offline exact-match `selectProofsToSend(..., exactMatch=true)` shortcut that skips the swap roundtrip when a perfect subset exists.

## Reproducing on a live mint (confirmed against nutshell 0.20.1 @ 250 ppk)

This gnarly bug only fires when `targetAmount = amount + fees(originalSelection)` lands on a "bad" popcount: the swap's binary-split output count crosses the next 4-proof fee bucket. Lightning `fee_reserve` usually nudges `targetAmount` away from those values, which is why straightforward LN melts often happen to work even on pre-fix code.

To reproduce reliably you need `fee_reserve = 0`, i.e. a **mint-to-mint payment** on the same mint:

I tested using: `https://mint.mountainlake.io`, which runs Nutshell 0.20.1 and has 250ppk fees.

1. Check out `main` (or any pre-fix branch). Confirm the mint's `input_fee_ppk` via `GET /v1/keysets`.
2. Start with a wallet containing one large proof, e.g. receive 257 sats from same mint → wallet holds `[256]` after fee.
3. From any wallet using the same mint, generate a 30-sat bolt11 invoice.
4. Paste it into cashu.me and pay.

Trace:
- `amount = 30 + 0 = 30`, `coinSelect` picks `[256]`, `fees = 1`, `targetAmount = 31`
- Swap to 31 produces sendProofs = `[16, 8, 4, 2, 1]` (5 proofs, fees = 2)
- Mint validates: `provided 31, needed 30 + 2 = 32` → **`Provided: 31, needed: 32`**

Check out this PR's branch and repeat — the melt succeeds first try.

## Test plan

- [x] Existing `wallet.test.js` (15 tests) pass on the fix
- [x] New regression test `forwards includeFees and raw amount to the swap when no exact match exists` passes on the fix, fails on `main` with a clean assertion diff (`expected swap.send(100, …) + .includeFees(true)`, got `swap.send(101, …)` with no `.includeFees` call)
- [x] Manual smoke test against a live fee-charging mint (nutshell 0.20.1, 250 ppk) via mint-to-mint melt: reproduces "Provided: 31, needed: 32" on `main`; succeeds on this branch