### PR TITLE
fix: accept uppercase query keys in BIP-321 bitcoin: URIs

### DIFF
--- a/src/stores/__tests__/wallet.test.js
+++ b/src/stores/__tests__/wallet.test.js
@@ -1634,6 +1634,20 @@ describe("wallet store", () => {
     expect(h.uiStore.closeDialogs).toHaveBeenCalled();
   });
 
+  it("decodes BIP-321 bitcoin: URIs with uppercase query keys", async () => {
+    const wallet = useWalletStore();
+    vi.spyOn(wallet, "handleBolt11InvoiceBolt11").mockResolvedValue(undefined);
+    vi.spyOn(wallet, "handlePaymentRequest").mockResolvedValue(undefined);
+
+    await wallet.decodeRequest(
+      "BITCOIN:?LIGHTNING=LNBCUPPER&CREQ=CREQB1UPPERCASE"
+    );
+
+    expect(wallet.handlePaymentRequest).toHaveBeenCalledWith(
+      "CREQB1UPPERCASE"
+    );
+  });
+
   it("redeem shows the normalized received amount for v4 proofs", async () => {
     const wallet = useWalletStore();
     h.receiveTokensStore.receiveData.tokensBase64 = "cashuB500";

--- a/src/stores/__tests__/wallet.test.js
+++ b/src/stores/__tests__/wallet.test.js
@@ -1643,9 +1643,7 @@ describe("wallet store", () => {
       "BITCOIN:?LIGHTNING=LNBCUPPER&CREQ=CREQB1UPPERCASE"
     );
 
-    expect(wallet.handlePaymentRequest).toHaveBeenCalledWith(
-      "CREQB1UPPERCASE"
-    );
+    expect(wallet.handlePaymentRequest).toHaveBeenCalledWith("CREQB1UPPERCASE");
   });
 
   it("redeem shows the normalized received amount for v4 proofs", async () => {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -1330,8 +1330,17 @@ export const useWalletStore = defineStore("wallet", {
             req.replace(/^bitcoin:/i, "bitcoin://placeholder/")
           );
           const address = url.pathname.replace(/^\//, "");
-          const creq = url.searchParams.get("creq");
-          const lightning = url.searchParams.get("lightning");
+          // BIP-321 query keys are case-insensitive (per RFC 3986 / BIP-21).
+          // Encoders may emit fully uppercase URIs to enable QR alphanumeric
+          // mode for denser codes (e.g. CDK, cashu-for-woocommerce).
+          const getParamCI = (name: string): string | null => {
+            for (const [k, v] of url.searchParams) {
+              if (k.toLowerCase() === name) return v;
+            }
+            return null;
+          };
+          const creq = getParamCI("creq");
+          const lightning = getParamCI("lightning");
           if (creq) {
             this.payInvoiceData.input.request = creq;
             await this.handlePaymentRequest(creq);


### PR DESCRIPTION
## Summary

- BIP-321 / BIP-21 query keys are case-insensitive per RFC 3986. Encoders can (and do) emit fully uppercase URIs to pack the QR in alphanumeric mode for denser codes — e.g. the CDK reference encoder and cashu-for-woocommerce both produce `BITCOIN:?LIGHTNING=LNBC...&CREQ=CREQB...`.
- CME's `decodeRequest` parsed the URL but called `url.searchParams.get("creq" | "lightning")`, which is **case-sensitive**. With uppercase keys both lookups returned `null` and the scan was a silent no-op (dialogs closed, nothing handled).
- Fix: a tiny case-insensitive param-lookup helper inside the existing `try` block. Values are returned untouched (BOLT11 and `creqB` are bech32/bech32m so case-insensitive on the wire anyway).

The existing lowercase BIP-321 test path still passes, so this is purely additive coverage.

## Test plan

- [x] New unit test `decodes BIP-321 bitcoin: URIs with uppercase query keys` in `src/stores/__tests__/wallet.test.js` — verifies `handlePaymentRequest` is called with the uppercase `CREQB...` value
- [x] Existing `routes decodeRequest branches` test still passes (lowercase BIP-321 unchanged)
- [x] `npx vitest run src/stores/__tests__/wallet.test.js` — 16/16 green
- [x] `npx eslint src/stores/wallet.ts src/stores/__tests__/wallet.test.js` — clean
- [x] `npx tsc --noEmit` — no new errors on touched file