### PR TITLE
feat: honour P2PK/HTLC locks in NUT-18 payment requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@capacitor/clipboard": "^6.0.2",
         "@capacitor/core": "^6.2.0",
         "@capacitor/haptics": "^6.0.2",
-        "@cashu/cashu-ts": "^4.5.0",
+        "@cashu/cashu-ts": "^4.6.0",
         "@chenfengyuan/vue-qrcode": "^2.0.0",
         "@gandlaf21/bc-ur": "^1.1.12",
         "@nostr-dev-kit/ndk": "^2.8.1",
@@ -1962,9 +1962,9 @@
       }
     },
     "node_modules/@cashu/cashu-ts": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-4.5.0.tgz",
-      "integrity": "sha512-NoUOitUMaxzmA3k4qLozZyFM1qonBdNB2ZM55U45X9SwFIQovRDttVDFL6Dn39q3H8v6pUTYxOHeUKdAmY/V/g==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-4.6.0.tgz",
+      "integrity": "sha512-B0XG662h53ZBTKFnVdTVXyK5GwNC5QDkZqbXu6Bl0SduCc6GV90+h9f3SI/bLDxMKFVk/aFs00LeSUCj4JknKg==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@capacitor/clipboard": "^6.0.2",
     "@capacitor/core": "^6.2.0",
     "@capacitor/haptics": "^6.0.2",
-    "@cashu/cashu-ts": "^4.5.0",
+    "@cashu/cashu-ts": "^4.6.0",
     "@chenfengyuan/vue-qrcode": "^2.0.0",
     "@gandlaf21/bc-ur": "^1.1.12",
     "@nostr-dev-kit/ndk": "^2.8.1",

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -501,10 +501,9 @@ export default defineComponent({
         }
       } else {
         clearInterval(this.qrInterval);
-        this.sendData.data = "";
         this.sendData.tokensBase64 = "";
-        this.sendData.historyToken = null;
-        this.sendData.paymentRequest = null;
+        this.sendData.historyToken = undefined;
+        this.sendData.paymentRequest = undefined;
       }
     },
   },
@@ -620,7 +619,7 @@ export default defineComponent({
           this.activeUnit,
           true
         );
-        const { _, sendProofs } = await this.sendToLock(
+        const { sendProofs } = await this.sendToLock(
           this.activeProofs,
           mintWallet,
           sendAmount,
@@ -672,7 +671,7 @@ export default defineComponent({
           false
         );
         // keep firstProofs, send scndProofs and delete them (invalidate=true)
-        const { _, sendProofs } = await this.send(
+        const { sendProofs } = await this.send(
           this.activeProofs,
           mintWallet,
           sendAmount,

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -560,13 +560,25 @@ export default defineComponent({
         this.activeUnit,
         true
       );
-      const { sendProofs } = await this.send(
-        this.activeProofs,
-        mintWallet,
-        sendAmount,
-        true,
-        this.includeFeesInSendAmount
-      );
+      // NUT-18 payment requests may require the proofs to be locked with a
+      // NUT-10 spending condition. PaymentRequest.toP2PKOptions() builds the
+      // P2PK/HTLC lock cashu-ts can honour, or returns undefined for any other
+      // kind, in which case we fall back to a normal unlocked send.
+      const lockOptions = this.sendData.paymentRequest.toP2PKOptions();
+      const { sendProofs } = lockOptions
+        ? await this.sendToLock(
+            this.activeProofs,
+            mintWallet,
+            sendAmount,
+            lockOptions
+          )
+        : await this.send(
+            this.activeProofs,
+            mintWallet,
+            sendAmount,
+            true,
+            this.includeFeesInSendAmount
+          );
       const serialized = this.serializeProofs(sendProofs);
       if (!serialized) {
         throw new Error(

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -80,6 +80,7 @@ import {
   ProofState,
   KeyChain,
   type AmountLike,
+  type P2PKOptions,
   type CounterSource,
   createEphemeralCounterSource,
   // ConsoleLogger,
@@ -542,8 +543,16 @@ export const useWalletStore = defineStore("wallet", {
       proofs: WalletProof[],
       wallet: Wallet,
       amount: number,
-      receiverPubkey: string
+      receiverPubkey: string | P2PKOptions
     ) {
+      // Accept a bare pubkey (manual lock flow) or a full P2PKOptions so a
+      // NUT-18 payment request can reproduce its requested NUT-10 condition
+      // (P2PK or HTLC). Going through the `.asP2PK()` builder keeps the
+      // blinding keyset-aware (for upcoming cashu-ts v5).
+      const p2pkOptions: P2PKOptions =
+        typeof receiverPubkey === "string"
+          ? { pubkey: receiverPubkey }
+          : receiverPubkey;
       const spendableProofs = this.spendableProofs(proofs, amount);
       const proofsToSend = this.coinSelect(
         spendableProofs,
@@ -555,7 +564,7 @@ export const useWalletStore = defineStore("wallet", {
       const { keep: keepProofs, send: sendProofs } = await wallet.ops
         .send(amount, toProofs(proofsToSend))
         .keyset(keysetId)
-        .asP2PK({ pubkey: receiverPubkey })
+        .asP2PK(p2pkOptions)
         .run();
       const proofsStore = useProofsStore();
       await proofsStore.removeProofs(proofsToSend);

--- a/test/vitest/__tests__/p2pkPaymentRequest.test.ts
+++ b/test/vitest/__tests__/p2pkPaymentRequest.test.ts
@@ -13,11 +13,19 @@ import { useProofsStore } from "src/stores/proofs";
 
 const PUBKEY =
   "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2";
-const HASH =
-  "e0d21f5a0158ee5eafcd25f31036ff2b9ea23bda56c81b883c5b41d3d9b56b39";
+const HASH = "e0d21f5a0158ee5eafcd25f31036ff2b9ea23bda56c81b883c5b41d3d9b56b39";
 
 const makePr = (nut10?: { kind: string; data: string; tags: string[][] }) =>
-  new PaymentRequest(undefined, "pr1", 21, "sat", undefined, undefined, false, nut10);
+  new PaymentRequest(
+    undefined,
+    "pr1",
+    21,
+    "sat",
+    undefined,
+    undefined,
+    false,
+    nut10
+  );
 
 describe("PaymentRequest.toP2PKOptions (NUT-18 lock contract)", () => {
   // SendTokenDialog.payPaymentRequest branches on this contract: options
@@ -77,7 +85,9 @@ describe("walletStore.sendToLock pubkey normalization", () => {
       unit: "sat",
       mint: { mintUrl: "https://mint.test" },
       ops: {
-        send: vi.fn().mockReturnValue({ keyset: vi.fn().mockReturnValue({ asP2PK }) }),
+        send: vi
+          .fn()
+          .mockReturnValue({ keyset: vi.fn().mockReturnValue({ asP2PK }) }),
       },
     } as any;
     wallet.spendableProofs = vi.fn().mockReturnValue(walletProofs);

--- a/test/vitest/__tests__/p2pkPaymentRequest.test.ts
+++ b/test/vitest/__tests__/p2pkPaymentRequest.test.ts
@@ -1,0 +1,116 @@
+import { test, describe, expect, vi } from "vitest";
+import { PaymentRequest } from "@cashu/cashu-ts";
+
+// The wallet store grabs `t` from useI18n() in its state initializer, which
+// only works inside a component setup context.
+vi.mock("vue-i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue-i18n")>()),
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+import { useWalletStore } from "src/stores/wallet";
+import { useProofsStore } from "src/stores/proofs";
+
+const PUBKEY =
+  "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2";
+const HASH =
+  "e0d21f5a0158ee5eafcd25f31036ff2b9ea23bda56c81b883c5b41d3d9b56b39";
+
+const makePr = (nut10?: { kind: string; data: string; tags: string[][] }) =>
+  new PaymentRequest(undefined, "pr1", 21, "sat", undefined, undefined, false, nut10);
+
+describe("PaymentRequest.toP2PKOptions (NUT-18 lock contract)", () => {
+  // SendTokenDialog.payPaymentRequest branches on this contract: options
+  // returned -> sendToLock, undefined -> plain send.
+  test("returns undefined when the request has no nut10 lock", () => {
+    expect(makePr().toP2PKOptions()).toBeUndefined();
+  });
+
+  test("returns undefined for an unsupported lock kind", () => {
+    expect(
+      makePr({ kind: "DLC", data: "deadbeef", tags: [] }).toP2PKOptions()
+    ).toBeUndefined();
+  });
+
+  test("builds P2PK options from a P2PK lock", () => {
+    const opts = makePr({
+      kind: "P2PK",
+      data: PUBKEY,
+      tags: [["locktime", "1750000000"]],
+    }).toP2PKOptions();
+    expect(opts).toMatchObject({ pubkey: PUBKEY, locktime: 1750000000 });
+    expect(opts?.hashlock).toBeUndefined();
+  });
+
+  test("builds HTLC options from an HTLC lock", () => {
+    const opts = makePr({
+      kind: "HTLC",
+      data: HASH,
+      tags: [["pubkeys", PUBKEY]],
+    }).toP2PKOptions();
+    expect(opts).toMatchObject({ hashlock: HASH, pubkey: [PUBKEY] });
+  });
+
+  test("survives a creqA encode/decode round-trip", () => {
+    const encoded = makePr({
+      kind: "P2PK",
+      data: PUBKEY,
+      tags: [],
+    }).toEncodedCreqA();
+    const decoded = PaymentRequest.fromEncodedRequest(encoded);
+    expect(decoded.toP2PKOptions()).toMatchObject({ pubkey: PUBKEY });
+  });
+});
+
+describe("walletStore.sendToLock pubkey normalization", () => {
+  const setup = () => {
+    const wallet = useWalletStore();
+    const proofs = useProofsStore();
+    const walletProofs = [
+      { id: "ks1", amount: 21, secret: "s1", C: "c1", reserved: false },
+    ] as any[];
+    const sendProofs = [{ id: "ks1", amount: 21, secret: "s2", C: "c2" }];
+    const asP2PK = vi.fn().mockReturnValue({
+      run: vi.fn().mockResolvedValue({ keep: [], send: sendProofs }),
+    });
+    const mockWallet = {
+      unit: "sat",
+      mint: { mintUrl: "https://mint.test" },
+      ops: {
+        send: vi.fn().mockReturnValue({ keyset: vi.fn().mockReturnValue({ asP2PK }) }),
+      },
+    } as any;
+    wallet.spendableProofs = vi.fn().mockReturnValue(walletProofs);
+    wallet.coinSelect = vi.fn().mockReturnValue(walletProofs);
+    wallet.getKeyset = vi.fn().mockReturnValue("ks1");
+    proofs.removeProofs = vi.fn().mockResolvedValue(undefined);
+    proofs.addProofs = vi.fn().mockResolvedValue(undefined);
+    return { wallet, mockWallet, asP2PK, sendProofs, walletProofs };
+  };
+
+  test("wraps a bare pubkey string in P2PKOptions", async () => {
+    const { wallet, mockWallet, asP2PK, sendProofs } = setup();
+    const result = await wallet.sendToLock([], mockWallet, 21, PUBKEY);
+    expect(asP2PK).toHaveBeenCalledWith({ pubkey: PUBKEY });
+    expect(result.sendProofs).toEqual(sendProofs);
+  });
+
+  test("passes full P2PKOptions through untouched", async () => {
+    const { wallet, mockWallet, asP2PK } = setup();
+    const lockOptions = {
+      pubkey: [PUBKEY],
+      hashlock: HASH,
+      locktime: 1750000000,
+    };
+    await wallet.sendToLock([], mockWallet, 21, lockOptions);
+    expect(asP2PK).toHaveBeenCalledWith(lockOptions);
+  });
+
+  test("removes inputs and keeps change, but not the locked sendProofs", async () => {
+    const { wallet, mockWallet, walletProofs } = setup();
+    const proofs = useProofsStore();
+    await wallet.sendToLock([], mockWallet, 21, PUBKEY);
+    expect(proofs.removeProofs).toHaveBeenCalledWith(walletProofs);
+    expect(proofs.addProofs).toHaveBeenCalledWith([]);
+  });
+});


### PR DESCRIPTION
## Summary

Pay NUT-18 payment requests that carry a `nut10` locking option by producing ecash locked to exactly the spending condition the payee requested, instead of sending unlocked proofs.

Previously `preparePaymentRequestTokens` always called the plain `send()` path and ignored `paymentRequest.nut10`, so a payee requiring (e.g.) a P2PK-locked token — for offline receive — would reject the payment.

## Changes

- Bump `@cashu/cashu-ts` to `^4.6.0`, which adds `PaymentRequest.toP2PKOptions()` (the NUT-18 → NUT-11/14 mapping now lives in the lib).
- `preparePaymentRequestTokens` calls `paymentRequest.toP2PKOptions()`; when it returns options it locks via `sendToLock()`, otherwise falls back to a normal unlocked send.
- `sendToLock()` now accepts `string | P2PKOptions` and routes through cashu-ts' `.asP2PK()` builder, which stays keyset-aware (so this remains correct under the future v5/BLS keysets).

### Coverage / limits
- Honours the two NUT-10 kinds cashu-ts can build today: **P2PK** (NUT-11) and **HTLC** (NUT-14, expressed as a `hashlock`), including locktime / refund / multisig tags.
- Any other/unknown NUT-10 kind is ignored (unlocked send) rather than guessed at.

## Cleanup

Also includes a small, behavior-preserving type-hygiene pass on the touched send/lock paths in `SendTokenDialog.vue` (drop a dead `sendData.data` write, `null` → `undefined` on cleared fields, remove an unused `_` destructure binding). Deeper pre-existing typing debt in that file (the `g` mixin typed `never`, `tokens: string` holding proof arrays, partial `HistoryToken` literals, nullability) is intentionally left for a separate PR.

## Tests

`test/vitest/__tests__/p2pkPaymentRequest.test.ts` adds regression coverage for both halves of the change:

- the `toP2PKOptions()` contract the dialog branches on, run against the real cashu-ts 4.6.0: P2PK and HTLC locks map to the expected options, no lock or an unsupported kind returns `undefined` (plain send), and a P2PK lock survives a creqA encode/decode round-trip.
- `sendToLock()` normalization: a bare pubkey string is wrapped as `{ pubkey }`, a full `P2PKOptions` object passes through to `.asP2PK()` untouched, and input proofs are removed while the locked proofs are returned to the caller rather than stored.

## Verified
- End-to-end against a real `creqA…` request with a P2PK `nut10` option, producing proofs locked to the requested pubkey.
- The cashu-ts side (`toP2PKOptions()`) shipped in 4.6.0 with its own test coverage.
