### PR TITLE
fix: resolve NWC connection drops and concurrent same-second requests

### DIFF
--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -581,6 +581,14 @@ export default {
         }
       });
     },
+    handleVisibilityChange: function () {
+      if (document.visibilityState === "visible") {
+        console.log("### App brought to foreground, checking NWC...");
+        if (this.nwcEnabled) {
+          this.listenToNWCCommands();
+        }
+      }
+    },
   },
   watch: {},
 
@@ -594,11 +602,16 @@ export default {
     this.$nextTick(this.equalizeButtonWidths);
     // Add window resize listener to handle responsive layouts
     window.addEventListener("resize", this.equalizeButtonWidths);
+    document.addEventListener("visibilitychange", this.handleVisibilityChange);
   },
 
   beforeUnmount: function () {
     // Remove event listener when component is destroyed
     window.removeEventListener("resize", this.equalizeButtonWidths);
+    document.removeEventListener(
+      "visibilitychange",
+      this.handleVisibilityChange
+    );
   },
 
   created: async function () {

--- a/src/stores/nwc.ts
+++ b/src/stores/nwc.ts
@@ -62,6 +62,9 @@ const NWCKind = {
   NWCResponse: 23195,
 };
 
+const NWC_SUBSCRIPTION_WINDOW_SECONDS = 86400; // 24 hours
+const NWC_MAX_TRACKED_REQUEST_IDS = 1000;
+
 export const useNWCStore = defineStore("nwc", {
   state: () => ({
     nwcEnabled: useLocalStorage<boolean>("cashu.nwc.enabled", false),
@@ -468,7 +471,7 @@ export const useNWCStore = defineStore("nwc", {
       const conn = this.connections[0];
 
       const currentUnitTime = Math.floor(Date.now() / 1000);
-      const subscribeSince = currentUnitTime - 86400; // 24 hours
+      const subscribeSince = currentUnitTime - NWC_SUBSCRIPTION_WINDOW_SECONDS; // 24 hours
       const filter = {
         kinds: [NWCKind.NWCRequest as NDKKind],
         since: subscribeSince,
@@ -500,7 +503,10 @@ export const useNWCStore = defineStore("nwc", {
           console.log("### Received NWC command but NWC is disabled");
           return;
         }
-        if (event.created_at < currentUnitTime - 86400) {
+        if (
+          event.created_at <
+          currentUnitTime - NWC_SUBSCRIPTION_WINDOW_SECONDS
+        ) {
           return; // ignore events older than 24 hours
         }
 
@@ -516,7 +522,7 @@ export const useNWCStore = defineStore("nwc", {
 
         // Track the processed request ID
         conn.processedRequestIds.push(event.id);
-        if (conn.processedRequestIds.length > 1000) {
+        if (conn.processedRequestIds.length > NWC_MAX_TRACKED_REQUEST_IDS) {
           conn.processedRequestIds.shift();
         }
         // Re-assign to trigger Vue/Pinia LocalStorage watch

--- a/src/stores/nwc.ts
+++ b/src/stores/nwc.ts
@@ -22,6 +22,7 @@ type NWCConnection = {
   connectionSecret: string;
   connectionPublicKey: string;
   allowanceLeft: number;
+  processedRequestIds?: string[];
 };
 
 type NWCCommand = {
@@ -467,7 +468,7 @@ export const useNWCStore = defineStore("nwc", {
       const conn = this.connections[0];
 
       const currentUnitTime = Math.floor(Date.now() / 1000);
-      const subscribeSince = currentUnitTime - 60; // 1 minute
+      const subscribeSince = currentUnitTime - 86400; // 24 hours
       const filter = {
         kinds: [NWCKind.NWCRequest as NDKKind],
         since: subscribeSince,
@@ -499,11 +500,27 @@ export const useNWCStore = defineStore("nwc", {
           console.log("### Received NWC command but NWC is disabled");
           return;
         }
-        // check if the events date is after the last seen command
-        if (event.created_at <= this.seenCommandsUntil) {
+        if (event.created_at < currentUnitTime - 86400) {
+          return; // ignore events older than 24 hours
+        }
+
+        // Initialize processedRequestIds array if not present on connection
+        if (!conn.processedRequestIds) {
+          conn.processedRequestIds = [];
+        }
+
+        // Check if we have already processed this event ID for this connection
+        if (conn.processedRequestIds.includes(event.id)) {
           return;
         }
-        this.seenCommandsUntil = event.created_at;
+
+        // Track the processed request ID
+        conn.processedRequestIds.push(event.id);
+        if (conn.processedRequestIds.length > 1000) {
+          conn.processedRequestIds.shift();
+        }
+        // Re-assign to trigger Vue/Pinia LocalStorage watch
+        this.connections = [...this.connections];
 
         console.log("### NWC request!");
         console.log("### event", event);


### PR DESCRIPTION
This PR resolves two major architectural NWC (Nostr Wallet Connect) bugs that cause clients like Primal or Damus to drop connections, time out, and force users to completely set up everything again.

### Bug Fixes:
1. **Parallel/Same-Second Requests**: Concurrent requests (e.g. `get_info`, `get_balance`, `list_transactions` fired simultaneously on app start) often share the same integer second timestamp (`created_at`). The previous implementation used `event.created_at <= this.seenCommandsUntil`, which silently dropped subsequent same-second requests. This PR implements unique Event ID tracking per connection (`processedRequestIds`) to support concurrent same-second requests safely.
2. **Offline Subscription Window**: Expanded the subscription lookup window from 60 seconds to 24 hours. If Cashu.me is suspended/offline in the background when the client is opened, it will now successfully fetch and process any missed requests upon reconnection.
3. **App Active / Foreground Listener**: Added a `visibilitychange` event listener in `WalletPage.vue` to automatically trigger `listenToNWCCommands()` when bringing the wallet tab/PWA back to the foreground, reviving closed Nostr WebSocket connections.