### PR TITLE
Fix wallet overlay back navigation

### DIFF
--- a/src/components/CreateInvoiceDialog.vue
+++ b/src/components/CreateInvoiceDialog.vue
@@ -248,6 +248,7 @@ import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
 import type { InvoiceHistory } from "src/stores/wallet";
 import { PaymentMethod } from "src/stores/walletTypes";
 import { mintSupportsPaymentMethod } from "src/js/mint-payment-methods";
+import { getWalletOverlayLocation } from "src/js/overlays";
 
 declare const windowMixin: any;
 
@@ -500,15 +501,13 @@ export default defineComponent({
         if (this.isOnchain) {
           const mintQuote = await this.requestMintOnchain(wallet);
 
-          this.showCreateInvoiceDialog = false;
-          this.showInvoiceDetails = true;
+          this.$router.push(getWalletOverlayLocation("invoiceDetails"));
           await this.mintOnPaidOnchain(mintQuote.quote);
         } else if (this.isBolt12) {
           // BOLT12 Flow
           const mintQuote = await this.requestMintBolt12(amount, wallet);
 
-          this.showCreateInvoiceDialog = false;
-          this.showInvoiceDetails = true;
+          this.$router.push(getWalletOverlayLocation("invoiceDetails"));
 
           // Start listening for payment
           await this.mintOnPaidBolt12(mintQuote.quote);
@@ -516,8 +515,7 @@ export default defineComponent({
           // BOLT11 Flow
           const mintQuote = await this.requestMintBolt11(amount, wallet);
 
-          this.showCreateInvoiceDialog = false;
-          this.showInvoiceDetails = true;
+          this.$router.push(getWalletOverlayLocation("invoiceDetails"));
           await this.mintOnPaid(mintQuote.quote);
         }
       } catch (e) {

--- a/src/components/CreateInvoiceDialog.vue
+++ b/src/components/CreateInvoiceDialog.vue
@@ -248,7 +248,7 @@ import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
 import type { InvoiceHistory } from "src/stores/wallet";
 import { PaymentMethod } from "src/stores/walletTypes";
 import { mintSupportsPaymentMethod } from "src/js/mint-payment-methods";
-import { getWalletOverlayLocation } from "src/js/overlays";
+import { openWalletOverlay, WalletOverlay } from "src/js/overlays";
 
 declare const windowMixin: any;
 
@@ -501,13 +501,13 @@ export default defineComponent({
         if (this.isOnchain) {
           const mintQuote = await this.requestMintOnchain(wallet);
 
-          this.$router.push(getWalletOverlayLocation("invoiceDetails"));
+          openWalletOverlay(this.$router, WalletOverlay.InvoiceDetails);
           await this.mintOnPaidOnchain(mintQuote.quote);
         } else if (this.isBolt12) {
           // BOLT12 Flow
           const mintQuote = await this.requestMintBolt12(amount, wallet);
 
-          this.$router.push(getWalletOverlayLocation("invoiceDetails"));
+          openWalletOverlay(this.$router, WalletOverlay.InvoiceDetails);
 
           // Start listening for payment
           await this.mintOnPaidBolt12(mintQuote.quote);
@@ -515,7 +515,7 @@ export default defineComponent({
           // BOLT11 Flow
           const mintQuote = await this.requestMintBolt11(amount, wallet);
 
-          this.$router.push(getWalletOverlayLocation("invoiceDetails"));
+          openWalletOverlay(this.$router, WalletOverlay.InvoiceDetails);
           await this.mintOnPaid(mintQuote.quote);
         }
       } catch (e) {

--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -174,6 +174,7 @@ import {
 } from "lucide-vue-next";
 import { PaymentMethod, UnifiedTransactionType } from "src/stores/walletTypes";
 import { mintQuoteForHistoryInvoice } from "src/js/invoice-history";
+import { getWalletOverlayLocation } from "src/js/overlays";
 
 export default defineComponent({
   name: "HistoryTable",
@@ -328,7 +329,7 @@ export default defineComponent({
 
     receiveToken(tokenStr) {
       this.receiveData.tokensBase64 = tokenStr;
-      this.showReceiveTokens = true;
+      this.$router.push(getWalletOverlayLocation("receiveTokens"));
     },
 
     getTransactionKey(transaction) {
@@ -442,12 +443,12 @@ export default defineComponent({
       if (historyToken.status === "pending" && historyToken.amount < 0) {
         this.addOutgoingTokenToChecker(tokensBase64, true);
       }
-      this.showSendTokens = true;
+      this.$router.push(getWalletOverlayLocation("sendTokens"));
     },
 
     showInvoiceDialog: async function (invoice) {
       this.invoiceData = invoice;
-      this.showInvoiceDetails = true;
+      this.$router.push(getWalletOverlayLocation("invoiceDetails"));
       if (invoice.status === "pending") {
         if (
           invoice.method === PaymentMethod.Onchain ||

--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -174,7 +174,7 @@ import {
 } from "lucide-vue-next";
 import { PaymentMethod, UnifiedTransactionType } from "src/stores/walletTypes";
 import { mintQuoteForHistoryInvoice } from "src/js/invoice-history";
-import { getWalletOverlayLocation } from "src/js/overlays";
+import { openWalletOverlay, WalletOverlay } from "src/js/overlays";
 
 export default defineComponent({
   name: "HistoryTable",
@@ -329,7 +329,7 @@ export default defineComponent({
 
     receiveToken(tokenStr) {
       this.receiveData.tokensBase64 = tokenStr;
-      this.$router.push(getWalletOverlayLocation("receiveTokens"));
+      openWalletOverlay(this.$router, WalletOverlay.ReceiveTokens);
     },
 
     getTransactionKey(transaction) {
@@ -443,12 +443,12 @@ export default defineComponent({
       if (historyToken.status === "pending" && historyToken.amount < 0) {
         this.addOutgoingTokenToChecker(tokensBase64, true);
       }
-      this.$router.push(getWalletOverlayLocation("sendTokens"));
+      openWalletOverlay(this.$router, WalletOverlay.SendTokens);
     },
 
     showInvoiceDialog: async function (invoice) {
       this.invoiceData = invoice;
-      this.$router.push(getWalletOverlayLocation("invoiceDetails"));
+      openWalletOverlay(this.$router, WalletOverlay.InvoiceDetails);
       if (invoice.status === "pending") {
         if (
           invoice.method === PaymentMethod.Onchain ||

--- a/src/components/MultinutPaymentDialog.vue
+++ b/src/components/MultinutPaymentDialog.vue
@@ -311,7 +311,6 @@ export default defineComponent({
     return {
       multiMeltButtonLoading: false,
       selectedMints: [],
-      showMultinutPaymentDialog: false,
       // State tracking for each mint during payment
       mintStates: {}, // { mintUrl: 'requesting' | 'paying' | 'success' | 'error' }
       isPaymentInProgress: false,
@@ -321,7 +320,10 @@ export default defineComponent({
   },
   computed: {
     ...mapWritableState(useWalletStore, ["payInvoiceData"]),
-    ...mapWritableState(useUiStore, ["multinutExperimentalWarningDismissed"]),
+    ...mapWritableState(useUiStore, [
+      "multinutExperimentalWarningDismissed",
+      "showMultinutPaymentDialog",
+    ]),
     ...mapState(useMintsStore, ["mints", "activeUnit", "multiMints"]),
     totalSelectedBalance() {
       return this.selectedMints.reduce((total, mint) => {

--- a/src/components/NoMintWarnBanner.vue
+++ b/src/components/NoMintWarnBanner.vue
@@ -47,7 +47,7 @@ import { mapWritableState } from "pinia";
 import { useReceiveTokensStore } from "src/stores/receiveTokensStore";
 import { EventBus } from "../js/eventBus";
 import { sumProofAmounts } from "src/js/proofs";
-import { getWalletOverlayLocation } from "src/js/overlays";
+import { openWalletOverlay, WalletOverlay } from "src/js/overlays";
 
 export default defineComponent({
   name: "NoMintWarnBanner",
@@ -85,7 +85,7 @@ export default defineComponent({
     //   this.showReceiveTokens = true;
     // },
     handleReceiveEcash: function () {
-      this.$router.push(getWalletOverlayLocation("receiveEcashDrawer"));
+      openWalletOverlay(this.$router, WalletOverlay.ReceiveEcash);
     },
     handleAddMintClick: function () {
       this.expandHistory = true;

--- a/src/components/NoMintWarnBanner.vue
+++ b/src/components/NoMintWarnBanner.vue
@@ -47,6 +47,7 @@ import { mapWritableState } from "pinia";
 import { useReceiveTokensStore } from "src/stores/receiveTokensStore";
 import { EventBus } from "../js/eventBus";
 import { sumProofAmounts } from "src/js/proofs";
+import { getWalletOverlayLocation } from "src/js/overlays";
 
 export default defineComponent({
   name: "NoMintWarnBanner",
@@ -84,7 +85,7 @@ export default defineComponent({
     //   this.showReceiveTokens = true;
     // },
     handleReceiveEcash: function () {
-      this.showReceiveEcashDrawer = true;
+      this.$router.push(getWalletOverlayLocation("receiveEcashDrawer"));
     },
     handleAddMintClick: function () {
       this.expandHistory = true;

--- a/src/components/PaymentRequestPayments.vue
+++ b/src/components/PaymentRequestPayments.vue
@@ -57,6 +57,7 @@ import { formatDistanceToNow, parseISO } from "date-fns";
 import token from "src/js/token";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import { Coins as CoinsIcon } from "lucide-vue-next";
+import { getWalletOverlayLocation } from "src/js/overlays";
 
 export default defineComponent({
   name: "PaymentRequestPayments",
@@ -120,7 +121,7 @@ export default defineComponent({
       this.sendData.paymentRequest = historyToken.paymentRequest;
       this.sendData.historyAmount = historyToken.amount;
       this.sendData.historyToken = historyToken as any;
-      this.showSendTokens = true;
+      this.$router.push(getWalletOverlayLocation("sendTokens"));
     },
   },
 });

--- a/src/components/PaymentRequestPayments.vue
+++ b/src/components/PaymentRequestPayments.vue
@@ -57,7 +57,7 @@ import { formatDistanceToNow, parseISO } from "date-fns";
 import token from "src/js/token";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import { Coins as CoinsIcon } from "lucide-vue-next";
-import { getWalletOverlayLocation } from "src/js/overlays";
+import { openWalletOverlay, WalletOverlay } from "src/js/overlays";
 
 export default defineComponent({
   name: "PaymentRequestPayments",
@@ -121,7 +121,7 @@ export default defineComponent({
       this.sendData.paymentRequest = historyToken.paymentRequest;
       this.sendData.historyAmount = historyToken.amount;
       this.sendData.historyToken = historyToken as any;
-      this.$router.push(getWalletOverlayLocation("sendTokens"));
+      openWalletOverlay(this.$router, WalletOverlay.SendTokens);
     },
   },
 });

--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -29,7 +29,11 @@
       <q-card-section class="q-pa-md">
         <div class="q-gutter-y-md">
           <!-- Ecash Option -->
-          <div class="action-row" @click="toggleReceiveEcashDrawer">
+          <button
+            type="button"
+            class="action-row"
+            @click="toggleReceiveEcashDrawer"
+          >
             <div class="row items-center no-wrap">
               <div class="icon-circle">
                 <CoinsIcon :size="24" />
@@ -40,11 +44,12 @@
                 </div>
               </div>
             </div>
-          </div>
+          </button>
 
           <!-- Lightning Invoice Option -->
-          <div
+          <button
             v-if="canReceiveLightning"
+            type="button"
             class="action-row"
             @click="showInvoiceCreateDialog"
           >
@@ -58,11 +63,12 @@
                 </div>
               </div>
             </div>
-          </div>
+          </button>
 
           <!-- On-chain Option -->
-          <div
+          <button
             v-if="canReceiveOnchain"
+            type="button"
             class="action-row"
             @click="showOnchainCreateDialog"
           >
@@ -74,7 +80,7 @@
                 <div class="text-body1 text-weight-medium">On-chain</div>
               </div>
             </div>
-          </div>
+          </button>
         </div>
       </q-card-section>
     </q-card>
@@ -104,6 +110,7 @@ import {
   ensurePaymentMintActive,
   firstMintSupportingPaymentMethods,
 } from "src/js/mint-payment-methods";
+import { getWalletOverlayLocation } from "src/js/overlays";
 
 export default defineComponent({
   name: "ReceiveDialog",
@@ -170,14 +177,11 @@ export default defineComponent({
   methods: {
     ...mapActions(useMintsStore, ["selectMintUrl"]),
     toggleReceiveEcashDrawer: function () {
-      this.showReceiveDialog = false;
-      this.showReceiveTokens = false;
-      this.showReceiveEcashDrawer = true;
+      this.$router.push(getWalletOverlayLocation("receiveEcashDrawer"));
     },
     showReceiveTokensDialog: function () {
       this.receiveData.tokensBase64 = "";
-      this.showReceiveTokens = true;
-      this.showReceiveDialog = false;
+      this.$router.push(getWalletOverlayLocation("receiveTokens"));
     },
     showInvoiceCreateDialog: async function () {
       const mintResult = await ensurePaymentMintActive(
@@ -201,8 +205,7 @@ export default defineComponent({
       this.invoiceData.hash = "";
       this.invoiceData.memo = "";
       this.invoiceData.type = mintResult.method;
-      this.showCreateInvoiceDialog = true;
-      this.showReceiveDialog = false;
+      this.$router.push(getWalletOverlayLocation("createInvoice"));
     },
     showOnchainCreateDialog: async function () {
       const mintResult = await ensurePaymentMintActive(
@@ -223,8 +226,7 @@ export default defineComponent({
       this.invoiceData.hash = "";
       this.invoiceData.memo = "";
       this.invoiceData.type = PaymentMethod.Onchain;
-      this.showCreateInvoiceDialog = true;
-      this.showReceiveDialog = false;
+      this.$router.push(getWalletOverlayLocation("createInvoice"));
     },
     ...mapActions(useCameraStore, ["closeCamera", "showCamera"]),
   },
@@ -250,9 +252,15 @@ export default defineComponent({
 }
 
 .action-row {
+  border: 0;
   background: rgba(255, 255, 255, 0.06);
   border-radius: 12px;
+  color: inherit;
+  display: block;
+  font: inherit;
   padding: 12px 16px;
+  text-align: left;
+  width: 100%;
   cursor: pointer;
   transition: background 0.2s ease;
 

--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -181,7 +181,9 @@ export default defineComponent({
     },
     showReceiveTokensDialog: function () {
       this.receiveData.tokensBase64 = "";
-      openWalletOverlay(this.$router, WalletOverlay.ReceiveTokens);
+      openWalletOverlay(this.$router, WalletOverlay.ReceiveTokens, {
+        closeFlowOnBack: true,
+      });
     },
     showInvoiceCreateDialog: async function () {
       const mintResult = await ensurePaymentMintActive(
@@ -205,7 +207,9 @@ export default defineComponent({
       this.invoiceData.hash = "";
       this.invoiceData.memo = "";
       this.invoiceData.type = mintResult.method;
-      openWalletOverlay(this.$router, WalletOverlay.CreateInvoice);
+      openWalletOverlay(this.$router, WalletOverlay.CreateInvoice, {
+        closeFlowOnBack: true,
+      });
     },
     showOnchainCreateDialog: async function () {
       const mintResult = await ensurePaymentMintActive(
@@ -226,7 +230,9 @@ export default defineComponent({
       this.invoiceData.hash = "";
       this.invoiceData.memo = "";
       this.invoiceData.type = PaymentMethod.Onchain;
-      openWalletOverlay(this.$router, WalletOverlay.CreateInvoice);
+      openWalletOverlay(this.$router, WalletOverlay.CreateInvoice, {
+        closeFlowOnBack: true,
+      });
     },
     ...mapActions(useCameraStore, ["closeCamera", "showCamera"]),
   },

--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -110,7 +110,7 @@ import {
   ensurePaymentMintActive,
   firstMintSupportingPaymentMethods,
 } from "src/js/mint-payment-methods";
-import { getWalletOverlayLocation } from "src/js/overlays";
+import { openWalletOverlay, WalletOverlay } from "src/js/overlays";
 
 export default defineComponent({
   name: "ReceiveDialog",
@@ -177,11 +177,11 @@ export default defineComponent({
   methods: {
     ...mapActions(useMintsStore, ["selectMintUrl"]),
     toggleReceiveEcashDrawer: function () {
-      this.$router.push(getWalletOverlayLocation("receiveEcashDrawer"));
+      openWalletOverlay(this.$router, WalletOverlay.ReceiveEcash);
     },
     showReceiveTokensDialog: function () {
       this.receiveData.tokensBase64 = "";
-      this.$router.push(getWalletOverlayLocation("receiveTokens"));
+      openWalletOverlay(this.$router, WalletOverlay.ReceiveTokens);
     },
     showInvoiceCreateDialog: async function () {
       const mintResult = await ensurePaymentMintActive(
@@ -205,7 +205,7 @@ export default defineComponent({
       this.invoiceData.hash = "";
       this.invoiceData.memo = "";
       this.invoiceData.type = mintResult.method;
-      this.$router.push(getWalletOverlayLocation("createInvoice"));
+      openWalletOverlay(this.$router, WalletOverlay.CreateInvoice);
     },
     showOnchainCreateDialog: async function () {
       const mintResult = await ensurePaymentMintActive(
@@ -226,7 +226,7 @@ export default defineComponent({
       this.invoiceData.hash = "";
       this.invoiceData.memo = "";
       this.invoiceData.type = PaymentMethod.Onchain;
-      this.$router.push(getWalletOverlayLocation("createInvoice"));
+      openWalletOverlay(this.$router, WalletOverlay.CreateInvoice);
     },
     ...mapActions(useCameraStore, ["closeCamera", "showCamera"]),
   },

--- a/src/components/ReceiveEcashDrawer.vue
+++ b/src/components/ReceiveEcashDrawer.vue
@@ -41,7 +41,11 @@
             </div>
           </button>
 
-          <button type="button" class="action-row" @click="showCamera">
+          <button
+            type="button"
+            class="action-row"
+            @click="showCameraFromBottomSheet"
+          >
             <div class="row items-center no-wrap">
               <div class="icon-circle">
                 <ScanIcon :size="24" />
@@ -220,7 +224,9 @@ export default defineComponent({
     },
     handlePasteBtn: function () {
       this.receiveData.tokensBase64 = "";
-      openWalletOverlay(this.$router, WalletOverlay.ReceiveTokens);
+      openWalletOverlay(this.$router, WalletOverlay.ReceiveTokens, {
+        closeFlowOnBack: true,
+      });
       // if (!this.isiOsSafari()
       if (this.autoPasteEcashReceive) {
         this.watchClipboardPaste = true;
@@ -231,12 +237,21 @@ export default defineComponent({
         this.generateKeypair();
       }
       this.showLastKey();
-      openWalletOverlay(this.$router, WalletOverlay.P2PK);
+      openWalletOverlay(this.$router, WalletOverlay.P2PK, {
+        closeFlowOnBack: true,
+      });
     },
     handlePaymentRequestBtn: function () {
       const prStore = usePRStore();
       prStore.newPaymentRequest();
-      openWalletOverlay(this.$router, WalletOverlay.PaymentRequest);
+      openWalletOverlay(this.$router, WalletOverlay.PaymentRequest, {
+        closeFlowOnBack: true,
+      });
+    },
+    showCameraFromBottomSheet: function () {
+      openWalletOverlay(this.$router, WalletOverlay.Camera, {
+        closeFlowOnBack: true,
+      });
     },
     handleNFCBtn: function () {
       this.toggleScanner();

--- a/src/components/ReceiveEcashDrawer.vue
+++ b/src/components/ReceiveEcashDrawer.vue
@@ -28,7 +28,7 @@
 
       <q-card-section class="q-pa-md">
         <div class="q-gutter-y-md">
-          <div class="action-row" @click="handlePasteBtn">
+          <button type="button" class="action-row" @click="handlePasteBtn">
             <div class="row items-center no-wrap">
               <div class="icon-circle">
                 <ClipboardIcon :size="24" />
@@ -39,9 +39,9 @@
                 </div>
               </div>
             </div>
-          </div>
+          </button>
 
-          <div class="action-row" @click="showCamera">
+          <button type="button" class="action-row" @click="showCamera">
             <div class="row items-center no-wrap">
               <div class="icon-circle">
                 <ScanIcon :size="24" />
@@ -52,10 +52,11 @@
                 </div>
               </div>
             </div>
-          </div>
+          </button>
 
-          <div
+          <button
             v-if="enablePaymentRequest"
+            type="button"
             class="action-row"
             @click="handlePaymentRequestBtn"
           >
@@ -69,10 +70,11 @@
                 </div>
               </div>
             </div>
-          </div>
+          </button>
 
-          <div
+          <button
             v-if="showP2PkButtonInDrawer"
+            type="button"
             class="action-row"
             @click="handleLockBtn"
           >
@@ -86,10 +88,11 @@
                 </div>
               </div>
             </div>
-          </div>
+          </button>
 
-          <div
+          <button
             v-if="ndefSupported && showNfcButtonInDrawer"
+            type="button"
             class="action-row"
             @click="handleNFCBtn"
           >
@@ -109,13 +112,13 @@
                 </div>
               </div>
             </div>
-          </div>
+          </button>
         </div>
       </q-card-section>
     </q-card>
   </q-dialog>
-  <P2PKDialog v-model="showP2PKDialog" />
-  <PRDialog v-model="showPRDialog" />
+  <P2PKDialog />
+  <PRDialog />
 </template>
 
 <script lang="ts">
@@ -146,6 +149,7 @@ import {
 import TokenInformation from "components/TokenInformation.vue";
 import { map } from "underscore";
 import { notifyError, notifySuccess, notify } from "../js/notify";
+import { getWalletOverlayLocation } from "src/js/overlays";
 
 export default defineComponent({
   name: "ReceiveTokenDialog",
@@ -161,9 +165,7 @@ export default defineComponent({
     NfcIcon,
   },
   data: function () {
-    return {
-      showP2PKDialog: false,
-    };
+    return {};
   },
   computed: {
     ...mapWritableState(useReceiveTokensStore, [
@@ -186,6 +188,7 @@ export default defineComponent({
     ...mapWritableState(useMintsStore, ["addMintData", "showAddMintDialog"]),
     ...mapWritableState(usePRStore, ["showPRDialog"]),
     ...mapState(useCameraStore, ["hasCamera"]),
+    ...mapWritableState(useP2PKStore, ["showP2PKDialog"]),
     ...mapState(useP2PKStore, ["p2pkKeys", "showP2PkButtonInDrawer"]),
     ...mapState(usePRStore, ["enablePaymentRequest"]),
     ...mapWritableState(useUiStore, ["showReceiveDialog"]),
@@ -208,10 +211,6 @@ export default defineComponent({
       "toggleScanner",
       "pasteToParseDialog",
     ]),
-    ...mapWritableState(useReceiveTokensStore, [
-      "showReceiveTokens",
-      "receiveData",
-    ]),
     isiOsSafari() {
       const userAgent = window.navigator.userAgent.toLowerCase();
       const match =
@@ -221,28 +220,23 @@ export default defineComponent({
     },
     handlePasteBtn: function () {
       this.receiveData.tokensBase64 = "";
-      this.showReceiveTokens = true;
-      this.showReceiveEcashDrawer = false;
+      this.$router.push(getWalletOverlayLocation("receiveTokens"));
       // if (!this.isiOsSafari()
       if (this.autoPasteEcashReceive) {
         this.watchClipboardPaste = true;
       }
     },
     handleLockBtn: function () {
-      this.showP2PKDialog = !this.showP2PKDialog;
-      if (!this.p2pkKeys.length || !this.showP2PKDialog) {
+      if (!this.p2pkKeys.length) {
         this.generateKeypair();
       }
       this.showLastKey();
-      this.showReceiveEcashDrawer = false;
+      this.$router.push(getWalletOverlayLocation("p2pkDialog"));
     },
     handlePaymentRequestBtn: function () {
       const prStore = usePRStore();
-      this.showPRDialog = !this.showPRDialog;
-      if (this.showPRDialog) {
-        prStore.newPaymentRequest();
-      }
-      this.showReceiveEcashDrawer = false;
+      prStore.newPaymentRequest();
+      this.$router.push(getWalletOverlayLocation("prDialog"));
     },
     handleNFCBtn: function () {
       this.toggleScanner();
@@ -254,8 +248,7 @@ export default defineComponent({
       // You might want to process the result here
     },
     goBack: function () {
-      this.showReceiveEcashDrawer = false;
-      this.showReceiveDialog = true;
+      this.$router.push(getWalletOverlayLocation("receiveDialog"));
     },
   },
 });
@@ -279,9 +272,15 @@ export default defineComponent({
 }
 
 .action-row {
+  border: 0;
   background: rgba(255, 255, 255, 0.06);
   border-radius: 12px;
+  color: inherit;
+  display: block;
+  font: inherit;
   padding: 12px 16px;
+  text-align: left;
+  width: 100%;
   cursor: pointer;
   transition: background 0.2s ease;
 

--- a/src/components/ReceiveEcashDrawer.vue
+++ b/src/components/ReceiveEcashDrawer.vue
@@ -149,7 +149,7 @@ import {
 import TokenInformation from "components/TokenInformation.vue";
 import { map } from "underscore";
 import { notifyError, notifySuccess, notify } from "../js/notify";
-import { getWalletOverlayLocation } from "src/js/overlays";
+import { openWalletOverlay, WalletOverlay } from "src/js/overlays";
 
 export default defineComponent({
   name: "ReceiveTokenDialog",
@@ -220,7 +220,7 @@ export default defineComponent({
     },
     handlePasteBtn: function () {
       this.receiveData.tokensBase64 = "";
-      this.$router.push(getWalletOverlayLocation("receiveTokens"));
+      openWalletOverlay(this.$router, WalletOverlay.ReceiveTokens);
       // if (!this.isiOsSafari()
       if (this.autoPasteEcashReceive) {
         this.watchClipboardPaste = true;
@@ -231,12 +231,12 @@ export default defineComponent({
         this.generateKeypair();
       }
       this.showLastKey();
-      this.$router.push(getWalletOverlayLocation("p2pkDialog"));
+      openWalletOverlay(this.$router, WalletOverlay.P2PK);
     },
     handlePaymentRequestBtn: function () {
       const prStore = usePRStore();
       prStore.newPaymentRequest();
-      this.$router.push(getWalletOverlayLocation("prDialog"));
+      openWalletOverlay(this.$router, WalletOverlay.PaymentRequest);
     },
     handleNFCBtn: function () {
       this.toggleScanner();
@@ -248,7 +248,7 @@ export default defineComponent({
       // You might want to process the result here
     },
     goBack: function () {
-      this.$router.push(getWalletOverlayLocation("receiveDialog"));
+      openWalletOverlay(this.$router, WalletOverlay.Receive);
     },
   },
 });

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -107,7 +107,7 @@ import {
   ensurePaymentMintActive,
   firstMintSupportingPaymentMethods,
 } from "src/js/mint-payment-methods";
-import { getWalletOverlayLocation } from "src/js/overlays";
+import { openWalletOverlay, WalletOverlay } from "src/js/overlays";
 
 export default defineComponent({
   name: "SendDialog",
@@ -202,7 +202,7 @@ export default defineComponent({
       this.payInvoiceData.input.request = "";
       this.payInvoiceData.input.comment = "";
       this.camera.show = false;
-      this.$router.push(getWalletOverlayLocation("payInvoice"));
+      openWalletOverlay(this.$router, WalletOverlay.PayInvoice);
     },
     showOnchainPayDialog: async function () {
       const mintResult = await ensurePaymentMintActive(
@@ -227,7 +227,7 @@ export default defineComponent({
       this.payInvoiceData.input.amount = undefined;
       this.payInvoiceData.input.comment = "";
       this.camera.show = false;
-      this.$router.push(getWalletOverlayLocation("payInvoice"));
+      openWalletOverlay(this.$router, WalletOverlay.PayInvoice);
     },
     showSendTokensDialog: function () {
       console.log("##### showSendTokensDialog");
@@ -243,7 +243,7 @@ export default defineComponent({
       this.sendData.p2pkPubkey = "";
       this.sendData.paymentRequest = undefined;
       this.showLockInput = false;
-      this.$router.push(getWalletOverlayLocation("sendTokens"));
+      openWalletOverlay(this.$router, WalletOverlay.SendTokens);
     },
   },
   created: function () {},

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -28,7 +28,11 @@
 
       <q-card-section class="q-pa-md">
         <div class="q-gutter-y-md">
-          <div class="action-row" @click="showSendTokensDialog">
+          <button
+            type="button"
+            class="action-row"
+            @click="showSendTokensDialog"
+          >
             <div class="row items-center no-wrap">
               <div class="icon-circle">
                 <CoinsIcon :size="24" />
@@ -39,10 +43,11 @@
                 </div>
               </div>
             </div>
-          </div>
+          </button>
 
-          <div
+          <button
             v-if="canSendLightning"
+            type="button"
             class="action-row"
             @click="showParseDialog"
           >
@@ -56,10 +61,11 @@
                 </div>
               </div>
             </div>
-          </div>
+          </button>
 
-          <div
+          <button
             v-if="canSendOnchain"
+            type="button"
             class="action-row"
             @click="showOnchainPayDialog"
           >
@@ -71,7 +77,7 @@
                 <div class="text-body1 text-weight-medium">On-chain</div>
               </div>
             </div>
-          </div>
+          </button>
         </div>
       </q-card-section>
     </q-card>
@@ -101,6 +107,7 @@ import {
   ensurePaymentMintActive,
   firstMintSupportingPaymentMethods,
 } from "src/js/mint-payment-methods";
+import { getWalletOverlayLocation } from "src/js/overlays";
 
 export default defineComponent({
   name: "SendDialog",
@@ -187,7 +194,6 @@ export default defineComponent({
         this.showSendDialog = false;
         return;
       }
-      this.payInvoiceData.show = true;
       this.payInvoiceData.invoice = null;
       this.payInvoiceData.lnurlpay = null;
       this.payInvoiceData.domain = "";
@@ -196,7 +202,7 @@ export default defineComponent({
       this.payInvoiceData.input.request = "";
       this.payInvoiceData.input.comment = "";
       this.camera.show = false;
-      this.showSendDialog = false;
+      this.$router.push(getWalletOverlayLocation("payInvoice"));
     },
     showOnchainPayDialog: async function () {
       const mintResult = await ensurePaymentMintActive(
@@ -212,7 +218,6 @@ export default defineComponent({
         this.showSendDialog = false;
         return;
       }
-      this.payInvoiceData.show = true;
       this.payInvoiceData.invoice = null;
       this.payInvoiceData.lnurlpay = null;
       this.payInvoiceData.domain = "";
@@ -222,7 +227,7 @@ export default defineComponent({
       this.payInvoiceData.input.amount = undefined;
       this.payInvoiceData.input.comment = "";
       this.camera.show = false;
-      this.showSendDialog = false;
+      this.$router.push(getWalletOverlayLocation("payInvoice"));
     },
     showSendTokensDialog: function () {
       console.log("##### showSendTokensDialog");
@@ -237,9 +242,8 @@ export default defineComponent({
       this.sendData.memo = "";
       this.sendData.p2pkPubkey = "";
       this.sendData.paymentRequest = undefined;
-      this.showSendDialog = false;
-      this.showSendTokens = true;
       this.showLockInput = false;
+      this.$router.push(getWalletOverlayLocation("sendTokens"));
     },
   },
   created: function () {},
@@ -264,9 +268,15 @@ export default defineComponent({
 }
 
 .action-row {
+  border: 0;
   background: rgba(255, 255, 255, 0.06);
   border-radius: 12px;
+  color: inherit;
+  display: block;
+  font: inherit;
   padding: 12px 16px;
+  text-align: left;
+  width: 100%;
   cursor: pointer;
   transition: background 0.2s ease;
 

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -202,7 +202,9 @@ export default defineComponent({
       this.payInvoiceData.input.request = "";
       this.payInvoiceData.input.comment = "";
       this.camera.show = false;
-      openWalletOverlay(this.$router, WalletOverlay.PayInvoice);
+      openWalletOverlay(this.$router, WalletOverlay.PayInvoice, {
+        closeFlowOnBack: true,
+      });
     },
     showOnchainPayDialog: async function () {
       const mintResult = await ensurePaymentMintActive(
@@ -227,7 +229,9 @@ export default defineComponent({
       this.payInvoiceData.input.amount = undefined;
       this.payInvoiceData.input.comment = "";
       this.camera.show = false;
-      openWalletOverlay(this.$router, WalletOverlay.PayInvoice);
+      openWalletOverlay(this.$router, WalletOverlay.PayInvoice, {
+        closeFlowOnBack: true,
+      });
     },
     showSendTokensDialog: function () {
       console.log("##### showSendTokensDialog");
@@ -243,7 +247,9 @@ export default defineComponent({
       this.sendData.p2pkPubkey = "";
       this.sendData.paymentRequest = undefined;
       this.showLockInput = false;
-      openWalletOverlay(this.$router, WalletOverlay.SendTokens);
+      openWalletOverlay(this.$router, WalletOverlay.SendTokens, {
+        closeFlowOnBack: true,
+      });
     },
   },
   created: function () {},

--- a/src/js/__tests__/overlays.test.ts
+++ b/src/js/__tests__/overlays.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  getWalletOverlayFromPath,
+  getWalletOverlayFromRoute,
+  getWalletOverlayPath,
+  isWalletHomePath,
+} from "src/js/overlays";
+
+describe("wallet overlay routes", () => {
+  it("maps overlay ids to stable wallet paths", () => {
+    expect(getWalletOverlayPath("sendDialog")).toBe("/wallet/send");
+    expect(getWalletOverlayPath("receiveDialog")).toBe("/wallet/receive");
+    expect(getWalletOverlayPath("payInvoice")).toBe("/wallet/pay-invoice");
+    expect(getWalletOverlayPath("multinutPayment")).toBe(
+      "/wallet/multinut-payment"
+    );
+  });
+
+  it("parses overlay ids from browser paths", () => {
+    expect(getWalletOverlayFromPath("/wallet/send-token")).toBe("sendTokens");
+    expect(getWalletOverlayFromPath("/wallet/receive-token?foo=bar")).toBe(
+      "receiveTokens"
+    );
+    expect(getWalletOverlayFromPath("#/wallet/create-invoice")).toBe(
+      "createInvoice"
+    );
+  });
+
+  it("parses overlay ids from Vue Router params", () => {
+    expect(
+      getWalletOverlayFromRoute({
+        path: "/wallet/send",
+        params: { walletOverlay: "send" },
+      })
+    ).toBe("sendDialog");
+  });
+
+  it("recognizes the wallet home path", () => {
+    expect(isWalletHomePath("/")).toBe(true);
+    expect(isWalletHomePath("/wallet/send")).toBe(false);
+  });
+});

--- a/src/js/__tests__/overlays.test.ts
+++ b/src/js/__tests__/overlays.test.ts
@@ -4,25 +4,30 @@ import {
   getWalletOverlayFromRoute,
   getWalletOverlayPath,
   isWalletHomePath,
+  WalletOverlay,
 } from "src/js/overlays";
 
 describe("wallet overlay routes", () => {
   it("maps overlay ids to stable wallet paths", () => {
-    expect(getWalletOverlayPath("sendDialog")).toBe("/wallet/send");
-    expect(getWalletOverlayPath("receiveDialog")).toBe("/wallet/receive");
-    expect(getWalletOverlayPath("payInvoice")).toBe("/wallet/pay-invoice");
-    expect(getWalletOverlayPath("multinutPayment")).toBe(
+    expect(getWalletOverlayPath(WalletOverlay.Send)).toBe("/wallet/send");
+    expect(getWalletOverlayPath(WalletOverlay.Receive)).toBe("/wallet/receive");
+    expect(getWalletOverlayPath(WalletOverlay.PayInvoice)).toBe(
+      "/wallet/pay-invoice"
+    );
+    expect(getWalletOverlayPath(WalletOverlay.MultinutPayment)).toBe(
       "/wallet/multinut-payment"
     );
   });
 
   it("parses overlay ids from browser paths", () => {
-    expect(getWalletOverlayFromPath("/wallet/send-token")).toBe("sendTokens");
+    expect(getWalletOverlayFromPath("/wallet/send-token")).toBe(
+      WalletOverlay.SendTokens
+    );
     expect(getWalletOverlayFromPath("/wallet/receive-token?foo=bar")).toBe(
-      "receiveTokens"
+      WalletOverlay.ReceiveTokens
     );
     expect(getWalletOverlayFromPath("#/wallet/create-invoice")).toBe(
-      "createInvoice"
+      WalletOverlay.CreateInvoice
     );
   });
 
@@ -32,7 +37,7 @@ describe("wallet overlay routes", () => {
         path: "/wallet/send",
         params: { walletOverlay: "send" },
       })
-    ).toBe("sendDialog");
+    ).toBe(WalletOverlay.Send);
   });
 
   it("recognizes the wallet home path", () => {

--- a/src/js/__tests__/overlays.test.ts
+++ b/src/js/__tests__/overlays.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   getWalletOverlayFromPath,
   getWalletOverlayFromRoute,
+  getWalletOverlayLocation,
   getWalletOverlayPath,
   isWalletHomePath,
+  walletOverlayHistoryState,
   WalletOverlay,
 } from "src/js/overlays";
 
@@ -43,5 +45,25 @@ describe("wallet overlay routes", () => {
   it("recognizes the wallet home path", () => {
     expect(isWalletHomePath("/")).toBe(true);
     expect(isWalletHomePath("/wallet/send")).toBe(false);
+  });
+
+  it("marks a terminal overlay to close its complete sheet flow", () => {
+    window.history.replaceState(
+      { [walletOverlayHistoryState.depth]: 2 },
+      "",
+      "/wallet/receive-ecash"
+    );
+
+    expect(
+      getWalletOverlayLocation(WalletOverlay.ReceiveTokens, {
+        closeFlowOnBack: true,
+      })
+    ).toEqual({
+      path: "/wallet/receive-token",
+      state: {
+        [walletOverlayHistoryState.depth]: 3,
+        [walletOverlayHistoryState.closeFlowOnBack]: true,
+      },
+    });
   });
 });

--- a/src/js/overlays.ts
+++ b/src/js/overlays.ts
@@ -9,7 +9,19 @@ import { useNWCStore } from "src/stores/nwc";
 import { useMintsStore } from "src/stores/mints";
 
 type WalletOverlayRouter = {
-  push(location: { path: string }): Promise<unknown> | unknown;
+  push(location: {
+    path: string;
+    state?: Record<string, unknown>;
+  }): Promise<unknown> | unknown;
+};
+
+export const walletOverlayHistoryState = {
+  depth: "walletOverlayDepth",
+  closeFlowOnBack: "walletOverlayCloseFlowOnBack",
+} as const;
+
+type OpenWalletOverlayOptions = {
+  closeFlowOnBack?: boolean;
 };
 
 /** Overlay ids in close-priority order (deepest / topmost first). */
@@ -93,19 +105,34 @@ export function getWalletOverlayPath(overlay: OverlayId): string {
   return `/wallet/${walletOverlaySlugs[overlay]}`;
 }
 
-export function getWalletOverlayLocation(overlay: OverlayId): {
+export function getWalletOverlayLocation(
+  overlay: OverlayId,
+  options: OpenWalletOverlayOptions = {}
+): {
   path: string;
+  state: Record<string, unknown>;
 } {
+  const currentDepth = Number(
+    window.history.state?.[walletOverlayHistoryState.depth] ?? 0
+  );
+
   return {
     path: getWalletOverlayPath(overlay),
+    state: {
+      [walletOverlayHistoryState.depth]: currentDepth + 1,
+      ...(options.closeFlowOnBack
+        ? { [walletOverlayHistoryState.closeFlowOnBack]: true }
+        : {}),
+    },
   };
 }
 
 export function openWalletOverlay(
   router: WalletOverlayRouter,
-  overlay: OverlayId
+  overlay: OverlayId,
+  options: OpenWalletOverlayOptions = {}
 ): Promise<unknown> | unknown {
-  return router.push(getWalletOverlayLocation(overlay));
+  return router.push(getWalletOverlayLocation(overlay, options));
 }
 
 export function getWalletOverlayFromPath(

--- a/src/js/overlays.ts
+++ b/src/js/overlays.ts
@@ -1,0 +1,345 @@
+import { useUiStore } from "src/stores/ui";
+import { useWalletStore } from "src/stores/wallet";
+import { useCameraStore } from "src/stores/camera";
+import { useSendTokensStore } from "src/stores/sendTokensStore";
+import { useReceiveTokensStore } from "src/stores/receiveTokensStore";
+import { useP2PKStore } from "src/stores/p2pk";
+import { usePRStore } from "src/stores/payment-request";
+import { useNWCStore } from "src/stores/nwc";
+import { useMintsStore } from "src/stores/mints";
+
+/** Overlay ids in close-priority order (deepest / topmost first). */
+export type OverlayId =
+  | "multinutPayment"
+  | "camera"
+  | "payInvoice"
+  | "sendTokens"
+  | "receiveTokens"
+  | "createInvoice"
+  | "invoiceDetails"
+  | "prDialog"
+  | "p2pkDialog"
+  | "nwcDialog"
+  | "addMint"
+  | "removeMint"
+  | "editMint"
+  | "mintInfo"
+  | "receiveEcashDrawer"
+  | "sendDialog"
+  | "receiveDialog";
+
+const walletOverlaySlugs: Record<OverlayId, string> = {
+  multinutPayment: "multinut-payment",
+  camera: "scan",
+  payInvoice: "pay-invoice",
+  sendTokens: "send-token",
+  receiveTokens: "receive-token",
+  createInvoice: "create-invoice",
+  invoiceDetails: "invoice-details",
+  prDialog: "payment-request",
+  p2pkDialog: "p2pk",
+  nwcDialog: "nwc",
+  addMint: "add-mint",
+  removeMint: "remove-mint",
+  editMint: "edit-mint",
+  mintInfo: "mint-info",
+  receiveEcashDrawer: "receive-ecash",
+  sendDialog: "send",
+  receiveDialog: "receive",
+};
+
+const overlayBySlug = Object.entries(walletOverlaySlugs).reduce(
+  (acc, [overlay, slug]) => {
+    acc[slug] = overlay as OverlayId;
+    return acc;
+  },
+  {} as Record<string, OverlayId>
+);
+
+type WalletRouteLike = {
+  path?: string;
+  params?: {
+    walletOverlay?: string | string[];
+  };
+};
+
+function normalizePath(path?: string | null): string {
+  if (!path) {
+    return "";
+  }
+
+  let normalized = path;
+  const hashIndex = normalized.indexOf("#");
+  if (hashIndex >= 0) {
+    const hashPath = normalized.slice(hashIndex + 1);
+    if (hashPath.startsWith("/")) {
+      normalized = hashPath;
+    }
+  }
+
+  normalized = normalized.split("?")[0].split("#")[0];
+  normalized = normalized.replace(/\/+$/, "");
+  return normalized || "/";
+}
+
+export function getWalletOverlayPath(overlay: OverlayId): string {
+  return `/wallet/${walletOverlaySlugs[overlay]}`;
+}
+
+export function getWalletOverlayLocation(overlay: OverlayId): {
+  path: string;
+} {
+  return {
+    path: getWalletOverlayPath(overlay),
+  };
+}
+
+export function getWalletOverlayFromPath(
+  path?: string | null
+): OverlayId | null {
+  const normalized = normalizePath(path);
+  if (!normalized.startsWith("/wallet/")) {
+    return null;
+  }
+
+  const slug = normalized.slice("/wallet/".length);
+  return overlayBySlug[slug] ?? null;
+}
+
+export function getWalletOverlayFromRoute(
+  route?: WalletRouteLike | null
+): OverlayId | null {
+  const param = route?.params?.walletOverlay;
+  const slug = Array.isArray(param) ? param[0] : param;
+  if (slug && overlayBySlug[slug]) {
+    return overlayBySlug[slug];
+  }
+
+  return getWalletOverlayFromPath(route?.path);
+}
+
+export function isWalletHomePath(path?: string | null): boolean {
+  return normalizePath(path) === "/";
+}
+
+export function isWalletRoute(route?: WalletRouteLike | null): boolean {
+  return (
+    isWalletHomePath(route?.path) || Boolean(getWalletOverlayFromRoute(route))
+  );
+}
+
+/**
+ * Returns currently open wallet overlays, deepest / topmost first.
+ * Call only after Pinia is active (e.g. from a mounted component).
+ */
+export function getOpenOverlays(): OverlayId[] {
+  const uiStore = useUiStore();
+  const walletStore = useWalletStore();
+  const cameraStore = useCameraStore();
+  const sendTokensStore = useSendTokensStore();
+  const receiveTokensStore = useReceiveTokensStore();
+  const p2pkStore = useP2PKStore();
+  const prStore = usePRStore();
+  const nwcStore = useNWCStore();
+  const mintsStore = useMintsStore();
+
+  const open: OverlayId[] = [];
+
+  if (uiStore.showMultinutPaymentDialog) open.push("multinutPayment");
+  if (cameraStore.camera.show) open.push("camera");
+  if (walletStore.payInvoiceData.show) open.push("payInvoice");
+  if (sendTokensStore.showSendTokens) open.push("sendTokens");
+  if (receiveTokensStore.showReceiveTokens) open.push("receiveTokens");
+  if (uiStore.showCreateInvoiceDialog) open.push("createInvoice");
+  if (uiStore.showInvoiceDetails) open.push("invoiceDetails");
+  if (prStore.showPRDialog) open.push("prDialog");
+  if (p2pkStore.showP2PKDialog) open.push("p2pkDialog");
+  if (nwcStore.showNWCDialog) open.push("nwcDialog");
+  if (mintsStore.showAddMintDialog) open.push("addMint");
+  if (mintsStore.showRemoveMintDialog) open.push("removeMint");
+  if (mintsStore.showEditMintDialog) open.push("editMint");
+  if (mintsStore.showMintInfoDialog) open.push("mintInfo");
+  if (uiStore.showReceiveEcashDrawer) open.push("receiveEcashDrawer");
+  if (uiStore.showSendDialog) open.push("sendDialog");
+  if (uiStore.showReceiveDialog) open.push("receiveDialog");
+
+  return open;
+}
+
+export function hasOpenDialogs(): boolean {
+  return getOpenOverlays().length > 0;
+}
+
+export function openOverlay(overlay: OverlayId): void {
+  const uiStore = useUiStore();
+  const walletStore = useWalletStore();
+  const cameraStore = useCameraStore();
+  const sendTokensStore = useSendTokensStore();
+  const receiveTokensStore = useReceiveTokensStore();
+  const p2pkStore = useP2PKStore();
+  const prStore = usePRStore();
+  const nwcStore = useNWCStore();
+  const mintsStore = useMintsStore();
+
+  switch (overlay) {
+    case "multinutPayment":
+      uiStore.showMultinutPaymentDialog = true;
+      break;
+    case "camera":
+      cameraStore.camera.show = true;
+      break;
+    case "payInvoice":
+      walletStore.payInvoiceData.show = true;
+      break;
+    case "sendTokens":
+      sendTokensStore.showSendTokens = true;
+      break;
+    case "receiveTokens":
+      receiveTokensStore.showReceiveTokens = true;
+      break;
+    case "createInvoice":
+      uiStore.showCreateInvoiceDialog = true;
+      break;
+    case "invoiceDetails":
+      uiStore.showInvoiceDetails = true;
+      break;
+    case "prDialog":
+      prStore.showPRDialog = true;
+      break;
+    case "p2pkDialog":
+      p2pkStore.showP2PKDialog = true;
+      break;
+    case "nwcDialog":
+      nwcStore.showNWCDialog = true;
+      break;
+    case "addMint":
+      mintsStore.showAddMintDialog = true;
+      break;
+    case "removeMint":
+      mintsStore.showRemoveMintDialog = true;
+      break;
+    case "editMint":
+      mintsStore.showEditMintDialog = true;
+      break;
+    case "mintInfo":
+      mintsStore.showMintInfoDialog = true;
+      break;
+    case "receiveEcashDrawer":
+      uiStore.showReceiveEcashDrawer = true;
+      break;
+    case "sendDialog":
+      uiStore.showSendDialog = true;
+      break;
+    case "receiveDialog":
+      uiStore.showReceiveDialog = true;
+      break;
+  }
+}
+
+export function openOnlyOverlay(overlay: OverlayId): void {
+  closeAllOverlays();
+  openOverlay(overlay);
+}
+
+/** Closes the topmost overlay. Returns true if something was closed. */
+export function closeTopOverlay(): boolean {
+  const top = getOpenOverlays()[0];
+  if (!top) {
+    return false;
+  }
+
+  const uiStore = useUiStore();
+  const walletStore = useWalletStore();
+  const cameraStore = useCameraStore();
+  const sendTokensStore = useSendTokensStore();
+  const receiveTokensStore = useReceiveTokensStore();
+  const p2pkStore = useP2PKStore();
+  const prStore = usePRStore();
+  const nwcStore = useNWCStore();
+  const mintsStore = useMintsStore();
+
+  switch (top) {
+    case "multinutPayment":
+      uiStore.showMultinutPaymentDialog = false;
+      break;
+    case "camera":
+      cameraStore.camera.show = false;
+      break;
+    case "payInvoice":
+      walletStore.payInvoiceData.show = false;
+      break;
+    case "sendTokens":
+      sendTokensStore.showSendTokens = false;
+      break;
+    case "receiveTokens":
+      receiveTokensStore.showReceiveTokens = false;
+      break;
+    case "createInvoice":
+      uiStore.showCreateInvoiceDialog = false;
+      break;
+    case "invoiceDetails":
+      uiStore.showInvoiceDetails = false;
+      break;
+    case "prDialog":
+      prStore.showPRDialog = false;
+      break;
+    case "p2pkDialog":
+      p2pkStore.showP2PKDialog = false;
+      break;
+    case "nwcDialog":
+      nwcStore.showNWCDialog = false;
+      break;
+    case "addMint":
+      mintsStore.showAddMintDialog = false;
+      break;
+    case "removeMint":
+      mintsStore.showRemoveMintDialog = false;
+      break;
+    case "editMint":
+      mintsStore.showEditMintDialog = false;
+      break;
+    case "mintInfo":
+      mintsStore.showMintInfoDialog = false;
+      break;
+    case "receiveEcashDrawer":
+      // Match ReceiveEcashDrawer.goBack(): restore receive chooser
+      uiStore.showReceiveEcashDrawer = false;
+      uiStore.showReceiveDialog = true;
+      break;
+    case "sendDialog":
+      uiStore.showSendDialog = false;
+      break;
+    case "receiveDialog":
+      uiStore.showReceiveDialog = false;
+      break;
+  }
+
+  return true;
+}
+
+/** Closes every tracked overlay (hard reset). */
+export function closeAllOverlays(): void {
+  const uiStore = useUiStore();
+  const walletStore = useWalletStore();
+  const cameraStore = useCameraStore();
+  const sendTokensStore = useSendTokensStore();
+  const receiveTokensStore = useReceiveTokensStore();
+  const p2pkStore = useP2PKStore();
+  const prStore = usePRStore();
+  const nwcStore = useNWCStore();
+  const mintsStore = useMintsStore();
+
+  uiStore.closeDialogs();
+  uiStore.showMultinutPaymentDialog = false;
+  walletStore.payInvoiceData.show = false;
+  sendTokensStore.showSendTokens = false;
+  receiveTokensStore.showReceiveTokens = false;
+  cameraStore.camera.show = false;
+  prStore.showPRDialog = false;
+  p2pkStore.showP2PKDialog = false;
+  nwcStore.showNWCDialog = false;
+  mintsStore.showAddMintDialog = false;
+  mintsStore.showRemoveMintDialog = false;
+  mintsStore.showEditMintDialog = false;
+  mintsStore.showMintInfoDialog = false;
+}

--- a/src/js/overlays.ts
+++ b/src/js/overlays.ts
@@ -8,52 +8,59 @@ import { usePRStore } from "src/stores/payment-request";
 import { useNWCStore } from "src/stores/nwc";
 import { useMintsStore } from "src/stores/mints";
 
-/** Overlay ids in close-priority order (deepest / topmost first). */
-export type OverlayId =
-  | "multinutPayment"
-  | "camera"
-  | "payInvoice"
-  | "sendTokens"
-  | "receiveTokens"
-  | "createInvoice"
-  | "invoiceDetails"
-  | "prDialog"
-  | "p2pkDialog"
-  | "nwcDialog"
-  | "addMint"
-  | "removeMint"
-  | "editMint"
-  | "mintInfo"
-  | "receiveEcashDrawer"
-  | "sendDialog"
-  | "receiveDialog";
+type WalletOverlayRouter = {
+  push(location: { path: string }): Promise<unknown> | unknown;
+};
 
-const walletOverlaySlugs: Record<OverlayId, string> = {
-  multinutPayment: "multinut-payment",
-  camera: "scan",
-  payInvoice: "pay-invoice",
-  sendTokens: "send-token",
-  receiveTokens: "receive-token",
-  createInvoice: "create-invoice",
-  invoiceDetails: "invoice-details",
-  prDialog: "payment-request",
-  p2pkDialog: "p2pk",
-  nwcDialog: "nwc",
-  addMint: "add-mint",
-  removeMint: "remove-mint",
-  editMint: "edit-mint",
-  mintInfo: "mint-info",
-  receiveEcashDrawer: "receive-ecash",
-  sendDialog: "send",
-  receiveDialog: "receive",
+/** Overlay ids in close-priority order (deepest / topmost first). */
+export enum WalletOverlay {
+  MultinutPayment = "multinutPayment",
+  Camera = "camera",
+  PayInvoice = "payInvoice",
+  SendTokens = "sendTokens",
+  ReceiveTokens = "receiveTokens",
+  CreateInvoice = "createInvoice",
+  InvoiceDetails = "invoiceDetails",
+  PaymentRequest = "prDialog",
+  P2PK = "p2pkDialog",
+  NWC = "nwcDialog",
+  AddMint = "addMint",
+  RemoveMint = "removeMint",
+  EditMint = "editMint",
+  MintInfo = "mintInfo",
+  ReceiveEcash = "receiveEcashDrawer",
+  Send = "sendDialog",
+  Receive = "receiveDialog",
+}
+
+export type OverlayId = WalletOverlay;
+
+const walletOverlaySlugs: Record<WalletOverlay, string> = {
+  [WalletOverlay.MultinutPayment]: "multinut-payment",
+  [WalletOverlay.Camera]: "scan",
+  [WalletOverlay.PayInvoice]: "pay-invoice",
+  [WalletOverlay.SendTokens]: "send-token",
+  [WalletOverlay.ReceiveTokens]: "receive-token",
+  [WalletOverlay.CreateInvoice]: "create-invoice",
+  [WalletOverlay.InvoiceDetails]: "invoice-details",
+  [WalletOverlay.PaymentRequest]: "payment-request",
+  [WalletOverlay.P2PK]: "p2pk",
+  [WalletOverlay.NWC]: "nwc",
+  [WalletOverlay.AddMint]: "add-mint",
+  [WalletOverlay.RemoveMint]: "remove-mint",
+  [WalletOverlay.EditMint]: "edit-mint",
+  [WalletOverlay.MintInfo]: "mint-info",
+  [WalletOverlay.ReceiveEcash]: "receive-ecash",
+  [WalletOverlay.Send]: "send",
+  [WalletOverlay.Receive]: "receive",
 };
 
 const overlayBySlug = Object.entries(walletOverlaySlugs).reduce(
   (acc, [overlay, slug]) => {
-    acc[slug] = overlay as OverlayId;
+    acc[slug] = overlay as WalletOverlay;
     return acc;
   },
-  {} as Record<string, OverlayId>
+  {} as Record<string, WalletOverlay>
 );
 
 type WalletRouteLike = {
@@ -92,6 +99,13 @@ export function getWalletOverlayLocation(overlay: OverlayId): {
   return {
     path: getWalletOverlayPath(overlay),
   };
+}
+
+export function openWalletOverlay(
+  router: WalletOverlayRouter,
+  overlay: OverlayId
+): Promise<unknown> | unknown {
+  return router.push(getWalletOverlayLocation(overlay));
 }
 
 export function getWalletOverlayFromPath(
@@ -145,23 +159,25 @@ export function getOpenOverlays(): OverlayId[] {
 
   const open: OverlayId[] = [];
 
-  if (uiStore.showMultinutPaymentDialog) open.push("multinutPayment");
-  if (cameraStore.camera.show) open.push("camera");
-  if (walletStore.payInvoiceData.show) open.push("payInvoice");
-  if (sendTokensStore.showSendTokens) open.push("sendTokens");
-  if (receiveTokensStore.showReceiveTokens) open.push("receiveTokens");
-  if (uiStore.showCreateInvoiceDialog) open.push("createInvoice");
-  if (uiStore.showInvoiceDetails) open.push("invoiceDetails");
-  if (prStore.showPRDialog) open.push("prDialog");
-  if (p2pkStore.showP2PKDialog) open.push("p2pkDialog");
-  if (nwcStore.showNWCDialog) open.push("nwcDialog");
-  if (mintsStore.showAddMintDialog) open.push("addMint");
-  if (mintsStore.showRemoveMintDialog) open.push("removeMint");
-  if (mintsStore.showEditMintDialog) open.push("editMint");
-  if (mintsStore.showMintInfoDialog) open.push("mintInfo");
-  if (uiStore.showReceiveEcashDrawer) open.push("receiveEcashDrawer");
-  if (uiStore.showSendDialog) open.push("sendDialog");
-  if (uiStore.showReceiveDialog) open.push("receiveDialog");
+  if (uiStore.showMultinutPaymentDialog)
+    open.push(WalletOverlay.MultinutPayment);
+  if (cameraStore.camera.show) open.push(WalletOverlay.Camera);
+  if (walletStore.payInvoiceData.show) open.push(WalletOverlay.PayInvoice);
+  if (sendTokensStore.showSendTokens) open.push(WalletOverlay.SendTokens);
+  if (receiveTokensStore.showReceiveTokens)
+    open.push(WalletOverlay.ReceiveTokens);
+  if (uiStore.showCreateInvoiceDialog) open.push(WalletOverlay.CreateInvoice);
+  if (uiStore.showInvoiceDetails) open.push(WalletOverlay.InvoiceDetails);
+  if (prStore.showPRDialog) open.push(WalletOverlay.PaymentRequest);
+  if (p2pkStore.showP2PKDialog) open.push(WalletOverlay.P2PK);
+  if (nwcStore.showNWCDialog) open.push(WalletOverlay.NWC);
+  if (mintsStore.showAddMintDialog) open.push(WalletOverlay.AddMint);
+  if (mintsStore.showRemoveMintDialog) open.push(WalletOverlay.RemoveMint);
+  if (mintsStore.showEditMintDialog) open.push(WalletOverlay.EditMint);
+  if (mintsStore.showMintInfoDialog) open.push(WalletOverlay.MintInfo);
+  if (uiStore.showReceiveEcashDrawer) open.push(WalletOverlay.ReceiveEcash);
+  if (uiStore.showSendDialog) open.push(WalletOverlay.Send);
+  if (uiStore.showReceiveDialog) open.push(WalletOverlay.Receive);
 
   return open;
 }
@@ -182,55 +198,55 @@ export function openOverlay(overlay: OverlayId): void {
   const mintsStore = useMintsStore();
 
   switch (overlay) {
-    case "multinutPayment":
+    case WalletOverlay.MultinutPayment:
       uiStore.showMultinutPaymentDialog = true;
       break;
-    case "camera":
+    case WalletOverlay.Camera:
       cameraStore.camera.show = true;
       break;
-    case "payInvoice":
+    case WalletOverlay.PayInvoice:
       walletStore.payInvoiceData.show = true;
       break;
-    case "sendTokens":
+    case WalletOverlay.SendTokens:
       sendTokensStore.showSendTokens = true;
       break;
-    case "receiveTokens":
+    case WalletOverlay.ReceiveTokens:
       receiveTokensStore.showReceiveTokens = true;
       break;
-    case "createInvoice":
+    case WalletOverlay.CreateInvoice:
       uiStore.showCreateInvoiceDialog = true;
       break;
-    case "invoiceDetails":
+    case WalletOverlay.InvoiceDetails:
       uiStore.showInvoiceDetails = true;
       break;
-    case "prDialog":
+    case WalletOverlay.PaymentRequest:
       prStore.showPRDialog = true;
       break;
-    case "p2pkDialog":
+    case WalletOverlay.P2PK:
       p2pkStore.showP2PKDialog = true;
       break;
-    case "nwcDialog":
+    case WalletOverlay.NWC:
       nwcStore.showNWCDialog = true;
       break;
-    case "addMint":
+    case WalletOverlay.AddMint:
       mintsStore.showAddMintDialog = true;
       break;
-    case "removeMint":
+    case WalletOverlay.RemoveMint:
       mintsStore.showRemoveMintDialog = true;
       break;
-    case "editMint":
+    case WalletOverlay.EditMint:
       mintsStore.showEditMintDialog = true;
       break;
-    case "mintInfo":
+    case WalletOverlay.MintInfo:
       mintsStore.showMintInfoDialog = true;
       break;
-    case "receiveEcashDrawer":
+    case WalletOverlay.ReceiveEcash:
       uiStore.showReceiveEcashDrawer = true;
       break;
-    case "sendDialog":
+    case WalletOverlay.Send:
       uiStore.showSendDialog = true;
       break;
-    case "receiveDialog":
+    case WalletOverlay.Receive:
       uiStore.showReceiveDialog = true;
       break;
   }
@@ -259,57 +275,57 @@ export function closeTopOverlay(): boolean {
   const mintsStore = useMintsStore();
 
   switch (top) {
-    case "multinutPayment":
+    case WalletOverlay.MultinutPayment:
       uiStore.showMultinutPaymentDialog = false;
       break;
-    case "camera":
+    case WalletOverlay.Camera:
       cameraStore.camera.show = false;
       break;
-    case "payInvoice":
+    case WalletOverlay.PayInvoice:
       walletStore.payInvoiceData.show = false;
       break;
-    case "sendTokens":
+    case WalletOverlay.SendTokens:
       sendTokensStore.showSendTokens = false;
       break;
-    case "receiveTokens":
+    case WalletOverlay.ReceiveTokens:
       receiveTokensStore.showReceiveTokens = false;
       break;
-    case "createInvoice":
+    case WalletOverlay.CreateInvoice:
       uiStore.showCreateInvoiceDialog = false;
       break;
-    case "invoiceDetails":
+    case WalletOverlay.InvoiceDetails:
       uiStore.showInvoiceDetails = false;
       break;
-    case "prDialog":
+    case WalletOverlay.PaymentRequest:
       prStore.showPRDialog = false;
       break;
-    case "p2pkDialog":
+    case WalletOverlay.P2PK:
       p2pkStore.showP2PKDialog = false;
       break;
-    case "nwcDialog":
+    case WalletOverlay.NWC:
       nwcStore.showNWCDialog = false;
       break;
-    case "addMint":
+    case WalletOverlay.AddMint:
       mintsStore.showAddMintDialog = false;
       break;
-    case "removeMint":
+    case WalletOverlay.RemoveMint:
       mintsStore.showRemoveMintDialog = false;
       break;
-    case "editMint":
+    case WalletOverlay.EditMint:
       mintsStore.showEditMintDialog = false;
       break;
-    case "mintInfo":
+    case WalletOverlay.MintInfo:
       mintsStore.showMintInfoDialog = false;
       break;
-    case "receiveEcashDrawer":
+    case WalletOverlay.ReceiveEcash:
       // Match ReceiveEcashDrawer.goBack(): restore receive chooser
       uiStore.showReceiveEcashDrawer = false;
       uiStore.showReceiveDialog = true;
       break;
-    case "sendDialog":
+    case WalletOverlay.Send:
       uiStore.showSendDialog = false;
       break;
-    case "receiveDialog":
+    case WalletOverlay.Receive:
       uiStore.showReceiveDialog = false;
       break;
   }

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -260,10 +260,11 @@ import {
   getOpenOverlays,
   getWalletOverlayFromPath,
   getWalletOverlayFromRoute,
-  getWalletOverlayLocation,
   isWalletHomePath,
   isWalletRoute,
+  openWalletOverlay,
   openOnlyOverlay,
+  WalletOverlay,
 } from "src/js/overlays";
 import type { OverlayId } from "src/js/overlays";
 
@@ -488,10 +489,10 @@ export default {
       // this.$nextTick(() => this.$refs[el].focus());
     },
     showReceiveOverlay: function () {
-      this.$router.push(getWalletOverlayLocation("receiveDialog"));
+      openWalletOverlay(this.$router, WalletOverlay.Receive);
     },
     showSendOverlay: function () {
-      this.$router.push(getWalletOverlayLocation("sendDialog"));
+      openWalletOverlay(this.$router, WalletOverlay.Send);
     },
     showParseDialog: function () {
       this.payInvoiceData.invoice = null;
@@ -501,7 +502,7 @@ export default {
       this.payInvoiceData.input.request = "";
       this.payInvoiceData.input.comment = "";
       this.camera.show = false;
-      this.$router.push(getWalletOverlayLocation("payInvoice"));
+      openWalletOverlay(this.$router, WalletOverlay.PayInvoice);
       this.focusInput("parseDialogInput");
     },
     showWelcomePage: function () {
@@ -529,7 +530,7 @@ export default {
       this.invoiceData.request = "";
       this.invoiceData.hash = "";
       this.invoiceData.memo = "";
-      this.$router.push(getWalletOverlayLocation("createInvoice"));
+      openWalletOverlay(this.$router, WalletOverlay.CreateInvoice);
     },
     showSendTokensDialog: function () {
       console.log("##### showSendTokensDialog");
@@ -537,14 +538,14 @@ export default {
       this.sendData.tokensBase64 = "";
       this.sendData.amount = null;
       this.sendData.memo = "";
-      this.$router.push(getWalletOverlayLocation("sendTokens"));
+      openWalletOverlay(this.$router, WalletOverlay.SendTokens);
     },
     hideSendTokensDialog: function () {
       this.showSendTokens = false;
     },
     showReceiveTokensDialog: function () {
       this.receiveData.tokensBase64 = "";
-      this.$router.push(getWalletOverlayLocation("receiveTokens"));
+      openWalletOverlay(this.$router, WalletOverlay.ReceiveTokens);
     },
 
     //////////////////////// MINT //////////////////////////////////////////
@@ -734,7 +735,7 @@ export default {
         this.walletOverlayRouteDepth = currentRouteOverlay
           ? this.walletOverlayRouteDepth + 1
           : 1;
-        this.$router.push(getWalletOverlayLocation(newTopOverlay));
+        openWalletOverlay(this.$router, newTopOverlay);
         return;
       }
 
@@ -806,7 +807,7 @@ export default {
       const addMintUrl = params.get("mint") as string;
       await this.setTab("mints");
       this.addMintData = { url: addMintUrl };
-      this.$router.push(getWalletOverlayLocation("addMint"));
+      openWalletOverlay(this.$router, WalletOverlay.AddMint);
     }
     if (!localStorage.getItem("cashu.activeMintUrl")) {
       this.setTab("mints");
@@ -830,7 +831,7 @@ export default {
       if (!seen) {
         // show receive token dialog
         this.receiveData.tokensBase64 = tokenBase64;
-        this.$router.push(getWalletOverlayLocation("receiveTokens"));
+        openWalletOverlay(this.$router, WalletOverlay.ReceiveTokens);
       }
     }
 

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -264,6 +264,7 @@ import {
   isWalletRoute,
   openWalletOverlay,
   openOnlyOverlay,
+  walletOverlayHistoryState,
   WalletOverlay,
 } from "src/js/overlays";
 import type { OverlayId } from "src/js/overlays";
@@ -322,6 +323,7 @@ export default {
       newName: "",
       syncingOverlayRoute: false,
       walletOverlayRouteDepth: 0,
+      closeOverlayFlowDepthOnBack: 0,
     };
   },
   computed: {
@@ -653,6 +655,37 @@ export default {
       const state = window.history.state as { forward?: string } | null;
       return typeof state?.forward === "string" ? state.forward : "";
     },
+    getOverlayHistoryDepth: function () {
+      return Number(
+        window.history.state?.[walletOverlayHistoryState.depth] ?? 0
+      );
+    },
+    shouldCloseOverlayFlowOnBack: function () {
+      return Boolean(
+        window.history.state?.[
+          walletOverlayHistoryState.closeFlowOnBack
+        ]
+      );
+    },
+    handleOverlayRouteChange: function () {
+      const routeOverlay = getWalletOverlayFromRoute(this.$route);
+
+      // A native/browser Back has already moved from the terminal dialog to
+      // its sheet. Skip the remaining sheet entries and land on the wallet.
+      if (this.closeOverlayFlowDepthOnBack > 0) {
+        const remainingSteps = this.closeOverlayFlowDepthOnBack - 1;
+        this.closeOverlayFlowDepthOnBack = 0;
+        if (routeOverlay && remainingSteps > 0) {
+          this.$router.go(-remainingSteps);
+          return;
+        }
+      }
+
+      this.closeOverlayFlowDepthOnBack = this.shouldCloseOverlayFlowOnBack()
+        ? this.getOverlayHistoryDepth()
+        : 0;
+      this.syncOpenOverlaysWithRoute();
+    },
     finishOverlayRouteSync: function () {
       this.$nextTick(() => {
         this.syncingOverlayRoute = false;
@@ -740,6 +773,14 @@ export default {
       }
 
       if (currentRouteOverlay) {
+        if (this.shouldCloseOverlayFlowOnBack()) {
+          const steps = -this.getOverlayHistoryDepth();
+          this.closeOverlayFlowDepthOnBack = 0;
+          this.walletOverlayRouteDepth = 0;
+          this.$router.go(steps);
+          return;
+        }
+
         const previousPath = this.getPreviousHistoryPath();
         if (isWalletHomePath(previousPath)) {
           this.walletOverlayRouteDepth = 0;
@@ -758,7 +799,7 @@ export default {
     "$route.fullPath": {
       immediate: true,
       handler: function () {
-        this.syncOpenOverlaysWithRoute();
+        this.handleOverlayRouteChange();
       },
     },
     openOverlayKey: function (newKey: string) {

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -13,7 +13,7 @@
             dense
             class="q-px-md q-mr-md wallet-action-btn"
             color="primary"
-            @click="showReceiveDialog = true"
+            @click="showReceiveOverlay"
           >
             <div class="button-content">
               <span>{{ $t("WalletPage.actions.receive.label") }}</span>
@@ -36,15 +36,15 @@
             dense
             class="q-px-md q-ml-md wallet-action-btn"
             color="primary"
-            @click="showSendDialog = true"
+            @click="showSendOverlay"
           >
             <div class="button-content">
               <span>{{ $t("WalletPage.actions.send.label") }}</span>
             </div>
           </q-btn>
         </div>
-        <ReceiveDialog v-model="showReceiveDialog" />
-        <SendDialog v-model="showSendDialog" />
+        <ReceiveDialog />
+        <SendDialog />
       </div>
       <!-- ///////////////////////////////////////////
       ////////////////// TABLES /////////////////
@@ -134,7 +134,7 @@
     <!-- DIALOGS  -->
 
     <!-- INPUT PARSER  -->
-    <PayInvoiceDialog v-model="payInvoiceData.show" />
+    <PayInvoiceDialog />
 
     <!-- QR CODE SCANNER  -->
     <q-dialog v-model="camera.show" backdrop-filter="blur(2px) brightness(60%)">
@@ -151,14 +151,14 @@
     />
 
     <!-- INVOICE DETAILS  -->
-    <CreateInvoiceDialog v-model="showCreateInvoiceDialog" />
-    <InvoiceDetailDialog v-model="showInvoiceDetails" />
+    <CreateInvoiceDialog />
+    <InvoiceDetailDialog />
 
     <!-- SEND TOKENS DIALOG  -->
-    <SendTokenDialog v-model="showSendTokens" />
+    <SendTokenDialog />
 
     <!-- RECEIVE TOKENS DIALOG  -->
-    <ReceiveTokenDialog v-model="showReceiveTokens" />
+    <ReceiveTokenDialog />
   </div>
 </template>
 <style>
@@ -255,6 +255,17 @@ import ReceiveTokenDialog from "src/components/ReceiveTokenDialog.vue";
 import { useWelcomeStore } from "../stores/welcome";
 import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
 import { notifyError, notify } from "../js/notify";
+import {
+  closeAllOverlays,
+  getOpenOverlays,
+  getWalletOverlayFromPath,
+  getWalletOverlayFromRoute,
+  getWalletOverlayLocation,
+  isWalletHomePath,
+  isWalletRoute,
+  openOnlyOverlay,
+} from "src/js/overlays";
+import type { OverlayId } from "src/js/overlays";
 
 import {
   X as XIcon,
@@ -308,6 +319,8 @@ export default {
       baseURL: location.protocol + "//" + location.host + location.pathname,
       credit: 0,
       newName: "",
+      syncingOverlayRoute: false,
+      walletOverlayRouteDepth: 0,
     };
   },
   computed: {
@@ -319,6 +332,8 @@ export default {
       "tab",
       "showSendDialog",
       "showReceiveDialog",
+      "showReceiveEcashDrawer",
+      "showMultinutPaymentDialog",
     ]),
     ...mapWritableState(useUiStore, ["expandHistory"]),
     ...mapWritableState(useReceiveTokensStore, [
@@ -338,7 +353,13 @@ export default {
       "invoiceData",
       "payInvoiceData",
     ]),
-    ...mapWritableState(useMintsStore, ["addMintData", "showAddMintDialog"]),
+    ...mapWritableState(useMintsStore, [
+      "addMintData",
+      "showAddMintDialog",
+      "showRemoveMintDialog",
+      "showEditMintDialog",
+      "showMintInfoDialog",
+    ]),
     ...mapWritableState(useWorkersStore, [
       "invoiceCheckListener",
       "tokensCheckSpendableListener",
@@ -348,12 +369,35 @@ export default {
     ...mapWritableState(useCameraStore, ["camera", "hasCamera"]),
     ...mapWritableState(useP2PKStore, ["showP2PKDialog"]),
     ...mapWritableState(useNWCStore, ["showNWCDialog", "nwcEnabled"]),
+    ...mapWritableState(usePRStore, ["showPRDialog"]),
     pendingPaymentsExist: function () {
       return this.payments.findIndex((payment) => payment.pending) !== -1;
     },
 
     balance: function () {
       return sumProofAmounts(this.activeProofs.flat());
+    },
+    openOverlayKey: function () {
+      [
+        this.showMultinutPaymentDialog,
+        this.camera.show,
+        this.payInvoiceData.show,
+        this.showSendTokens,
+        this.showReceiveTokens,
+        this.showCreateInvoiceDialog,
+        this.showInvoiceDetails,
+        this.showPRDialog,
+        this.showP2PKDialog,
+        this.showNWCDialog,
+        this.showAddMintDialog,
+        this.showRemoveMintDialog,
+        this.showEditMintDialog,
+        this.showMintInfoDialog,
+        this.showReceiveEcashDrawer,
+        this.showSendDialog,
+        this.showReceiveDialog,
+      ];
+      return getOpenOverlays().join("|");
     },
   },
   methods: {
@@ -443,8 +487,13 @@ export default {
       // TODO: fix this
       // this.$nextTick(() => this.$refs[el].focus());
     },
+    showReceiveOverlay: function () {
+      this.$router.push(getWalletOverlayLocation("receiveDialog"));
+    },
+    showSendOverlay: function () {
+      this.$router.push(getWalletOverlayLocation("sendDialog"));
+    },
     showParseDialog: function () {
-      this.payInvoiceData.show = true;
       this.payInvoiceData.invoice = null;
       this.payInvoiceData.lnurlpay = null;
       this.payInvoiceData.domain = "";
@@ -452,6 +501,7 @@ export default {
       this.payInvoiceData.input.request = "";
       this.payInvoiceData.input.comment = "";
       this.camera.show = false;
+      this.$router.push(getWalletOverlayLocation("payInvoice"));
       this.focusInput("parseDialogInput");
     },
     showWelcomePage: function () {
@@ -479,7 +529,7 @@ export default {
       this.invoiceData.request = "";
       this.invoiceData.hash = "";
       this.invoiceData.memo = "";
-      this.showCreateInvoiceDialog = true;
+      this.$router.push(getWalletOverlayLocation("createInvoice"));
     },
     showSendTokensDialog: function () {
       console.log("##### showSendTokensDialog");
@@ -487,14 +537,14 @@ export default {
       this.sendData.tokensBase64 = "";
       this.sendData.amount = null;
       this.sendData.memo = "";
-      this.showSendTokens = true;
+      this.$router.push(getWalletOverlayLocation("sendTokens"));
     },
     hideSendTokensDialog: function () {
       this.showSendTokens = false;
     },
     showReceiveTokensDialog: function () {
       this.receiveData.tokensBase64 = "";
-      this.showReceiveTokens = true;
+      this.$router.push(getWalletOverlayLocation("receiveTokens"));
     },
 
     //////////////////////// MINT //////////////////////////////////////////
@@ -544,6 +594,10 @@ export default {
         }
       });
     },
+    setWelcomeDialogSeen: function () {
+      this.welcomeDialog.show = false;
+      useWelcomeStore().showWelcome = false;
+    },
     registerBroadcastChannel: async function () {
       // uses session storage to identify the tab so we can ignore incoming messages from the same tab
       if (!sessionStorage.getItem("tabId")) {
@@ -590,8 +644,126 @@ export default {
         }
       });
     },
+    getPreviousHistoryPath: function () {
+      const state = window.history.state as { back?: string } | null;
+      return typeof state?.back === "string" ? state.back : "";
+    },
+    getForwardHistoryPath: function () {
+      const state = window.history.state as { forward?: string } | null;
+      return typeof state?.forward === "string" ? state.forward : "";
+    },
+    finishOverlayRouteSync: function () {
+      this.$nextTick(() => {
+        this.syncingOverlayRoute = false;
+      });
+    },
+    updateOverlayRouteDepthFromRoute: function () {
+      const routeOverlay = getWalletOverlayFromRoute(this.$route);
+      if (!routeOverlay) {
+        this.walletOverlayRouteDepth = 0;
+        return;
+      }
+
+      const forwardOverlay = getWalletOverlayFromPath(
+        this.getForwardHistoryPath()
+      );
+      if (forwardOverlay && this.walletOverlayRouteDepth > 0) {
+        this.walletOverlayRouteDepth = Math.max(
+          1,
+          this.walletOverlayRouteDepth - 1
+        );
+      }
+    },
+    syncOpenOverlaysWithRoute: function () {
+      if (!isWalletRoute(this.$route)) {
+        return;
+      }
+
+      this.updateOverlayRouteDepthFromRoute();
+
+      const routeOverlay = getWalletOverlayFromRoute(this.$route);
+      const openOverlays = getOpenOverlays();
+
+      if (routeOverlay) {
+        if (openOverlays[0] !== routeOverlay) {
+          this.syncingOverlayRoute = true;
+          openOnlyOverlay(routeOverlay);
+          this.finishOverlayRouteSync();
+        }
+        return;
+      }
+
+      if (openOverlays.length) {
+        this.syncingOverlayRoute = true;
+        closeAllOverlays();
+        this.finishOverlayRouteSync();
+      }
+    },
+    syncRouteWithOpenOverlays: function (newKey: string) {
+      if (this.syncingOverlayRoute || !isWalletRoute(this.$route)) {
+        return;
+      }
+
+      const openOverlays = newKey
+        ? (newKey.split("|") as OverlayId[])
+        : ([] as OverlayId[]);
+      const newTopOverlay = openOverlays[0];
+      const currentRouteOverlay = getWalletOverlayFromRoute(this.$route);
+
+      if (newTopOverlay) {
+        if (newTopOverlay === currentRouteOverlay) {
+          return;
+        }
+
+        const previousRouteOverlay = getWalletOverlayFromPath(
+          this.getPreviousHistoryPath()
+        );
+        if (
+          currentRouteOverlay &&
+          previousRouteOverlay &&
+          newTopOverlay === previousRouteOverlay
+        ) {
+          this.walletOverlayRouteDepth = Math.max(
+            0,
+            this.walletOverlayRouteDepth - 1
+          );
+          this.$router.back();
+          return;
+        }
+
+        this.walletOverlayRouteDepth = currentRouteOverlay
+          ? this.walletOverlayRouteDepth + 1
+          : 1;
+        this.$router.push(getWalletOverlayLocation(newTopOverlay));
+        return;
+      }
+
+      if (currentRouteOverlay) {
+        const previousPath = this.getPreviousHistoryPath();
+        if (isWalletHomePath(previousPath)) {
+          this.walletOverlayRouteDepth = 0;
+          this.$router.back();
+        } else if (this.walletOverlayRouteDepth > 0) {
+          const steps = -this.walletOverlayRouteDepth;
+          this.walletOverlayRouteDepth = 0;
+          this.$router.go(steps);
+        } else {
+          this.$router.replace({ path: "/" });
+        }
+      }
+    },
   },
-  watch: {},
+  watch: {
+    "$route.fullPath": {
+      immediate: true,
+      handler: function () {
+        this.syncOpenOverlaysWithRoute();
+      },
+    },
+    openOverlayKey: function (newKey: string) {
+      this.syncRouteWithOpenOverlays(newKey);
+    },
+  },
 
   mounted: function () {
     // generate NPC connection
@@ -633,8 +805,8 @@ export default {
     if (params.get("mint")) {
       const addMintUrl = params.get("mint") as string;
       await this.setTab("mints");
-      this.showAddMintDialog = true;
       this.addMintData = { url: addMintUrl };
+      this.$router.push(getWalletOverlayLocation("addMint"));
     }
     if (!localStorage.getItem("cashu.activeMintUrl")) {
       this.setTab("mints");
@@ -658,7 +830,7 @@ export default {
       if (!seen) {
         // show receive token dialog
         this.receiveData.tokensBase64 = tokenBase64;
-        this.showReceiveTokens = true;
+        this.$router.push(getWalletOverlayLocation("receiveTokens"));
       }
     }
 

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -3,7 +3,11 @@ const routes = [
     path: "/",
     component: () => import("layouts/MainLayout.vue"),
     children: [
-      { path: "", component: () => import("src/pages/WalletPage.vue") },
+      {
+        path: "",
+        alias: "wallet/:walletOverlay",
+        component: () => import("src/pages/WalletPage.vue"),
+      },
     ],
   },
   {

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -30,6 +30,7 @@ export const useUiStore = defineStore("ui", {
     showSendDialog: false,
     showReceiveDialog: false,
     showReceiveEcashDrawer: false,
+    showMultinutPaymentDialog: false,
     showNumericKeyboard: false,
     activityOrb: false,
     tab: useLocalStorage("cashu.ui.tab", "history" as string),
@@ -49,6 +50,7 @@ export const useUiStore = defineStore("ui", {
       this.showSendDialog = false;
       this.showReceiveDialog = false;
       this.showReceiveEcashDrawer = false;
+      this.showMultinutPaymentDialog = false;
     },
     async lockMutex() {
       const nRetries = 10;


### PR DESCRIPTION
## Summary
- add typed wallet overlay navigation with a shared open helper
- route wallet send/receive, ecash, invoice, payment request, and history detail overlays through URL-backed paths
- keep overlay route mapping covered by tests so browser and Android back navigation can return to the previous wallet screen

## Tests
- npx eslint src/js/overlays.ts src/pages/WalletPage.vue src/components/SendDialog.vue src/components/ReceiveDialog.vue src/components/ReceiveEcashDrawer.vue src/components/HistoryTable.vue src/components/PaymentRequestPayments.vue src/components/CreateInvoiceDialog.vue src/components/NoMintWarnBanner.vue src/js/__tests__/overlays.test.ts
- npx vitest run src/js/__tests__/overlays.test.ts
- npm run test:ci
- npm run build