### PR TITLE
Use ZXing WASM QR scanner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cashu",
       "version": "0.0.1",
       "dependencies": {
+        "@agicash/qr-scanner": "^0.1.2",
         "@capacitor/clipboard": "^6.0.2",
         "@capacitor/core": "^6.2.0",
         "@capacitor/haptics": "^6.0.2",
@@ -29,7 +30,6 @@
         "lucide-vue-next": "^0.453.0",
         "nostr-tools": "^2.5.2",
         "pinia": "^2.1.7",
-        "qr-scanner": "^1.4.2",
         "qrcode": "^1.5.3",
         "quasar": "^2.18.2",
         "underscore": "^1.13.6",
@@ -74,6 +74,15 @@
         "node": ">=22.4.0",
         "npm": ">= 6.13.4",
         "yarn": ">= 1.21.1"
+      }
+    },
+    "node_modules/@agicash/qr-scanner": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@agicash/qr-scanner/-/qr-scanner-0.1.2.tgz",
+      "integrity": "sha512-7qNJoDRqBbHSm12qZ1l0O2JDof0sXNiooebsCXGZOsJpCLBYF9bAJXuy/4Q/jFwbiH0knFZq8myRI5v6IFqpEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zxing-wasm": "2.2.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5406,6 +5415,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "0.0.39",
       "dev": true,
@@ -5508,10 +5523,6 @@
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/offscreencanvas": {
-      "version": "2019.7.3",
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -15545,13 +15556,6 @@
         "teleport": ">=0.2.0"
       }
     },
-    "node_modules/qr-scanner": {
-      "version": "1.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "@types/offscreencanvas": "^2019.6.4"
-      }
-    },
     "node_modules/qrcode": {
       "version": "1.5.3",
       "license": "MIT",
@@ -17581,6 +17585,18 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tar": {
       "version": "6.2.1",
@@ -20015,6 +20031,34 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/zxing-wasm": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-2.2.4.tgz",
+      "integrity": "sha512-1gq5zs4wuNTs5umWLypzNNeuJoluFvwmvjiiT3L9z/TMlVveeJRWy7h90xyUqCe+Qq0zL0w7o5zkdDMWDr9aZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "^1.41.5",
+        "type-fest": "^5.2.0"
+      },
+      "peerDependencies": {
+        "@types/emscripten": ">=1.39.6"
+      }
+    },
+    "node_modules/zxing-wasm/node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
+    "@agicash/qr-scanner": "^0.1.2",
     "@capacitor/clipboard": "^6.0.2",
     "@capacitor/core": "^6.2.0",
     "@capacitor/haptics": "^6.0.2",
@@ -40,7 +41,6 @@
     "lucide-vue-next": "^0.453.0",
     "nostr-tools": "^2.5.2",
     "pinia": "^2.1.7",
-    "qr-scanner": "^1.4.2",
     "qrcode": "^1.5.3",
     "quasar": "^2.18.2",
     "underscore": "^1.13.6",

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -91,6 +91,7 @@ module.exports = configure(function (/* ctx */) {
         viteConf.optimizeDeps = viteConf.optimizeDeps || {};
         viteConf.optimizeDeps.exclude = [
           ...(viteConf.optimizeDeps.exclude || []),
+          "@agicash/qr-scanner",
           "@cashu/cashu-ts",
         ];
       },

--- a/src/components/QrcodeReader.vue
+++ b/src/components/QrcodeReader.vue
@@ -1,9 +1,14 @@
 <script lang="ts">
-import QrScanner from "qr-scanner";
+import QrScanner, { type ScanResult } from "@agicash/qr-scanner";
 import { URDecoder } from "@gandlaf21/bc-ur";
+import zxingReaderWasmUrl from "zxing-wasm/reader/zxing_reader.wasm?url";
 import { useCameraStore } from "src/stores/camera";
-import { mapActions, mapState, mapWritableState } from "pinia";
+import { mapActions, mapState } from "pinia";
 import { useUiStore } from "src/stores/ui";
+
+QrScanner.configureWasm({
+  locateFile: () => zxingReaderWasmUrl,
+});
 
 export default {
   emits: ["decode"],
@@ -21,11 +26,10 @@ export default {
   mounted() {
     this.qrScanner = new QrScanner(
       this.$refs.cameraEl as HTMLVideoElement,
-      (result: QrScanner.ScanResult) => {
+      (result: ScanResult) => {
         this.handleResult(result);
       },
       {
-        returnDetailedScanResult: true,
         highlightScanRegion: true,
         highlightCodeOutline: true,
         onDecodeError: () => {},
@@ -46,7 +50,7 @@ export default {
   },
   methods: {
     ...mapActions(useCameraStore, ["closeCamera", "showCamera"]),
-    handleResult(result: QrScanner.ScanResult) {
+    handleResult(result: ScanResult) {
       // if this is a multipart-qr code, do not yet emit
       if (result.data.toLowerCase().startsWith("ur:")) {
         this.urDecoder?.receivePart(result.data);

--- a/src/components/QrcodeReader.vue
+++ b/src/components/QrcodeReader.vue
@@ -30,7 +30,12 @@ export default {
         this.handleResult(result);
       },
       {
-        highlightScanRegion: true,
+        calculateScanRegion: (video) => ({
+          x: 0,
+          y: 0,
+          width: video.videoWidth,
+          height: video.videoHeight,
+        }),
         highlightCodeOutline: true,
         onDecodeError: () => {},
       }

--- a/types/vite-assets/index.d.ts
+++ b/types/vite-assets/index.d.ts
@@ -1,0 +1,4 @@
+declare module "*.wasm?url" {
+  const url: string;
+  export default url;
+}


### PR DESCRIPTION
## Summary
- replace the QR scanner dependency with @agicash/qr-scanner
- load the ZXing reader WASM through Vite's hashed asset URL instead of a fixed public path
- exclude the scanner package from Vite dep optimization so its worker URL stays intact

## Verification
- npm run lint
- npm run build
- npm run build:pwa