### PR TITLE
Prepare Bolt11 batch quote fallback

### DIFF
--- a/.scratch/nut29-bolt11-batch-checking/PRD.md
+++ b/.scratch/nut29-bolt11-batch-checking/PRD.md
@@ -1,0 +1,118 @@
+# NUT-29 Bolt11 Batch Checking and Batch Minting
+
+Status: ready-for-agent
+
+## Problem Statement
+
+Cashu.me currently checks and mints pending incoming payments one quote at a time in the background. When a wallet has many pending Bolt11 mint quotes, startup and interval-based checking can create unnecessary request churn: each quote may require a separate quote-state request and a separate mint request. Users rarely mint actively; they expect the wallet to receive payments in the background quickly and quietly.
+
+## Solution
+
+Use NUT-29 as an invisible background optimization for the Bolt11 queue in `useInvoicesWorkerStore`. During each interval-based checker tick, Cashu.me should select one compatible mint/unit group of due Bolt11 pending incoming payments, batch quote check as many as allowed by the mint's advertised NUT-29 limit, batch mint the paid subset, and leave unpaid entries queued with normal backoff. Manual checks and websocket-triggered flows keep using the existing single-quote behavior.
+
+## User Stories
+
+1. As a wallet user, I want pending incoming payments to become proofs faster in the background, so that my wallet balance updates without manual work.
+2. As a wallet user, I want background receiving to create fewer mint requests, so that startup and periodic checking are less noisy and more reliable.
+3. As a wallet user, I want the interface to stay the same, so that NUT-29 feels like a performance improvement rather than a new workflow.
+4. As a wallet user, I want manual checks on a single history item to stay immediate and scoped to that item, so that I get predictable feedback.
+5. As a wallet user, I want unpaid pending incoming payments to remain pending after a batch quote check, so that the wallet does not lose track of them.
+6. As a wallet user, I want already-issued Bolt11 quotes to be marked paid locally, so that old pending entries do not linger.
+7. As a wallet user, I want locked mint quotes to be batch minted correctly, so that privacy/security features do not disable the optimization.
+8. As a wallet user, I want a missing signing key to avoid breaking other paid quotes in the same checker tick, so that one bad entry does not block all background receiving.
+9. As a wallet user, I want mints without NUT-29 support to keep working as before, so that receiving remains compatible.
+10. As a wallet user, I want broken NUT-29 mints to fall back to the existing single-quote path, so that payments still arrive.
+11. As a wallet user, I want network and rate-limit problems to avoid extra fallback request bursts, so that degraded connectivity is not made worse.
+12. As a wallet user, I want the wallet to stay quiet during background batch receiving, so that I am not spammed with notifications.
+13. As a wallet user, I want my original incoming payment history dates preserved, so that history remains meaningful.
+14. As a wallet user, I want paid dates to reflect when Cashu.me completed local minting, so that background settlement is visible in history state.
+15. As a maintainer, I want NUT-29 protocol behavior delegated to cashu-ts, so that Cashu.me does not maintain duplicate protocol request logic.
+16. As a maintainer, I want the checker tick to make at most one batch quote check and one batch mint request, so that request volume remains bounded.
+17. As a maintainer, I want batching to prefer the largest compatible due group, so that each checker tick does as much useful work as possible.
+18. As a maintainer, I want batch entries capped by mint-advertised `max_batch_size`, so that predictable batch-size failures are avoided.
+19. As a maintainer, I want oldest due entries selected first when a group exceeds the cap, so that queue behavior is fair.
+20. As a maintainer, I want successful batch quote-check responses validated against request order, so that mint bugs are caught safely.
+21. As a maintainer, I want malformed batch responses to put the mint's batch path into cooldown, so that bad batch behavior does not repeat every interval.
+22. As a maintainer, I want interval-based tests to cover the full worker behavior, so that queue mutation, fallback, and proof persistence are verified together.
+23. As a maintainer, I want single manual checks to remain covered separately, so that background batching does not leak into user-triggered flows.
+
+## Implementation Decisions
+
+- Implement the feature as an invisible optimization in the interval-based incoming payment checker only. Do not add a visible "redeem all" or "batch receive" action.
+- The first implementation is Bolt11-only. Bolt12 and on-chain reusable/delta-based flows are out of scope.
+- Upgrade Cashu.me from the currently pinned `@cashu/cashu-ts` 4.5.x line to a release that exposes the typed Bolt11 batch quote-check API. Use `Wallet.checkMintQuoteBatchBolt11(quotes)` in the wallet path; only use the lower-level mint helper with `customRequest` if the implementation actually needs a custom request function.
+- Use cashu-ts NUT-29 batch mint APIs for batch minting, specifically the `prepareBatchMint("bolt11", entries, config)` and `completeBatchMint(preview)` flow. Do not add app-local NUT-29 HTTP request code.
+- Respect ADR-0001: Cashu protocol request, normalization, auth, and error behavior should remain centralized in cashu-ts.
+- Treat NUT-29 support as advertised by the stored mint info object on `StoredMint.info`. Handle both numeric and string nut keys (`nuts[29]` and `nuts["29"]`). If NUT-29 is present and its optional `methods` list is absent or includes `bolt11`, assume the mint supports Bolt11 batch quote checking and batch minting.
+- If mint info does not advertise NUT-29 Bolt11 support, use the existing single-quote checker.
+- Inside the Bolt11 portion of a checker tick, attempt exactly one single quote or one compatible Bolt11 group. Do not expand the existing Bolt12, on-chain, or outgoing queue behavior in this feature.
+- Pre-filter queued Bolt11 entries before grouping. Drop entries whose invoice is missing, not a pending incoming payment, not positive amount, too old, or not legacy/explicit Bolt11. Use the existing `shouldCheckInvoice(invoice)` and `dueTime(q)` rules where possible.
+- Group eligible due Bolt11 pending incoming payments by mint and unit.
+- Choose the due group with the largest number of entries, capped by mint `max_batch_size`. Break ties by oldest due queue entry, using `lastChecked || addedAt`.
+- When a group exceeds `max_batch_size`, select oldest due entries first, using `lastChecked || addedAt`.
+- If a mint does not advertise `max_batch_size`, rely on cashu-ts's default/internal cap rather than adding an app-specific setting.
+- Send batch quote-check requests in oldest-first order. Successful responses are expected to preserve request order.
+- Assert each successful batch quote-check response matches the requested quote at the same index before any batch minting. Treat mismatch, duplicates, missing quote fields, or wrong response lengths as malformed mint behavior.
+- Batch quote-check success can return mixed `PAID`, `UNPAID`, and `ISSUED` states.
+- Batch mint only `PAID` responses. Do not include unpaid quotes in a batch mint request.
+- Keep `UNPAID` quotes queued and update their queue entry `lastChecked` and `checkCount` as the current single-quote pending path does.
+- Normalize checked quote responses before persistence, matching the current `paymentHistory` amount normalization behavior.
+- Mark `ISSUED` quotes paid locally through `setInvoicePaid(quote, { mintQuote })` and remove them from the Bolt11 checker without attempting to mint them.
+- Do not re-check quotes after a successful batch mint. Use the batch quote-check responses for pre-mint state, then mark minted invoices paid after proofs are persisted.
+- Take the global wallet mutex only for the minting phase. Batch quote check happens outside the mutex.
+- Hold the global wallet mutex across both batch mint preparation and completion.
+- Use the same signed-output retry behavior as single minting by wrapping the full prepare/complete batch mint operation in the existing retry-on-signed-outputs mechanism.
+- Persist batch-minted proofs with the normal `proofsStore.addProofs` insertion path. Do not use missing-proof insertion for the normal fresh mint path.
+- Persist invoice and quote mutations through `usePaymentHistoryStore` (`setPaymentPaid`, `upsertMintQuote`, or equivalent), then sync the wallet's `invoiceHistory` mirror. `invoiceHistory` is no longer the canonical persistence boundary after the rebase.
+- Keep batch-minted proofs untagged by quote, matching current Bolt11 behavior. A batch produces one consolidated output set and cannot cleanly attribute every proof to one quote.
+- Do not persist batch mint previews in this feature. Match current single-mint recovery behavior.
+- Support locked mint quotes. Build a unique signing key set from stored invoice `privKey` values and pass it as `config.privkey` to cashu-ts; cashu-ts matches keys to locked quotes by public key, not by position.
+- If a paid locked mint quote requires a private key and no matching stored private key is available, exclude that quote from batch minting.
+- If a key-missing paid quote is the only paid quote in the tick, use the single-quote path as the tick's mint attempt. If other paid quotes can batch, batch those and leave the key-missing quote queued for later handling.
+- If batch quote check fails for a mint that advertises NUT-29 support, record a separate batch-path cooldown for that mint/unit/method and immediately fall back to one single-quote check for the attempted group unless the failure is network/rate-limit-like. Do not reuse the existing reusable-mint cooldown map, which is mint-only and tuned for Bolt12/on-chain network failures.
+- If batch mint fails after a successful batch quote check, record batch-path cooldown and fall back to one single paid quote only for protocol-like failures. Do not single-fallback for network or rate-limit failures.
+- Batch-path cooldown should apply to advertised NUT-29 failures: network errors, 5xx/429, malformed successful responses, and protocol rejections. Successful batch responses clear the cooldown.
+- While a mint's Bolt11 batch path is in cooldown, the interval checker should use the existing single-quote path for that mint.
+- Background batch behavior should not show user notifications. Keep concise developer logging for batch attempted, paid count, minted count, and fallback reason. Be careful with same-tick fallback through `checkInvoiceBolt11(false)`: the current single-check helper mints silently internally but still has UI side effects after success, so batch fallback must avoid new background notification bursts.
+- Manual user-triggered checks must continue to use the existing single-quote path even if other pending incoming payments are available.
+- Websocket-triggered `PAID` events must continue to use the existing single-quote path. Do not debounce or coalesce websocket events in this feature.
+
+## Testing Decisions
+
+- Test at the interval-based incoming payment checker seam in `src/stores/invoicesWorker.ts`. This is the highest useful seam: it exercises queue selection, batch quote check, batch minting, fallback, cooldown, proof persistence, and payment history mutation together.
+- Prefer existing store tests as prior art. The project already has `src/stores/__tests__/wallet.test.js`, `src/stores/__tests__/invoicesWorker.test.js`, and `src/stores/__tests__/paymentHistory.test.ts` covering pending quote queues, websocket subscriptions, concurrent mint serialization, payment-history mirroring, and subpayment history.
+- Mock the mint wallet/cashu-ts API at the store boundary. Tests should assert externally visible behavior: calls made to batch/single APIs, queue state, `paymentHistory`/`mintQuotes` state, the wallet `invoiceHistory` mirror, proof insertion, cooldown state, and absence of batch calls in manual flows.
+- Add a happy-path test: batch-checks and batch-mints paid Bolt11 quotes for the same mint/unit.
+- Add a mixed-state test: keeps unpaid Bolt11 quotes queued and mints only paid ones.
+- Add an issued-state test: marks issued Bolt11 quotes paid without minting them.
+- Add a request-bound test: processes only one Bolt11 batch group per checker tick.
+- Add a max-batch-size test: caps by mint NUT-29 `max_batch_size` and chooses oldest due entries.
+- Add a locked-quote test: batch-mints locked Bolt11 quotes with the stored batch signing key set and an unlocked quote in the same batch.
+- Add a missing-key test: excludes paid locked Bolt11 quotes without a matching private key from batch minting.
+- Add a batch-check failure fallback test: falls back to one single Bolt11 check and records batch cooldown after advertised batch quote check fails.
+- Add a batch-mint failure fallback test: falls back to one single paid Bolt11 quote after protocol-like batch mint failure.
+- Add a network/rate-limit failure test: does not single-fallback on network or 429-style batch failures.
+- Add an unsupported-mint test: uses the existing single-quote checker when mint info does not advertise NUT-29 Bolt11 support.
+- Add a malformed-check-response test: treats out-of-order, wrong-quote, duplicate, missing, or wrong-length batch quote-check responses as malformed.
+- Add a zero-paid test: stops after one successful batch check when no quotes are paid; unpaid entries back off, issued entries are marked paid, and no second group is attempted.
+- Add a manual-check test: manual `checkInvoiceBolt11` does not use NUT-29 batch APIs.
+
+## Out of Scope
+
+- Visible batch receive, redeem-all, or manual batch actions.
+- Bolt12 batch quote checking or batch minting.
+- On-chain batch quote checking or batch minting.
+- Websocket event coalescing or websocket-based batch minting.
+- Persisted batch mint previews or broader NUT-19 recovery improvements.
+- Per-quote proof attribution for batch-minted proofs.
+- App-local NUT-29 HTTP helper implementation.
+- User-facing settings for batch size or batch enablement.
+- Changes to outgoing payment checking, melting, token sending, or proof-state websocket flows.
+
+## Further Notes
+
+- The feature depends on upgrading from the pinned cashu-ts 4.5.x line to a release exposing `Wallet.checkMintQuoteBatchBolt11(quotes)` and NUT-29 batch mint prepare/complete APIs.
+- NUT-29 batch check and batch mint are both required for this feature's main path because the goal is reducing request churn, not only consolidating outputs.
+- The current single-quote path performs a pre-mint quote check and then mints without a post-mint re-check. The batch path should follow the same pattern at group scope.
+- Batch quote-check responses are expected to preserve request order. Cashu.me should still validate quote IDs defensively and cool down the batch path if a mint violates that contract.
+- The worker's existing background silence should be preserved. Developer logs are acceptable for diagnosis, but background batching should not create user notification bursts.

--- a/.scratch/nut29-bolt11-batch-checking/issues/01-upgrade-cashu-ts-and-preserve-single-quote-fallback.md
+++ b/.scratch/nut29-bolt11-batch-checking/issues/01-upgrade-cashu-ts-and-preserve-single-quote-fallback.md
@@ -1,0 +1,23 @@
+# Upgrade cashu-ts and preserve single-quote fallback
+
+Status: ready-for-agent
+
+## Parent
+
+`.scratch/nut29-bolt11-batch-checking/PRD.md`
+
+## What to build
+
+Cashu.me depends on the cashu-ts version with Bolt11 batch quote-check support, detects whether a stored mint advertises NUT-29 Bolt11 support, adds a separate batch-path cooldown, and keeps the current single-quote checker behavior when batch support is absent or unavailable.
+
+## Acceptance criteria
+
+- [ ] The app depends on a cashu-ts version that exposes `Wallet.checkMintQuoteBatchBolt11(quotes)` plus `prepareBatchMint("bolt11", ...)` and `completeBatchMint(...)`.
+- [ ] NUT-29 support detection treats an absent `methods` list or a list containing `bolt11` as Bolt11 batch-capable.
+- [ ] Mints that do not advertise NUT-29 Bolt11 support use the existing single-quote checker.
+- [ ] Mints in the new mint/unit/method batch cooldown use the existing single-quote checker.
+- [ ] Existing single-quote Bolt11 checker behavior remains covered by tests.
+
+## Blocked by
+
+- None - can start immediately.

--- a/.scratch/nut29-bolt11-batch-checking/issues/02-batch-quote-check-one-due-bolt11-group-per-checker-tick.md
+++ b/.scratch/nut29-bolt11-batch-checking/issues/02-batch-quote-check-one-due-bolt11-group-per-checker-tick.md
@@ -1,0 +1,25 @@
+# Batch quote check one due Bolt11 group per checker tick
+
+Status: ready-for-agent
+
+## Parent
+
+`.scratch/nut29-bolt11-batch-checking/PRD.md`
+
+## What to build
+
+The Bolt11 portion of the interval checker pre-filters due Bolt11 pending incoming payments, selects one compatible mint/unit group per checker tick, and performs one batch quote check that updates unpaid and issued entries without minting.
+
+## Acceptance criteria
+
+- [ ] Only valid due legacy/explicit Bolt11 pending incoming payments are eligible for grouping.
+- [ ] Eligible entries are grouped by mint and unit.
+- [ ] The Bolt11 queue attempts one group only and does not expand Bolt12, on-chain, or outgoing queue behavior.
+- [ ] The selected group maximizes due entries, respects the mint batch size, and chooses oldest due entries first using `lastChecked || addedAt`.
+- [ ] Unpaid responses remain queued with backoff updated.
+- [ ] Checked quote responses are normalized and persisted to `paymentHistory.mintQuotes`.
+- [ ] Issued responses are marked paid through payment history and removed without minting.
+
+## Blocked by
+
+- Upgrade cashu-ts and preserve single-quote fallback.

--- a/.scratch/nut29-bolt11-batch-checking/issues/03-batch-mint-paid-bolt11-quote-checks.md
+++ b/.scratch/nut29-bolt11-batch-checking/issues/03-batch-mint-paid-bolt11-quote-checks.md
@@ -1,0 +1,25 @@
+# Batch mint paid Bolt11 quote checks
+
+Status: ready-for-agent
+
+## Parent
+
+`.scratch/nut29-bolt11-batch-checking/PRD.md`
+
+## What to build
+
+Paid responses from a successful batch quote check are minted in one batch request, proofs are persisted, invoices are marked paid, and the background flow stays silent.
+
+## Acceptance criteria
+
+- [ ] Paid batch quote-check responses are minted through `prepareBatchMint("bolt11", ...)` and `completeBatchMint(...)` in one batch mint request.
+- [ ] The global wallet mutex is held across batch mint preparation and completion.
+- [ ] Signed-output retry behavior matches the current single mint path.
+- [ ] Minted proofs are added through `proofsStore.addProofs` and left untagged by quote.
+- [ ] Minted invoices are marked paid through payment history and removed from the checker after proof persistence.
+- [ ] Background batch minting does not show user notifications.
+
+## Blocked by
+
+- Batch quote check one due Bolt11 group per checker tick.
+- Defend batch response ordering and malformed success cases.

--- a/.scratch/nut29-bolt11-batch-checking/issues/04-support-locked-mint-quotes-in-bolt11-batches.md
+++ b/.scratch/nut29-bolt11-batch-checking/issues/04-support-locked-mint-quotes-in-bolt11-batches.md
@@ -1,0 +1,24 @@
+# Support locked mint quotes in Bolt11 batches
+
+Status: ready-for-agent
+
+## Parent
+
+`.scratch/nut29-bolt11-batch-checking/PRD.md`
+
+## What to build
+
+Batch minting supports locked mint quotes using the stored batch signing key set, including mixed locked/unlocked batches, while avoiding bad-key entries blocking other paid quotes.
+
+## Acceptance criteria
+
+- [ ] Locked paid quotes with matching stored private keys are included in batch minting.
+- [ ] Mixed locked and unlocked paid quotes can mint in the same batch.
+- [ ] The unique batch signing key set from invoice `privKey` values is passed as `config.privkey`, not as quote-order-dependent keys.
+- [ ] Paid locked quotes without matching private keys are excluded from batch minting.
+- [ ] If a key-missing locked quote is the only paid quote, the existing single-quote path is used as the tick's mint attempt.
+- [ ] If other paid quotes can batch, key-missing locked quotes remain queued for later handling.
+
+## Blocked by
+
+- Batch mint paid Bolt11 quote checks.

--- a/.scratch/nut29-bolt11-batch-checking/issues/05-cooldown-and-fallback-for-broken-batch-paths.md
+++ b/.scratch/nut29-bolt11-batch-checking/issues/05-cooldown-and-fallback-for-broken-batch-paths.md
@@ -1,0 +1,25 @@
+# Cooldown and fallback for broken batch paths
+
+Status: ready-for-agent
+
+## Parent
+
+`.scratch/nut29-bolt11-batch-checking/PRD.md`
+
+## What to build
+
+Advertised-but-broken NUT-29 batch behavior enters a separate mint/unit/method batch cooldown and falls back conservatively, preserving reliability without creating request bursts.
+
+## Acceptance criteria
+
+- [ ] Batch quote-check failures for advertised NUT-29 support record batch cooldown.
+- [ ] Batch mint failures after a successful batch quote check record batch cooldown.
+- [ ] Protocol-like batch failures fall back to exactly one single-quote attempt in the same checker tick.
+- [ ] Network and rate-limit failures do not trigger single-quote fallback in the same checker tick.
+- [ ] Successful batch responses clear the batch cooldown.
+- [ ] While cooldown is active, the interval checker uses the existing single-quote path for that mint/unit/method.
+- [ ] Batch cooldown does not reuse `reusableMintCooldowns`, which is mint-only and scoped to reusable Bolt12/on-chain failures.
+
+## Blocked by
+
+- Batch mint paid Bolt11 quote checks.

--- a/.scratch/nut29-bolt11-batch-checking/issues/06-defend-batch-response-ordering-and-malformed-success-cases.md
+++ b/.scratch/nut29-bolt11-batch-checking/issues/06-defend-batch-response-ordering-and-malformed-success-cases.md
@@ -1,0 +1,23 @@
+# Defend batch response ordering and malformed success cases
+
+Status: ready-for-agent
+
+## Parent
+
+`.scratch/nut29-bolt11-batch-checking/PRD.md`
+
+## What to build
+
+Successful batch quote-check responses are defensively validated against request order, and malformed success responses are handled as broken batch behavior.
+
+## Acceptance criteria
+
+- [ ] Response count must match request count.
+- [ ] Each response quote must match the requested quote at the same index.
+- [ ] Duplicate, missing, or wrong quote identifiers are treated as malformed.
+- [ ] Malformed responses prevent batch minting.
+- [ ] Malformed responses are surfaced through the same batch-failure path that the cooldown/fallback slice handles.
+
+## Blocked by
+
+- Batch quote check one due Bolt11 group per checker tick.

--- a/.scratch/nut29-bolt11-batch-checking/issues/07-protect-non-batch-entry-points.md
+++ b/.scratch/nut29-bolt11-batch-checking/issues/07-protect-non-batch-entry-points.md
@@ -1,0 +1,22 @@
+# Protect non-batch entry points
+
+Status: ready-for-agent
+
+## Parent
+
+`.scratch/nut29-bolt11-batch-checking/PRD.md`
+
+## What to build
+
+Manual checks and websocket-triggered paid events remain single-quote flows, so background batching does not change user-triggered behavior.
+
+## Acceptance criteria
+
+- [ ] Manual Bolt11 checks do not call NUT-29 batch APIs.
+- [ ] Websocket-triggered Bolt11 paid events do not call NUT-29 batch APIs.
+- [ ] Existing manual and websocket single-quote success behavior remains intact.
+- [ ] Background batch tests do not require changes to manual user flows.
+
+## Blocked by
+
+- Batch mint paid Bolt11 quote checks.

--- a/.scratch/nut29-bolt11-batch-checking/tickets.md
+++ b/.scratch/nut29-bolt11-batch-checking/tickets.md
@@ -1,0 +1,94 @@
+# Tickets: NUT-29 Bolt11 Batch Checking
+
+Build invisible NUT-29 batch quote checking and batch minting for interval-based Bolt11 pending incoming payments. Source spec: `./PRD.md`.
+
+Work the **frontier**: any ticket whose blockers are all done. Validation must land before paid batch responses are minted; after tickets 1, 2, and 6 are done, tickets 3, 4, 5, and 7 can proceed as their blockers allow.
+
+## Upgrade cashu-ts and preserve single-quote fallback
+
+**What to build:** Cashu.me depends on the cashu-ts version with Bolt11 batch quote-check support, detects whether a stored mint advertises NUT-29 Bolt11 support, adds a separate batch-path cooldown, and keeps the current single-quote checker behavior when batch support is absent or unavailable.
+
+**Blocked by:** None - can start immediately.
+
+- [ ] The app depends on a cashu-ts version that exposes `Wallet.checkMintQuoteBatchBolt11(quotes)` plus `prepareBatchMint("bolt11", ...)` and `completeBatchMint(...)`.
+- [ ] NUT-29 support detection treats an absent `methods` list or a list containing `bolt11` as Bolt11 batch-capable.
+- [ ] Mints that do not advertise NUT-29 Bolt11 support use the existing single-quote checker.
+- [ ] Mints in the new mint/unit/method batch cooldown use the existing single-quote checker.
+- [ ] Existing single-quote Bolt11 checker behavior remains covered by tests.
+
+## Batch quote check one due Bolt11 group per checker tick
+
+**What to build:** The Bolt11 portion of the interval checker pre-filters due Bolt11 pending incoming payments, selects one compatible mint/unit group per checker tick, and performs one batch quote check that updates unpaid and issued entries without minting.
+
+**Blocked by:** Upgrade cashu-ts and preserve single-quote fallback.
+
+- [ ] Only valid due legacy/explicit Bolt11 pending incoming payments are eligible for grouping.
+- [ ] Eligible entries are grouped by mint and unit.
+- [ ] The Bolt11 queue attempts one group only and does not expand Bolt12, on-chain, or outgoing queue behavior.
+- [ ] The selected group maximizes due entries, respects the mint batch size, and chooses oldest due entries first using `lastChecked || addedAt`.
+- [ ] Unpaid responses remain queued with backoff updated.
+- [ ] Checked quote responses are normalized and persisted to `paymentHistory.mintQuotes`.
+- [ ] Issued responses are marked paid through payment history and removed without minting.
+
+## Batch mint paid Bolt11 quote checks
+
+**What to build:** Paid responses from a successful batch quote check are minted in one batch request, proofs are persisted, invoices are marked paid, and the background flow stays silent.
+
+**Blocked by:** Batch quote check one due Bolt11 group per checker tick; Defend batch response ordering and malformed success cases.
+
+- [ ] Paid batch quote-check responses are minted through `prepareBatchMint("bolt11", ...)` and `completeBatchMint(...)` in one batch mint request.
+- [ ] The global wallet mutex is held across batch mint preparation and completion.
+- [ ] Signed-output retry behavior matches the current single mint path.
+- [ ] Minted proofs are added through `proofsStore.addProofs` and left untagged by quote.
+- [ ] Minted invoices are marked paid through payment history and removed from the checker after proof persistence.
+- [ ] Background batch minting does not show user notifications.
+
+## Support locked mint quotes in Bolt11 batches
+
+**What to build:** Batch minting supports locked mint quotes using the stored batch signing key set, including mixed locked/unlocked batches, while avoiding bad-key entries blocking other paid quotes.
+
+**Blocked by:** Batch mint paid Bolt11 quote checks.
+
+- [ ] Locked paid quotes with matching stored private keys are included in batch minting.
+- [ ] Mixed locked and unlocked paid quotes can mint in the same batch.
+- [ ] The unique batch signing key set from invoice `privKey` values is passed as `config.privkey`, not as quote-order-dependent keys.
+- [ ] Paid locked quotes without matching private keys are excluded from batch minting.
+- [ ] If a key-missing locked quote is the only paid quote, the existing single-quote path is used as the tick's mint attempt.
+- [ ] If other paid quotes can batch, key-missing locked quotes remain queued for later handling.
+
+## Cooldown and fallback for broken batch paths
+
+**What to build:** Advertised-but-broken NUT-29 batch behavior enters a separate mint/unit/method batch cooldown and falls back conservatively, preserving reliability without creating request bursts.
+
+**Blocked by:** Batch mint paid Bolt11 quote checks.
+
+- [ ] Batch quote-check failures for advertised NUT-29 support record batch cooldown.
+- [ ] Batch mint failures after a successful batch quote check record batch cooldown.
+- [ ] Protocol-like batch failures fall back to exactly one single-quote attempt in the same checker tick.
+- [ ] Network and rate-limit failures do not trigger single-quote fallback in the same checker tick.
+- [ ] Successful batch responses clear the batch cooldown.
+- [ ] While cooldown is active, the interval checker uses the existing single-quote path for that mint/unit/method.
+- [ ] Batch cooldown does not reuse `reusableMintCooldowns`, which is mint-only and scoped to reusable Bolt12/on-chain failures.
+
+## Defend batch response ordering and malformed success cases
+
+**What to build:** Successful batch quote-check responses are defensively validated against request order, and malformed success responses are handled as broken batch behavior.
+
+**Blocked by:** Batch quote check one due Bolt11 group per checker tick.
+
+- [ ] Response count must match request count.
+- [ ] Each response quote must match the requested quote at the same index.
+- [ ] Duplicate, missing, or wrong quote identifiers are treated as malformed.
+- [ ] Malformed responses prevent batch minting.
+- [ ] Malformed responses are surfaced through the same batch-failure path that the cooldown/fallback slice handles.
+
+## Protect non-batch entry points
+
+**What to build:** Manual checks and websocket-triggered paid events remain single-quote flows, so background batching does not change user-triggered behavior.
+
+**Blocked by:** Batch mint paid Bolt11 quote checks.
+
+- [ ] Manual Bolt11 checks do not call NUT-29 batch APIs.
+- [ ] Websocket-triggered Bolt11 paid events do not call NUT-29 batch APIs.
+- [ ] Existing manual and websocket single-quote success behavior remains intact.
+- [ ] Background batch tests do not require changes to manual user flows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,3 +163,17 @@ npm test -- src/path/to/test.ts
 - **Platform:** Use `this.getPwaDisplayMode()` to detect environment (Web vs PWA vs App).
 - **Assets:** Import icons from `lucide-vue-next` as `XIcon` (e.g., `import { Home as HomeIcon } from "lucide-vue-next"`).
 - **Reactivity:** Be careful with deep reactivity in Pinia state; use `storeToRefs` if destructuring in Composition API (though Options API is preferred here).
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked as local markdown files under `.scratch/<feature-slug>/`; external PRs are not a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The repo uses the default five-label triage vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This repo uses a single-context domain docs layout. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,29 @@
+# Cashu.me Wallet
+
+Cashu.me is a wallet context for receiving, storing, and spending Cashu ecash proofs across connected mints.
+
+## Language
+
+**Pending incoming payment**:
+An incoming payment request that has been created but has not yet resulted in local spendable proofs.
+_Avoid_: Pending invoice, unredeemed payment
+
+**Batch minting**:
+Minting proofs for multiple compatible paid mint quotes in one mint request as a background optimization.
+_Avoid_: Redeem all, bulk claim
+
+**Batch quote check**:
+Checking the payment state of multiple compatible mint quotes in one mint request as a background optimization. Successful responses preserve request order.
+_Avoid_: Multi-check, quote scan
+
+**Locked mint quote**:
+A mint quote whose minted outputs must be authorized by a private key corresponding to the quote's public key.
+_Avoid_: Protected invoice, signed invoice
+
+**Batch signing key set**:
+The private keys supplied to authorize any locked mint quotes in a batch. The keys are matched to locked quotes by public key rather than by position.
+_Avoid_: Ordered signing keys, key list
+
+**Checker tick**:
+One scheduled run of the background incoming payment checker. A Bolt11 batch checker tick should perform at most one batch quote check and one batch mint request.
+_Avoid_: Poll cycle, interval pass

--- a/docs/adr/0001-use-cashu-ts-for-nut29-batch-quote-checks.md
+++ b/docs/adr/0001-use-cashu-ts-for-nut29-batch-quote-checks.md
@@ -1,0 +1,3 @@
+# Use cashu-ts for NUT-29 batch quote checks
+
+Cashu.me will implement Bolt11 batch quote checking through a `@cashu/cashu-ts` release that exposes `Wallet.checkMintQuoteBatchBolt11(quotes)` and the NUT-29 `prepareBatchMint`/`completeBatchMint` flow, rather than adding local NUT-29 HTTP request code. This keeps Cashu protocol request, normalization, auth, and error behavior centralized in the wallet library; mints without NUT-29 support still fall back at runtime to the existing single-quote checker.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists - it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** - read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+|-- CONTEXT.md
+|-- docs/adr/
+|   |-- 0001-event-sourced-orders.md
+|   `-- 0002-postgres-for-write-model.md
+`-- src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+|-- CONTEXT-MAP.md
+|-- docs/adr/                          <- system-wide decisions
+`-- src/
+    |-- ordering/
+    |   |-- CONTEXT.md
+    |   `-- docs/adr/                  <- context-specific decisions
+    `-- billing/
+        |-- CONTEXT.md
+        `-- docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal - either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) - but worth reopening because..._

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,19 @@
+# Issue tracker: Local Markdown
+
+Issues and PRDs for this repo live as markdown files in `.scratch/`.
+
+## Conventions
+
+- One feature per directory: `.scratch/<feature-slug>/`
+- The PRD is `.scratch/<feature-slug>/PRD.md`
+- Implementation issues are `.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01`
+- Triage state is recorded as a `Status:` line near the top of each issue file (see `triage-labels.md` for the role strings)
+- Comments and conversation history append to the bottom of the file under a `## Comments` heading
+
+## When a skill says "publish to the issue tracker"
+
+Create a new file under `.scratch/<feature-slug>/` (creating the directory if needed).
+
+## When a skill says "fetch the relevant ticket"
+
+Read the file at the referenced path. The user will normally pass the path or the issue number directly.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@capacitor/clipboard": "^6.0.2",
         "@capacitor/core": "^6.2.0",
         "@capacitor/haptics": "^6.0.2",
-        "@cashu/cashu-ts": "^4.5.0",
+        "@cashu/cashu-ts": "^4.7.0",
         "@chenfengyuan/vue-qrcode": "^2.0.0",
         "@gandlaf21/bc-ur": "^1.1.12",
         "@nostr-dev-kit/ndk": "^2.8.1",
@@ -1963,9 +1963,9 @@
       }
     },
     "node_modules/@cashu/cashu-ts": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-4.5.0.tgz",
-      "integrity": "sha512-NoUOitUMaxzmA3k4qLozZyFM1qonBdNB2ZM55U45X9SwFIQovRDttVDFL6Dn39q3H8v6pUTYxOHeUKdAmY/V/g==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-4.7.0.tgz",
+      "integrity": "sha512-u/R9nHCBFugQeTKf1NCZscKp6Zblo3ubX8mFA0Ar8+lpGaHSndWmsQUsSQ7vrNGmdGtqOTMiR7hErEqVCVOY+A==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@capacitor/clipboard": "^6.0.2",
     "@capacitor/core": "^6.2.0",
     "@capacitor/haptics": "^6.0.2",
-    "@cashu/cashu-ts": "^4.5.0",
+    "@cashu/cashu-ts": "^4.7.0",
     "@chenfengyuan/vue-qrcode": "^2.0.0",
     "@gandlaf21/bc-ur": "^1.1.12",
     "@nostr-dev-kit/ndk": "^2.8.1",

--- a/src/stores/__tests__/invoicesWorker.test.js
+++ b/src/stores/__tests__/invoicesWorker.test.js
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
+import { useMintsStore } from "src/stores/mints";
 import { PaymentMethod } from "src/stores/walletTypes";
 
 describe("invoices worker", () => {
@@ -11,8 +12,10 @@ describe("invoices worker", () => {
     worker.onchainQuotes = [];
     worker.outgoingPayments = [];
     worker.reusableMintCooldowns = {};
+    worker.bolt11BatchCooldowns = {};
     worker.lastInvoiceCheckTime = 0;
     worker.lastOutgoingCheckTime = 0;
+    useMintsStore().mints = [];
   });
 
   it("does not reset reusable quote backoff when re-queueing an existing quote", () => {
@@ -50,6 +53,222 @@ describe("invoices worker", () => {
     expect(startSpy).toHaveBeenCalledWith(true);
     expect(worker.quotes.map((q) => q.quote)).toContain("bolt11-q");
     expect(worker.bolt12Quotes.map((q) => q.quote)).toContain("bolt12-q");
+  });
+
+  it("detects advertised NUT-29 Bolt11 batch support", () => {
+    const worker = useInvoicesWorkerStore();
+
+    expect(
+      worker.mintSupportsNut29Bolt11Batch({
+        url: "https://mint.example",
+        info: { nuts: { 29: {} } },
+      })
+    ).toBe(true);
+    expect(
+      worker.mintSupportsNut29Bolt11Batch({
+        url: "https://mint.example",
+        info: { nuts: { 29: { methods: ["bolt11"] } } },
+      })
+    ).toBe(true);
+    expect(
+      worker.mintSupportsNut29Bolt11Batch({
+        url: "https://mint.example",
+        info: { nuts: { 29: { methods: [{ method: "bolt11" }] } } },
+      })
+    ).toBe(true);
+    expect(
+      worker.mintSupportsNut29Bolt11Batch({
+        url: "https://mint.example",
+        info: { nuts: { 29: { methods: ["bolt12"] } } },
+      })
+    ).toBe(false);
+    expect(
+      worker.mintSupportsNut29Bolt11Batch({
+        url: "https://mint.example",
+        info: { nuts: {} },
+      })
+    ).toBe(false);
+  });
+
+  it("scopes Bolt11 batch cooldowns by mint, unit, and method", () => {
+    const worker = useInvoicesWorkerStore();
+    const now = Date.now();
+
+    worker.recordBolt11BatchFailure(
+      "https://mint.example",
+      "sat",
+      new Error("batch unavailable"),
+      now
+    );
+
+    expect(
+      worker.bolt11BatchInCooldown("https://mint.example", "sat", now + 1)
+    ).toBe(true);
+    expect(
+      worker.bolt11BatchInCooldown("https://mint.example", "usd", now + 1)
+    ).toBe(false);
+    expect(
+      worker.bolt11BatchCooldowns[
+        worker.bolt11BatchCooldownKey("https://mint.example", "sat", "bolt11")
+      ]
+    ).toEqual(
+      expect.objectContaining({
+        failedAt: now,
+        failureCount: 1,
+        lastError: "batch unavailable",
+      })
+    );
+  });
+
+  it("uses the existing single Bolt11 checker when NUT-29 Bolt11 is not advertised", async () => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const now = Date.now();
+    worker.lastInvoiceCheckTime = 0;
+    worker.quotes = [
+      {
+        quote: "bolt11-q",
+        addedAt: now - 1_000,
+        lastChecked: 0,
+        checkCount: 0,
+      },
+    ];
+    mintStore.mints = [
+      {
+        url: "https://mint.example",
+        info: { nuts: { 29: { methods: ["bolt12"] } } },
+        keysets: [],
+        keys: [],
+      },
+    ];
+
+    const walletStore = {
+      invoiceHistory: [
+        {
+          quote: "bolt11-q",
+          amount: 21,
+          date: new Date(now).toISOString(),
+          status: "pending",
+          mint: "https://mint.example",
+          unit: "sat",
+          type: PaymentMethod.Bolt11,
+        },
+      ],
+      checkInvoiceBolt11: vi.fn(),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(
+      worker.canUseBolt11BatchPath(walletStore.invoiceHistory[0], now)
+    ).toBe(false);
+    expect(walletStore.checkInvoiceBolt11).toHaveBeenCalledWith(
+      "bolt11-q",
+      false
+    );
+    expect(worker.quotes).toEqual([]);
+  });
+
+  it("uses the existing single Bolt11 checker while the mint/unit/method batch path is in cooldown", async () => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const now = Date.now();
+    worker.lastInvoiceCheckTime = 0;
+    worker.quotes = [
+      {
+        quote: "bolt11-q",
+        addedAt: now - 1_000,
+        lastChecked: 0,
+        checkCount: 0,
+      },
+    ];
+    mintStore.mints = [
+      {
+        url: "https://mint.example",
+        info: { nuts: { 29: {} } },
+        keysets: [],
+        keys: [],
+      },
+    ];
+    worker.bolt11BatchCooldowns = {
+      [worker.bolt11BatchCooldownKey("https://mint.example", "sat")]: {
+        failedAt: now - 1_000,
+        failureCount: 1,
+        nextRetryAt: now + 60_000,
+      },
+    };
+
+    const walletStore = {
+      invoiceHistory: [
+        {
+          quote: "bolt11-q",
+          amount: 21,
+          date: new Date(now).toISOString(),
+          status: "pending",
+          mint: "https://mint.example",
+          unit: "sat",
+          type: PaymentMethod.Bolt11,
+        },
+      ],
+      checkInvoiceBolt11: vi.fn(),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(
+      worker.canUseBolt11BatchPath(walletStore.invoiceHistory[0], now)
+    ).toBe(false);
+    expect(walletStore.checkInvoiceBolt11).toHaveBeenCalledWith(
+      "bolt11-q",
+      false
+    );
+    expect(worker.quotes).toEqual([]);
+  });
+
+  it("preserves existing single Bolt11 checker backoff when a due invoice remains pending", async () => {
+    const worker = useInvoicesWorkerStore();
+    const now = Date.now();
+    worker.lastInvoiceCheckTime = 0;
+    worker.quotes = [
+      {
+        quote: "bolt11-q",
+        addedAt: now - 1_000,
+        lastChecked: 0,
+        checkCount: 0,
+      },
+    ];
+
+    const walletStore = {
+      invoiceHistory: [
+        {
+          quote: "bolt11-q",
+          amount: 21,
+          date: new Date(now).toISOString(),
+          status: "pending",
+          mint: "https://mint.example",
+          unit: "sat",
+          type: PaymentMethod.Bolt11,
+        },
+      ],
+      checkInvoiceBolt11: vi.fn(async () => {
+        throw new Error("invoice state not paid: UNPAID");
+      }),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(walletStore.checkInvoiceBolt11).toHaveBeenCalledWith(
+      "bolt11-q",
+      false
+    );
+    expect(worker.quotes).toEqual([
+      {
+        quote: "bolt11-q",
+        addedAt: now - 1_000,
+        lastChecked: now,
+        checkCount: 1,
+      },
+    ]);
   });
 
   it("skips reusable quote checks while the quote mint is in cooldown", async () => {

--- a/src/stores/invoicesWorker.ts
+++ b/src/stores/invoicesWorker.ts
@@ -4,6 +4,7 @@ import { useLocalStorage } from "@vueuse/core";
 import { useSettingsStore } from "./settings";
 import { PaymentMethod } from "src/stores/walletTypes";
 import { useTokensStore } from "./tokens";
+import { useMintsStore, type StoredMint } from "src/stores/mints";
 interface InvoiceQuote {
   quote: string;
   addedAt: number;
@@ -57,6 +58,9 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
       reusableMintCooldowns: useLocalStorage<
         Record<string, ReusableMintCooldown>
       >("cashu.worker.invoices.reusableMintCooldowns", {}),
+      bolt11BatchCooldowns: useLocalStorage<
+        Record<string, ReusableMintCooldown>
+      >("cashu.worker.invoices.bolt11BatchCooldowns", {}),
       outgoingPayments: useLocalStorage<OutgoingPaymentCheck[]>(
         "cashu.worker.outgoing.queue",
         []
@@ -227,6 +231,96 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
       const cooldown = this.reusableMintCooldowns[mintUrl];
       return Boolean(cooldown && cooldown.nextRetryAt > now);
     },
+    bolt11BatchCooldownKey(
+      mintUrl: string,
+      unit: string,
+      method = PaymentMethod.Bolt11
+    ) {
+      return `${mintUrl}|${unit}|${method}`;
+    },
+    bolt11BatchInCooldown(
+      mintUrl: string,
+      unit: string,
+      now: number,
+      method = PaymentMethod.Bolt11
+    ) {
+      const cooldown =
+        this.bolt11BatchCooldowns[
+          this.bolt11BatchCooldownKey(mintUrl, unit, method)
+        ];
+      return Boolean(cooldown && cooldown.nextRetryAt > now);
+    },
+    clearBolt11BatchCooldown(
+      mintUrl: string,
+      unit: string,
+      method = PaymentMethod.Bolt11
+    ) {
+      const key = this.bolt11BatchCooldownKey(mintUrl, unit, method);
+      if (this.bolt11BatchCooldowns[key]) {
+        delete this.bolt11BatchCooldowns[key];
+      }
+    },
+    recordBolt11BatchFailure(
+      mintUrl: string,
+      unit: string,
+      error: any,
+      now: number,
+      method = PaymentMethod.Bolt11
+    ) {
+      const key = this.bolt11BatchCooldownKey(mintUrl, unit, method);
+      const previous = this.bolt11BatchCooldowns[key];
+      const failureCount = (previous?.failureCount ?? 0) + 1;
+      const retryDelay = Math.min(
+        this.reusableMintCooldownBaseInterval *
+          Math.pow(2, Math.max(0, failureCount - 1)),
+        this.oneHour
+      );
+      this.bolt11BatchCooldowns[key] = {
+        failedAt: now,
+        failureCount,
+        nextRetryAt: now + retryDelay,
+        lastError: this.errorMessage(error),
+      };
+    },
+    mintSupportsNut29Bolt11Batch(mint: StoredMint | undefined | null) {
+      const nuts = mint?.info?.nuts as Record<string | number, any> | undefined;
+      const nut29 = nuts?.[29] || nuts?.["29"];
+      if (!nut29) return false;
+      if (typeof nut29 !== "object") return false;
+      if (!("methods" in nut29) || nut29.methods == null) return true;
+      if (!Array.isArray(nut29.methods)) return false;
+      return nut29.methods.some((method: any) => {
+        if (typeof method === "string") {
+          return method === PaymentMethod.Bolt11;
+        }
+        return method?.method === PaymentMethod.Bolt11;
+      });
+    },
+    storedMintForInvoice(invoice: any) {
+      return useMintsStore().mints.find((mint) => mint.url === invoice?.mint);
+    },
+    canUseBolt11BatchPath(invoice: any, now: number) {
+      if (!invoice?.mint || !invoice?.unit) return false;
+      const mint = this.storedMintForInvoice(invoice);
+      return (
+        this.mintSupportsNut29Bolt11Batch(mint) &&
+        !this.bolt11BatchInCooldown(invoice.mint, invoice.unit, now)
+      );
+    },
+    async checkSingleBolt11Quote(
+      walletStore: any,
+      q: InvoiceQuote,
+      index: number,
+      now: number
+    ) {
+      try {
+        await walletStore.checkInvoiceBolt11(q.quote, false);
+        this.quotes.splice(index, 1);
+      } catch (error) {
+        q.lastChecked = now;
+        q.checkCount += 1;
+      }
+    },
     clearReusableMintCooldown(mintUrl: string) {
       if (this.reusableMintCooldowns[mintUrl]) {
         delete this.reusableMintCooldowns[mintUrl];
@@ -364,13 +458,7 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
 
         const dueTime = this.dueTime(q);
         if (now > dueTime) {
-          try {
-            await walletStore.checkInvoiceBolt11(q.quote, false);
-            this.quotes.splice(i, 1);
-          } catch (error) {
-            q.lastChecked = now;
-            q.checkCount += 1;
-          }
+          await this.checkSingleBolt11Quote(walletStore, q, i, now);
           this.lastInvoiceCheckTime = now;
           break;
         }


### PR DESCRIPTION
## Slice

Implements `.scratch/nut29-bolt11-batch-checking/issues/01-upgrade-cashu-ts-and-preserve-single-quote-fallback.md` from parent PRD `.scratch/nut29-bolt11-batch-checking/PRD.md`.

## Summary

- Upgrades `@cashu/cashu-ts` to a version exposing Bolt11 batch quote-check and batch mint APIs.
- Adds NUT-29 Bolt11 capability detection from stored mint info.
- Adds a separate mint/unit/method Bolt11 batch cooldown map.
- Extracts the existing single Bolt11 checker path so unsupported or cooled-down batch paths continue using current behavior.

## Validation

- `npm test -- --run src/stores/__tests__/invoicesWorker.test.js`
- `npm run lint -- src/stores/invoicesWorker.ts src/stores/__tests__/invoicesWorker.test.js`
- `git diff --check 85b39c855854c42951d338f5b64c3196300b70a4..b8054d537d1569249bceed45d69f4e788fc43d60`

## Notes

Plain `npx tsc --noEmit` still fails on existing repo-wide type/declaration issues; this slice also exposes `cashu-ts@4.7.0` declarations that require newer generic `Uint8Array` library types. No local project typecheck script was added or changed in this slice.
