### PR TITLE
Add NUT-29 Bolt11 batch checking and minting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@capacitor/clipboard": "^6.0.2",
         "@capacitor/core": "^6.2.0",
         "@capacitor/haptics": "^6.0.2",
-        "@cashu/cashu-ts": "^4.6.0",
+        "@cashu/cashu-ts": "^4.7.0",
         "@chenfengyuan/vue-qrcode": "^2.0.0",
         "@gandlaf21/bc-ur": "^1.1.12",
         "@nostr-dev-kit/ndk": "^2.8.1",
@@ -1963,9 +1963,9 @@
       }
     },
     "node_modules/@cashu/cashu-ts": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-4.6.0.tgz",
-      "integrity": "sha512-B0XG662h53ZBTKFnVdTVXyK5GwNC5QDkZqbXu6Bl0SduCc6GV90+h9f3SI/bLDxMKFVk/aFs00LeSUCj4JknKg==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-4.7.0.tgz",
+      "integrity": "sha512-u/R9nHCBFugQeTKf1NCZscKp6Zblo3ubX8mFA0Ar8+lpGaHSndWmsQUsSQ7vrNGmdGtqOTMiR7hErEqVCVOY+A==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@capacitor/clipboard": "^6.0.2",
     "@capacitor/core": "^6.2.0",
     "@capacitor/haptics": "^6.0.2",
-    "@cashu/cashu-ts": "^4.6.0",
+    "@cashu/cashu-ts": "^4.7.0",
     "@chenfengyuan/vue-qrcode": "^2.0.0",
     "@gandlaf21/bc-ur": "^1.1.12",
     "@nostr-dev-kit/ndk": "^2.8.1",

--- a/src/stores/__tests__/invoicesWorker.test.js
+++ b/src/stores/__tests__/invoicesWorker.test.js
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
 import { useMintsStore } from "src/stores/mints";
 import { usePaymentHistoryStore } from "src/stores/paymentHistory";
+import { useProofsStore } from "src/stores/proofs";
+import { useUiStore } from "src/stores/ui";
 import { PaymentMethod } from "src/stores/walletTypes";
 
 function pendingInvoice(quote, overrides = {}) {
@@ -180,6 +182,103 @@ describe("invoices worker", () => {
       })
     );
     expect(walletStore.syncPaymentHistoryCache).toHaveBeenCalled();
+  });
+
+  it("batch-mints only paid responses before marking their invoices paid", async () => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const paymentHistoryStore = usePaymentHistoryStore();
+    const proofsStore = useProofsStore();
+    const uiStore = useUiStore();
+    const now = Date.now();
+    advertiseBatchMint(mintStore, "https://mint.example");
+    mintStore.mints[0].keysets = [{ id: "00aa", unit: "sat", active: true }];
+    worker.quotes = [
+      queuedQuote("paid-q", now - 20_000),
+      queuedQuote("unpaid-q", now - 10_000),
+    ];
+    const invoices = [pendingInvoice("paid-q"), pendingInvoice("unpaid-q")];
+    const paidResponse = {
+      quote: "paid-q",
+      amount: "10",
+      state: "PAID",
+      request: "lnbc-paid",
+      unit: "sat",
+    };
+    const unpaidResponse = {
+      quote: "unpaid-q",
+      amount: "10",
+      state: "UNPAID",
+      request: "lnbc-unpaid",
+      unit: "sat",
+    };
+    const preview = { keysetId: "00aa", quotes: [paidResponse] };
+    const proofs = [{ id: "00aa", amount: 10, secret: "batch-proof" }];
+    const checkMintQuoteBatchBolt11 = vi.fn(async () => [
+      paidResponse,
+      unpaidResponse,
+    ]);
+    const prepareBatchMint = vi.fn(async () => preview);
+    const completeBatchMint = vi.fn(async () => {
+      expect(uiStore.unlockMutex).not.toHaveBeenCalled();
+      return proofs;
+    });
+    vi.spyOn(paymentHistoryStore, "upsertMintQuote").mockResolvedValue();
+    const addProofs = vi.spyOn(proofsStore, "addProofs").mockResolvedValue();
+    vi.spyOn(uiStore, "lockMutex").mockResolvedValue();
+    vi.spyOn(uiStore, "unlockMutex").mockImplementation(() => {});
+    const setInvoicePaid = vi.fn(async (quote) => {
+      expect(addProofs).toHaveBeenCalledWith(proofs);
+      invoices.find((invoice) => invoice.quote === quote).status = "paid";
+    });
+    const retryOnceOnSignedOutputs = vi.fn(
+      async (_keysetId, operation) => await operation()
+    );
+    const walletStore = {
+      invoiceHistory: invoices,
+      mintWallet: vi.fn(async () => ({
+        checkMintQuoteBatchBolt11,
+        prepareBatchMint,
+        completeBatchMint,
+      })),
+      getKeyset: vi.fn(() => "00aa"),
+      retryOnceOnSignedOutputs,
+      checkInvoiceBolt11: vi.fn(),
+      setInvoicePaid,
+      syncPaymentHistoryCache: vi.fn(),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(prepareBatchMint).toHaveBeenCalledWith(
+      PaymentMethod.Bolt11,
+      [
+        {
+          amount: 10,
+          quote: expect.objectContaining({ quote: "paid-q", state: "PAID" }),
+        },
+      ],
+      { keysetId: "00aa", proofsWeHave: [] }
+    );
+    expect(completeBatchMint).toHaveBeenCalledWith(preview);
+    expect(retryOnceOnSignedOutputs).toHaveBeenCalledWith(
+      "00aa",
+      expect.any(Function),
+      false
+    );
+    expect(uiStore.lockMutex).toHaveBeenCalledOnce();
+    expect(uiStore.unlockMutex).toHaveBeenCalledOnce();
+    expect(addProofs).toHaveBeenCalledWith(proofs);
+    expect(setInvoicePaid).toHaveBeenCalledTimes(1);
+    expect(setInvoicePaid).toHaveBeenCalledWith(
+      "paid-q",
+      expect.objectContaining({
+        mintQuote: expect.objectContaining({ quote: "paid-q" }),
+      })
+    );
+    expect(worker.quotes).toEqual([
+      expect.objectContaining({ quote: "unpaid-q", checkCount: 1 }),
+    ]);
   });
 
   it("selects the largest due group, capped and ordered by oldest queue entry", async () => {

--- a/src/stores/__tests__/invoicesWorker.test.js
+++ b/src/stores/__tests__/invoicesWorker.test.js
@@ -52,7 +52,7 @@ describe("invoices worker", () => {
 
   it.each([
     [{ nuts: { 29: {} } }, true],
-    [{ nuts: { "29": { methods: ["bolt11"] } } }, true],
+    [{ nuts: { 29: { methods: ["bolt11"] } } }, true],
     [{ nuts: { 29: { methods: ["bolt12"] } } }, false],
     [{ nuts: {} }, false],
   ])("detects advertised Bolt11 batch support", (info, expected) => {
@@ -239,6 +239,58 @@ describe("invoices worker", () => {
     expect(worker.quotes.map((entry) => entry.quote)).not.toContain(
       "wrong-method"
     );
+  });
+
+  it.each([
+    ["wrong response length", [{ quote: "first-q", state: "UNPAID" }]],
+    [
+      "out-of-order quote IDs",
+      [
+        { quote: "second-q", state: "UNPAID" },
+        { quote: "first-q", state: "UNPAID" },
+      ],
+    ],
+    [
+      "duplicate quote IDs",
+      [
+        { quote: "first-q", state: "UNPAID" },
+        { quote: "first-q", state: "UNPAID" },
+      ],
+    ],
+    [
+      "missing quote ID",
+      [{ quote: "first-q", state: "UNPAID" }, { state: "UNPAID" }],
+    ],
+  ])("rejects malformed batch success: %s", async (_case, responses) => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const paymentHistoryStore = usePaymentHistoryStore();
+    const now = Date.now();
+    advertiseBatchMint(mintStore, "https://mint.example");
+    worker.quotes = [
+      queuedQuote("first-q", now - 20_000),
+      queuedQuote("second-q", now - 10_000),
+    ];
+    const upsertMintQuote = vi
+      .spyOn(paymentHistoryStore, "upsertMintQuote")
+      .mockResolvedValue();
+    const checkMintQuoteBatchBolt11 = vi.fn(async () => responses);
+    const walletStore = {
+      invoiceHistory: [pendingInvoice("first-q"), pendingInvoice("second-q")],
+      mintWallet: vi.fn(async () => ({ checkMintQuoteBatchBolt11 })),
+      checkInvoiceBolt11: vi.fn(),
+      setInvoicePaid: vi.fn(),
+      syncPaymentHistoryCache: vi.fn(),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(upsertMintQuote).not.toHaveBeenCalled();
+    expect(walletStore.setInvoicePaid).not.toHaveBeenCalled();
+    expect(worker.quotes).toEqual([
+      expect.objectContaining({ quote: "first-q", checkCount: 1 }),
+      expect.objectContaining({ quote: "second-q", checkCount: 1 }),
+    ]);
   });
 
   it("does not reset reusable quote backoff when re-queueing an existing quote", () => {

--- a/src/stores/__tests__/invoicesWorker.test.js
+++ b/src/stores/__tests__/invoicesWorker.test.js
@@ -281,6 +281,195 @@ describe("invoices worker", () => {
     ]);
   });
 
+  it("batch-mints mixed locked and unlocked quotes with a unique signing key set", async () => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const paymentHistoryStore = usePaymentHistoryStore();
+    const proofsStore = useProofsStore();
+    const uiStore = useUiStore();
+    const now = Date.now();
+    const privKey = "0".repeat(63) + "1";
+    const pubkey =
+      "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+    advertiseBatchMint(mintStore, "https://mint.example");
+    mintStore.mints[0].keysets = [{ id: "00aa", unit: "sat", active: true }];
+    worker.quotes = [
+      queuedQuote("locked-q", now - 20_000),
+      queuedQuote("open-q", now - 10_000),
+    ];
+    const responses = [
+      {
+        quote: "locked-q",
+        amount: 10,
+        state: "PAID",
+        request: "lnbc-locked",
+        unit: "sat",
+        pubkey,
+      },
+      {
+        quote: "open-q",
+        amount: 10,
+        state: "PAID",
+        request: "lnbc-open",
+        unit: "sat",
+      },
+    ];
+    const prepareBatchMint = vi.fn(async () => ({ keysetId: "00aa" }));
+    const completeBatchMint = vi.fn(async () => []);
+    vi.spyOn(paymentHistoryStore, "upsertMintQuote").mockResolvedValue();
+    vi.spyOn(proofsStore, "addProofs").mockResolvedValue();
+    vi.spyOn(uiStore, "lockMutex").mockResolvedValue();
+    vi.spyOn(uiStore, "unlockMutex").mockImplementation(() => {});
+    const walletStore = {
+      invoiceHistory: [
+        pendingInvoice("locked-q", { privKey }),
+        pendingInvoice("open-q"),
+      ],
+      mintWallet: vi.fn(async () => ({
+        checkMintQuoteBatchBolt11: vi.fn(async () => responses),
+        prepareBatchMint,
+        completeBatchMint,
+      })),
+      getKeyset: vi.fn(() => "00aa"),
+      retryOnceOnSignedOutputs: vi.fn(
+        async (_keysetId, operation) => await operation()
+      ),
+      checkInvoiceBolt11: vi.fn(),
+      setInvoicePaid: vi.fn(),
+      syncPaymentHistoryCache: vi.fn(),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(prepareBatchMint).toHaveBeenCalledWith(
+      PaymentMethod.Bolt11,
+      [
+        {
+          amount: 10,
+          quote: expect.objectContaining({ quote: "locked-q", pubkey }),
+        },
+        {
+          amount: 10,
+          quote: expect.objectContaining({ quote: "open-q" }),
+        },
+      ],
+      { keysetId: "00aa", proofsWeHave: [], privkey: [privKey] }
+    );
+  });
+
+  it("excludes a key-missing locked quote while batch-minting other paid quotes", async () => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const paymentHistoryStore = usePaymentHistoryStore();
+    const proofsStore = useProofsStore();
+    const uiStore = useUiStore();
+    const now = Date.now();
+    advertiseBatchMint(mintStore, "https://mint.example");
+    mintStore.mints[0].keysets = [{ id: "00aa", unit: "sat", active: true }];
+    worker.quotes = [
+      queuedQuote("missing-key-q", now - 20_000),
+      queuedQuote("open-q", now - 10_000),
+    ];
+    const responses = [
+      {
+        quote: "missing-key-q",
+        amount: 10,
+        state: "PAID",
+        request: "lnbc-locked",
+        unit: "sat",
+        pubkey:
+          "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+      },
+      {
+        quote: "open-q",
+        amount: 10,
+        state: "PAID",
+        request: "lnbc-open",
+        unit: "sat",
+      },
+    ];
+    const prepareBatchMint = vi.fn(async () => ({ keysetId: "00aa" }));
+    vi.spyOn(paymentHistoryStore, "upsertMintQuote").mockResolvedValue();
+    vi.spyOn(proofsStore, "addProofs").mockResolvedValue();
+    vi.spyOn(uiStore, "lockMutex").mockResolvedValue();
+    vi.spyOn(uiStore, "unlockMutex").mockImplementation(() => {});
+    const walletStore = {
+      invoiceHistory: [
+        pendingInvoice("missing-key-q"),
+        pendingInvoice("open-q"),
+      ],
+      mintWallet: vi.fn(async () => ({
+        checkMintQuoteBatchBolt11: vi.fn(async () => responses),
+        prepareBatchMint,
+        completeBatchMint: vi.fn(async () => []),
+      })),
+      getKeyset: vi.fn(() => "00aa"),
+      retryOnceOnSignedOutputs: vi.fn(
+        async (_keysetId, operation) => await operation()
+      ),
+      checkInvoiceBolt11: vi.fn(),
+      setInvoicePaid: vi.fn(),
+      syncPaymentHistoryCache: vi.fn(),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(prepareBatchMint).toHaveBeenCalledWith(
+      PaymentMethod.Bolt11,
+      [
+        {
+          amount: 10,
+          quote: expect.objectContaining({ quote: "open-q" }),
+        },
+      ],
+      { keysetId: "00aa", proofsWeHave: [] }
+    );
+    expect(walletStore.checkInvoiceBolt11).not.toHaveBeenCalled();
+    expect(worker.quotes).toEqual([
+      expect.objectContaining({ quote: "missing-key-q", checkCount: 1 }),
+    ]);
+  });
+
+  it("uses one single-quote attempt when every paid locked quote lacks its key", async () => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const paymentHistoryStore = usePaymentHistoryStore();
+    const now = Date.now();
+    advertiseBatchMint(mintStore, "https://mint.example");
+    worker.quotes = [queuedQuote("missing-key-q", now - 20_000)];
+    const prepareBatchMint = vi.fn();
+    vi.spyOn(paymentHistoryStore, "upsertMintQuote").mockResolvedValue();
+    const walletStore = {
+      invoiceHistory: [pendingInvoice("missing-key-q")],
+      mintWallet: vi.fn(async () => ({
+        checkMintQuoteBatchBolt11: vi.fn(async () => [
+          {
+            quote: "missing-key-q",
+            amount: 10,
+            state: "PAID",
+            request: "lnbc-locked",
+            unit: "sat",
+            pubkey:
+              "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+          },
+        ]),
+        prepareBatchMint,
+      })),
+      checkInvoiceBolt11: vi.fn(async () => {}),
+      setInvoicePaid: vi.fn(),
+      syncPaymentHistoryCache: vi.fn(),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(prepareBatchMint).not.toHaveBeenCalled();
+    expect(walletStore.checkInvoiceBolt11).toHaveBeenCalledOnce();
+    expect(walletStore.checkInvoiceBolt11).toHaveBeenCalledWith(
+      "missing-key-q",
+      false
+    );
+  });
+
   it("selects the largest due group, capped and ordered by oldest queue entry", async () => {
     const worker = useInvoicesWorkerStore();
     const mintStore = useMintsStore();

--- a/src/stores/__tests__/invoicesWorker.test.js
+++ b/src/stores/__tests__/invoicesWorker.test.js
@@ -1,7 +1,40 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
 import { useMintsStore } from "src/stores/mints";
+import { usePaymentHistoryStore } from "src/stores/paymentHistory";
 import { PaymentMethod } from "src/stores/walletTypes";
+
+function pendingInvoice(quote, overrides = {}) {
+  return {
+    quote,
+    amount: 10,
+    date: new Date().toISOString(),
+    status: "pending",
+    mint: "https://mint.example",
+    unit: "sat",
+    type: PaymentMethod.Bolt11,
+    ...overrides,
+  };
+}
+
+function queuedQuote(quote, addedAt, overrides = {}) {
+  return {
+    quote,
+    addedAt,
+    lastChecked: 0,
+    checkCount: 0,
+    ...overrides,
+  };
+}
+
+function advertiseBatchMint(mintStore, url, params = {}) {
+  mintStore.mints.push({
+    url,
+    keys: [],
+    keysets: [],
+    info: { nuts: { 29: params } },
+  });
+}
 
 describe("invoices worker", () => {
   beforeEach(() => {
@@ -75,6 +108,136 @@ describe("invoices worker", () => {
     expect(walletStore.checkInvoiceBolt11).toHaveBeenCalledWith(
       "bolt11-q",
       false
+    );
+  });
+
+  it("batch-checks one due Bolt11 group and persists unpaid and issued states", async () => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const paymentHistoryStore = usePaymentHistoryStore();
+    const now = Date.now();
+    advertiseBatchMint(mintStore, "https://mint.example");
+    worker.quotes = [
+      queuedQuote("unpaid-q", now - 20_000),
+      queuedQuote("issued-q", now - 10_000),
+    ];
+    const invoices = [pendingInvoice("unpaid-q"), pendingInvoice("issued-q")];
+    const batchResponses = [
+      {
+        quote: "unpaid-q",
+        amount: "10",
+        state: "UNPAID",
+        request: "lnbc-unpaid",
+        unit: "sat",
+      },
+      {
+        quote: "issued-q",
+        amount: "10",
+        state: "ISSUED",
+        request: "lnbc-issued",
+        unit: "sat",
+      },
+    ];
+    const checkMintQuoteBatchBolt11 = vi.fn(async () => batchResponses);
+    const upsertMintQuote = vi
+      .spyOn(paymentHistoryStore, "upsertMintQuote")
+      .mockResolvedValue();
+    const walletStore = {
+      invoiceHistory: invoices,
+      mintWallet: vi.fn(async () => ({ checkMintQuoteBatchBolt11 })),
+      checkInvoiceBolt11: vi.fn(),
+      setInvoicePaid: vi.fn(async (quote, { mintQuote }) => {
+        const invoice = invoices.find((item) => item.quote === quote);
+        invoice.status = "paid";
+        invoice.mintQuote = mintQuote;
+      }),
+      syncPaymentHistoryCache: vi.fn(),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(checkMintQuoteBatchBolt11).toHaveBeenCalledWith([
+      "unpaid-q",
+      "issued-q",
+    ]);
+    expect(walletStore.checkInvoiceBolt11).not.toHaveBeenCalled();
+    expect(upsertMintQuote).toHaveBeenCalledTimes(2);
+    expect(upsertMintQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ quote: "unpaid-q", amount: 10 }),
+      PaymentMethod.Bolt11
+    );
+    expect(worker.quotes).toEqual([
+      expect.objectContaining({
+        quote: "unpaid-q",
+        lastChecked: now,
+        checkCount: 1,
+      }),
+    ]);
+    expect(walletStore.setInvoicePaid).toHaveBeenCalledWith(
+      "issued-q",
+      expect.objectContaining({
+        mintQuote: expect.objectContaining({ state: "ISSUED", amount: 10 }),
+      })
+    );
+    expect(walletStore.syncPaymentHistoryCache).toHaveBeenCalled();
+  });
+
+  it("selects the largest due group, capped and ordered by oldest queue entry", async () => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const paymentHistoryStore = usePaymentHistoryStore();
+    const now = Date.now();
+    advertiseBatchMint(mintStore, "https://mint-a.example", {
+      max_batch_size: 2,
+    });
+    advertiseBatchMint(mintStore, "https://mint-b.example");
+    vi.spyOn(paymentHistoryStore, "upsertMintQuote").mockResolvedValue();
+    worker.quotes = [
+      queuedQuote("a-new", now - 10_000),
+      queuedQuote("a-old", now - 30_000),
+      queuedQuote("a-middle", now - 20_000),
+      queuedQuote("b-one", now - 15_000),
+      queuedQuote("not-due", now, { lastChecked: now }),
+      queuedQuote("wrong-method", now - 40_000),
+    ];
+    const invoices = [
+      pendingInvoice("a-new", { mint: "https://mint-a.example" }),
+      pendingInvoice("a-old", { mint: "https://mint-a.example" }),
+      pendingInvoice("a-middle", { mint: "https://mint-a.example" }),
+      pendingInvoice("b-one", { mint: "https://mint-b.example" }),
+      pendingInvoice("not-due", { mint: "https://mint-a.example" }),
+      pendingInvoice("wrong-method", { type: PaymentMethod.Bolt12 }),
+    ];
+    const checkMintQuoteBatchBolt11 = vi.fn(async (quotes) =>
+      quotes.map((quote) => ({
+        quote,
+        amount: 10,
+        state: "UNPAID",
+        request: `lnbc-${quote}`,
+        unit: "sat",
+      }))
+    );
+    const walletStore = {
+      invoiceHistory: invoices,
+      mintWallet: vi.fn(async () => ({ checkMintQuoteBatchBolt11 })),
+      checkInvoiceBolt11: vi.fn(),
+      syncPaymentHistoryCache: vi.fn(),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(walletStore.mintWallet).toHaveBeenCalledTimes(1);
+    expect(walletStore.mintWallet).toHaveBeenCalledWith(
+      "https://mint-a.example",
+      "sat"
+    );
+    expect(checkMintQuoteBatchBolt11).toHaveBeenCalledOnce();
+    expect(checkMintQuoteBatchBolt11).toHaveBeenCalledWith([
+      "a-old",
+      "a-middle",
+    ]);
+    expect(worker.quotes.map((entry) => entry.quote)).not.toContain(
+      "wrong-method"
     );
   });
 

--- a/src/stores/__tests__/invoicesWorker.test.js
+++ b/src/stores/__tests__/invoicesWorker.test.js
@@ -470,6 +470,173 @@ describe("invoices worker", () => {
     );
   });
 
+  it("records cooldown and falls back once after a protocol batch-check failure", async () => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const now = Date.now();
+    advertiseBatchMint(mintStore, "https://mint.example");
+    worker.quotes = [
+      queuedQuote("first-q", now - 20_000),
+      queuedQuote("second-q", now - 10_000),
+    ];
+    const walletStore = {
+      invoiceHistory: [pendingInvoice("first-q"), pendingInvoice("second-q")],
+      mintWallet: vi.fn(async () => ({
+        checkMintQuoteBatchBolt11: vi.fn(async () => {
+          throw new Error("batch endpoint rejected request");
+        }),
+      })),
+      checkInvoiceBolt11: vi.fn(async () => {}),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(walletStore.checkInvoiceBolt11).toHaveBeenCalledOnce();
+    expect(walletStore.checkInvoiceBolt11).toHaveBeenCalledWith(
+      "first-q",
+      false
+    );
+    expect(
+      worker.batchPathCooldowns["https://mint.example|sat|bolt11"]
+    ).toEqual(
+      expect.objectContaining({
+        failedAt: now,
+        failureCount: 1,
+        lastError: "batch endpoint rejected request",
+      })
+    );
+    expect(worker.quotes).toEqual([
+      expect.objectContaining({ quote: "second-q", checkCount: 1 }),
+    ]);
+  });
+
+  it("records cooldown without single fallback after a rate-limit batch failure", async () => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const now = Date.now();
+    advertiseBatchMint(mintStore, "https://mint.example");
+    worker.quotes = [
+      queuedQuote("first-q", now - 20_000),
+      queuedQuote("second-q", now - 10_000),
+    ];
+    const rateLimitError = Object.assign(new Error("too many requests"), {
+      status: 429,
+    });
+    const walletStore = {
+      invoiceHistory: [pendingInvoice("first-q"), pendingInvoice("second-q")],
+      mintWallet: vi.fn(async () => ({
+        checkMintQuoteBatchBolt11: vi.fn(async () => {
+          throw rateLimitError;
+        }),
+      })),
+      checkInvoiceBolt11: vi.fn(),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(walletStore.checkInvoiceBolt11).not.toHaveBeenCalled();
+    expect(
+      worker.batchPathCooldowns["https://mint.example|sat|bolt11"]
+    ).toEqual(expect.objectContaining({ failedAt: now, failureCount: 1 }));
+    expect(worker.quotes.every((entry) => entry.checkCount === 1)).toBe(true);
+  });
+
+  it("falls back to one paid quote after a protocol batch-mint failure", async () => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const paymentHistoryStore = usePaymentHistoryStore();
+    const proofsStore = useProofsStore();
+    const uiStore = useUiStore();
+    const now = Date.now();
+    advertiseBatchMint(mintStore, "https://mint.example");
+    mintStore.mints[0].keysets = [{ id: "00aa", unit: "sat", active: true }];
+    worker.quotes = [
+      queuedQuote("first-q", now - 20_000),
+      queuedQuote("second-q", now - 10_000),
+    ];
+    vi.spyOn(paymentHistoryStore, "upsertMintQuote").mockResolvedValue();
+    const addProofs = vi.spyOn(proofsStore, "addProofs").mockResolvedValue();
+    vi.spyOn(uiStore, "lockMutex").mockResolvedValue();
+    vi.spyOn(uiStore, "unlockMutex").mockImplementation(() => {});
+    const responses = ["first-q", "second-q"].map((quote) => ({
+      quote,
+      amount: 10,
+      state: "PAID",
+      request: `lnbc-${quote}`,
+      unit: "sat",
+    }));
+    const walletStore = {
+      invoiceHistory: [pendingInvoice("first-q"), pendingInvoice("second-q")],
+      mintWallet: vi.fn(async () => ({
+        checkMintQuoteBatchBolt11: vi.fn(async () => responses),
+        prepareBatchMint: vi.fn(async () => {
+          throw new Error("batch mint rejected");
+        }),
+      })),
+      getKeyset: vi.fn(() => "00aa"),
+      retryOnceOnSignedOutputs: vi.fn(
+        async (_keysetId, operation) => await operation()
+      ),
+      checkInvoiceBolt11: vi.fn(async () => {}),
+      syncPaymentHistoryCache: vi.fn(),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(addProofs).not.toHaveBeenCalled();
+    expect(uiStore.unlockMutex).toHaveBeenCalledOnce();
+    expect(walletStore.checkInvoiceBolt11).toHaveBeenCalledOnce();
+    expect(walletStore.checkInvoiceBolt11).toHaveBeenCalledWith(
+      "first-q",
+      false
+    );
+    expect(
+      worker.batchPathCooldowns["https://mint.example|sat|bolt11"]
+    ).toEqual(
+      expect.objectContaining({
+        failedAt: now,
+        lastError: "batch mint rejected",
+      })
+    );
+  });
+
+  it("clears an expired batch cooldown after a valid batch response", async () => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const paymentHistoryStore = usePaymentHistoryStore();
+    const now = Date.now();
+    advertiseBatchMint(mintStore, "https://mint.example");
+    worker.batchPathCooldowns = {
+      "https://mint.example|sat|bolt11": {
+        failedAt: now - 120_000,
+        failureCount: 2,
+        nextRetryAt: now - 1,
+      },
+    };
+    worker.quotes = [queuedQuote("unpaid-q", now - 20_000)];
+    vi.spyOn(paymentHistoryStore, "upsertMintQuote").mockResolvedValue();
+    const walletStore = {
+      invoiceHistory: [pendingInvoice("unpaid-q")],
+      mintWallet: vi.fn(async () => ({
+        checkMintQuoteBatchBolt11: vi.fn(async () => [
+          {
+            quote: "unpaid-q",
+            amount: 10,
+            state: "UNPAID",
+            request: "lnbc-unpaid",
+            unit: "sat",
+          },
+        ]),
+      })),
+      checkInvoiceBolt11: vi.fn(),
+      syncPaymentHistoryCache: vi.fn(),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(worker.batchPathCooldowns).toEqual({});
+  });
+
   it("selects the largest due group, capped and ordered by oldest queue entry", async () => {
     const worker = useInvoicesWorkerStore();
     const mintStore = useMintsStore();
@@ -508,7 +675,9 @@ describe("invoices worker", () => {
     const walletStore = {
       invoiceHistory: invoices,
       mintWallet: vi.fn(async () => ({ checkMintQuoteBatchBolt11 })),
-      checkInvoiceBolt11: vi.fn(),
+      checkInvoiceBolt11: vi.fn(async () => {
+        throw new Error("invoice still pending");
+      }),
       syncPaymentHistoryCache: vi.fn(),
     };
 
@@ -566,7 +735,9 @@ describe("invoices worker", () => {
     const walletStore = {
       invoiceHistory: [pendingInvoice("first-q"), pendingInvoice("second-q")],
       mintWallet: vi.fn(async () => ({ checkMintQuoteBatchBolt11 })),
-      checkInvoiceBolt11: vi.fn(),
+      checkInvoiceBolt11: vi.fn(async () => {
+        throw new Error("invoice still pending");
+      }),
       setInvoicePaid: vi.fn(),
       syncPaymentHistoryCache: vi.fn(),
     };
@@ -575,6 +746,10 @@ describe("invoices worker", () => {
 
     expect(upsertMintQuote).not.toHaveBeenCalled();
     expect(walletStore.setInvoicePaid).not.toHaveBeenCalled();
+    expect(walletStore.checkInvoiceBolt11).toHaveBeenCalledOnce();
+    expect(
+      worker.batchPathCooldowns["https://mint.example|sat|bolt11"]
+    ).toEqual(expect.objectContaining({ failedAt: now, failureCount: 1 }));
     expect(worker.quotes).toEqual([
       expect.objectContaining({ quote: "first-q", checkCount: 1 }),
       expect.objectContaining({ quote: "second-q", checkCount: 1 }),

--- a/src/stores/__tests__/invoicesWorker.test.js
+++ b/src/stores/__tests__/invoicesWorker.test.js
@@ -1,9 +1,11 @@
+import "fake-indexeddb/auto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
 import { useMintsStore } from "src/stores/mints";
 import { usePaymentHistoryStore } from "src/stores/paymentHistory";
 import { useProofsStore } from "src/stores/proofs";
 import { useUiStore } from "src/stores/ui";
+import { cashuDb } from "src/stores/dexie";
 import { PaymentMethod } from "src/stores/walletTypes";
 
 function pendingInvoice(quote, overrides = {}) {
@@ -83,9 +85,15 @@ describe("invoices worker", () => {
         info: { nuts: {} },
       },
     ];
-    worker.quotes = [queuedQuote("unsupported-q", now - 10_000)];
+    worker.quotes = [
+      queuedQuote("unsupported-older-q", now - 20_000),
+      queuedQuote("unsupported-newer-q", now - 10_000),
+    ];
     const walletStore = {
-      invoiceHistory: [pendingInvoice("unsupported-q")],
+      invoiceHistory: [
+        pendingInvoice("unsupported-older-q"),
+        pendingInvoice("unsupported-newer-q"),
+      ],
       mintWallet: vi.fn(),
       checkInvoiceBolt11: vi.fn(async () => {}),
     };
@@ -94,7 +102,7 @@ describe("invoices worker", () => {
 
     expect(walletStore.mintWallet).not.toHaveBeenCalled();
     expect(walletStore.checkInvoiceBolt11).toHaveBeenCalledWith(
-      "unsupported-q",
+      "unsupported-newer-q",
       false
     );
   });
@@ -315,6 +323,127 @@ describe("invoices worker", () => {
     expect(worker.quotes).toEqual([
       expect.objectContaining({ quote: "unpaid-q", checkCount: 1 }),
     ]);
+  });
+
+  it("persists batch quote state and mirrors paid history without changing original dates", async () => {
+    await cashuDb.paymentHistory.clear();
+    await cashuDb.mintQuotes.clear();
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const paymentHistoryStore = usePaymentHistoryStore();
+    const proofsStore = useProofsStore();
+    const uiStore = useUiStore();
+    const now = Date.now();
+    const originalDate = new Date(now - 60_000).toISOString();
+    const invoices = [
+      pendingInvoice("paid-q", {
+        date: originalDate,
+        request: "lnbc-paid",
+        memo: "paid",
+      }),
+      pendingInvoice("unpaid-q", {
+        date: originalDate,
+        request: "lnbc-unpaid",
+        memo: "unpaid",
+      }),
+    ];
+    for (const invoice of invoices) {
+      await paymentHistoryStore.addPayment(invoice);
+    }
+    advertiseBatchMint(mintStore, "https://mint.example");
+    mintStore.mints[0].keysets = [{ id: "00aa", unit: "sat", active: true }];
+    worker.quotes = [
+      queuedQuote("paid-q", now - 20_000),
+      queuedQuote("unpaid-q", now - 10_000),
+    ];
+    const responses = [
+      {
+        quote: "paid-q",
+        amount: "10",
+        state: "PAID",
+        request: "lnbc-paid",
+        unit: "sat",
+      },
+      {
+        quote: "unpaid-q",
+        amount: "10",
+        state: "UNPAID",
+        request: "lnbc-unpaid",
+        unit: "sat",
+      },
+    ];
+    const proofs = [{ id: "00aa", amount: 10, secret: "persisted-proof" }];
+    const addProofs = vi.spyOn(proofsStore, "addProofs").mockResolvedValue();
+    vi.spyOn(uiStore, "lockMutex").mockResolvedValue();
+    vi.spyOn(uiStore, "unlockMutex").mockImplementation(() => {});
+    const syncPaymentHistoryCache = vi.fn(() => {
+      walletStore.invoiceHistory = paymentHistoryStore.invoiceHistory.map(
+        (invoice) => ({ ...invoice })
+      );
+    });
+    const setInvoicePaid = vi.fn(async (quote, { mintQuote }) => {
+      await paymentHistoryStore.setPaymentPaid(quote, { mintQuote });
+      syncPaymentHistoryCache();
+    });
+    const walletStore = {
+      invoiceHistory: paymentHistoryStore.invoiceHistory.map((invoice) => ({
+        ...invoice,
+      })),
+      mintWallet: vi.fn(async () => ({
+        checkMintQuoteBatchBolt11: vi.fn(async () => responses),
+        prepareBatchMint: vi.fn(async () => ({ keysetId: "00aa" })),
+        completeBatchMint: vi.fn(async () => proofs),
+      })),
+      getKeyset: vi.fn(() => "00aa"),
+      retryOnceOnSignedOutputs: vi.fn(
+        async (_keysetId, operation) => await operation()
+      ),
+      checkInvoiceBolt11: vi.fn(),
+      setInvoicePaid,
+      syncPaymentHistoryCache,
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(addProofs).toHaveBeenCalledWith(proofs);
+    expect(paymentHistoryStore.mintQuotes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ quote: "paid-q", amount: 10, state: "PAID" }),
+        expect.objectContaining({
+          quote: "unpaid-q",
+          amount: 10,
+          state: "UNPAID",
+        }),
+      ])
+    );
+    expect(
+      paymentHistoryStore.paymentHistory.find(
+        (payment) => payment.quote === "paid-q"
+      )
+    ).toEqual(
+      expect.objectContaining({
+        status: "paid",
+        date: originalDate,
+        paidDate: expect.any(String),
+      })
+    );
+    expect(
+      paymentHistoryStore.paymentHistory.find(
+        (payment) => payment.quote === "unpaid-q"
+      )
+    ).toEqual(
+      expect.objectContaining({ status: "pending", date: originalDate })
+    );
+    expect(walletStore.invoiceHistory).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          quote: "paid-q",
+          status: "paid",
+          date: originalDate,
+          paidDate: expect.any(String),
+        }),
+      ])
+    );
   });
 
   it("batch-mints mixed locked and unlocked quotes with a unique signing key set", async () => {

--- a/src/stores/__tests__/invoicesWorker.test.js
+++ b/src/stores/__tests__/invoicesWorker.test.js
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
+import { useMintsStore } from "src/stores/mints";
 import { PaymentMethod } from "src/stores/walletTypes";
 
 describe("invoices worker", () => {
@@ -11,8 +12,70 @@ describe("invoices worker", () => {
     worker.onchainQuotes = [];
     worker.outgoingPayments = [];
     worker.reusableMintCooldowns = {};
+    worker.batchPathCooldowns = {};
     worker.lastInvoiceCheckTime = 0;
     worker.lastOutgoingCheckTime = 0;
+  });
+
+  it.each([
+    [{ nuts: { 29: {} } }, true],
+    [{ nuts: { "29": { methods: ["bolt11"] } } }, true],
+    [{ nuts: { 29: { methods: ["bolt12"] } } }, false],
+    [{ nuts: {} }, false],
+  ])("detects advertised Bolt11 batch support", (info, expected) => {
+    const worker = useInvoicesWorkerStore();
+
+    expect(worker.mintSupportsBolt11Batch({ info })).toBe(expected);
+  });
+
+  it("uses the single-quote checker while an advertised batch path is cooling down", async () => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const now = Date.now();
+    mintStore.mints = [
+      {
+        url: "https://mint.example",
+        keys: [],
+        keysets: [],
+        info: { nuts: { 29: { methods: ["bolt11"] } } },
+      },
+    ];
+    worker.quotes = [
+      {
+        quote: "bolt11-q",
+        addedAt: now - 10_000,
+        lastChecked: 0,
+        checkCount: 0,
+      },
+    ];
+    worker.batchPathCooldowns = {
+      "https://mint.example|sat|bolt11": {
+        failedAt: now - 1_000,
+        failureCount: 1,
+        nextRetryAt: now + 60_000,
+      },
+    };
+    const walletStore = {
+      invoiceHistory: [
+        {
+          quote: "bolt11-q",
+          amount: 10,
+          date: new Date(now).toISOString(),
+          status: "pending",
+          mint: "https://mint.example",
+          unit: "sat",
+          type: PaymentMethod.Bolt11,
+        },
+      ],
+      checkInvoiceBolt11: vi.fn(async () => {}),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(walletStore.checkInvoiceBolt11).toHaveBeenCalledWith(
+      "bolt11-q",
+      false
+    );
   });
 
   it("does not reset reusable quote backoff when re-queueing an existing quote", () => {

--- a/src/stores/__tests__/invoicesWorker.test.js
+++ b/src/stores/__tests__/invoicesWorker.test.js
@@ -63,6 +63,42 @@ describe("invoices worker", () => {
     expect(worker.mintSupportsBolt11Batch({ info })).toBe(expected);
   });
 
+  it("uses cashu-ts's normalized batch cap when the mint omits one", () => {
+    const worker = useInvoicesWorkerStore();
+
+    expect(worker.bolt11BatchSizeLimit({ info: { nuts: { 29: {} } } })).toBe(
+      100
+    );
+  });
+
+  it("uses the single-quote checker for a mint without NUT-29 support", async () => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const now = Date.now();
+    mintStore.mints = [
+      {
+        url: "https://mint.example",
+        keys: [],
+        keysets: [],
+        info: { nuts: {} },
+      },
+    ];
+    worker.quotes = [queuedQuote("unsupported-q", now - 10_000)];
+    const walletStore = {
+      invoiceHistory: [pendingInvoice("unsupported-q")],
+      mintWallet: vi.fn(),
+      checkInvoiceBolt11: vi.fn(async () => {}),
+    };
+
+    await worker.processIncomingQueues(now, walletStore);
+
+    expect(walletStore.mintWallet).not.toHaveBeenCalled();
+    expect(walletStore.checkInvoiceBolt11).toHaveBeenCalledWith(
+      "unsupported-q",
+      false
+    );
+  });
+
   it("uses the single-quote checker while an advertised batch path is cooling down", async () => {
     const worker = useInvoicesWorkerStore();
     const mintStore = useMintsStore();

--- a/src/stores/__tests__/wallet.test.js
+++ b/src/stores/__tests__/wallet.test.js
@@ -313,6 +313,9 @@ function mockMintWebsocket(unit = "sat") {
       webSocketConnection: connection,
     },
     unit,
+    checkMintQuoteBatchBolt11: vi.fn(),
+    prepareBatchMint: vi.fn(),
+    completeBatchMint: vi.fn(),
   };
   return {
     connection,
@@ -466,6 +469,77 @@ describe("wallet store", () => {
 
     expect(wallet.invoiceHistory[0].amount).toBe(0);
     expect(wallet.invoiceData.amount).toBe(0);
+  });
+
+  it("keeps manual Bolt11 checks on the single-quote path", async () => {
+    const wallet = useWalletStore();
+    const invoice = {
+      quote: "manual-q",
+      amount: 10,
+      request: "lnbc-manual",
+      memo: "manual",
+      date: "old",
+      status: "pending",
+      mint: "https://mint-a.example",
+      unit: "sat",
+      type: PaymentMethod.Bolt11,
+    };
+    wallet.invoiceHistory = [invoice];
+    const checkMintQuoteBolt11 = vi.fn(async () => ({ state: "PAID" }));
+    const checkMintQuoteBatchBolt11 = vi.fn();
+    const prepareBatchMint = vi.fn();
+    const completeBatchMint = vi.fn();
+    vi.spyOn(wallet, "mintWallet").mockResolvedValue({
+      checkMintQuoteBolt11,
+      checkMintQuoteBatchBolt11,
+      prepareBatchMint,
+      completeBatchMint,
+    });
+    vi.spyOn(wallet, "mintBolt11").mockResolvedValue([
+      { id: "00aa", amount: 10, secret: "manual-proof" },
+    ]);
+
+    await wallet.checkInvoiceBolt11("manual-q");
+
+    expect(checkMintQuoteBolt11).toHaveBeenCalledWith("manual-q");
+    expect(checkMintQuoteBatchBolt11).not.toHaveBeenCalled();
+    expect(prepareBatchMint).not.toHaveBeenCalled();
+    expect(completeBatchMint).not.toHaveBeenCalled();
+    expect(wallet.mintBolt11).toHaveBeenCalledWith(invoice, true);
+    expect(h.notifySuccess).toHaveBeenCalledOnce();
+  });
+
+  it("keeps background single-quote checks silent after successful minting", async () => {
+    const wallet = useWalletStore();
+    wallet.invoiceHistory = [
+      {
+        quote: "background-q",
+        amount: 10,
+        request: "lnbc-background",
+        memo: "background",
+        date: "old",
+        status: "pending",
+        mint: "https://mint-a.example",
+        unit: "sat",
+        type: PaymentMethod.Bolt11,
+      },
+    ];
+    vi.spyOn(wallet, "mintWallet").mockResolvedValue({
+      checkMintQuoteBolt11: vi.fn(async () => ({ state: "PAID" })),
+    });
+    vi.spyOn(wallet, "mintBolt11").mockResolvedValue([
+      { id: "00aa", amount: 10, secret: "background-proof" },
+    ]);
+    const hideInvoiceDetails = vi.spyOn(
+      wallet,
+      "hideInvoiceDetailsAfterReceiveSuccess"
+    );
+
+    await wallet.checkInvoiceBolt11("background-q", false);
+
+    expect(h.notifySuccess).not.toHaveBeenCalled();
+    expect(h.uiStore.vibrate).not.toHaveBeenCalled();
+    expect(hideInvoiceDetails).not.toHaveBeenCalled();
   });
 
   it("adds, updates and removes outgoing invoices", async () => {
@@ -736,6 +810,15 @@ describe("wallet store", () => {
       expect.any(Function)
     );
     expect(websocket.connection.cancelSubscription).toHaveBeenCalledTimes(1);
+    expect(wallet.mintBolt11).toHaveBeenCalledWith(
+      wallet.invoiceHistory[0],
+      false
+    );
+    expect(
+      websocket.mintWallet.checkMintQuoteBatchBolt11
+    ).not.toHaveBeenCalled();
+    expect(websocket.mintWallet.prepareBatchMint).not.toHaveBeenCalled();
+    expect(websocket.mintWallet.completeBatchMint).not.toHaveBeenCalled();
   });
 
   it("subscribes Bolt12 minting to Bolt12 websocket updates", async () => {

--- a/src/stores/invoicesWorker.ts
+++ b/src/stores/invoicesWorker.ts
@@ -673,17 +673,19 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
             entries[0].queueEntry.lastChecked || entries[0].queueEntry.addedAt,
         };
       });
-      candidates.sort(
+      const batchCandidates = candidates.filter(
+        (candidate) => candidate.canBatch
+      );
+      if (batchCandidates.length === 0) {
+        await this.processSingleBolt11Entry(dueEntries[0], now, walletStore);
+        return;
+      }
+      batchCandidates.sort(
         (left, right) =>
           right.attemptSize - left.attemptSize || left.oldest - right.oldest
       );
-      const selected = candidates[0];
+      const selected = batchCandidates[0];
       const attempted = selected.entries.slice(0, selected.attemptSize);
-
-      if (!selected.canBatch) {
-        await this.processSingleBolt11Entry(attempted[0], now, walletStore);
-        return;
-      }
 
       const { mint: mintUrl, unit } = attempted[0].invoice;
       console.log("Bolt11 batch quote check", {

--- a/src/stores/invoicesWorker.ts
+++ b/src/stores/invoicesWorker.ts
@@ -4,6 +4,7 @@ import { useLocalStorage } from "@vueuse/core";
 import { useSettingsStore } from "./settings";
 import { PaymentMethod } from "src/stores/walletTypes";
 import { useTokensStore } from "./tokens";
+import type { StoredMint } from "src/stores/mints";
 interface InvoiceQuote {
   quote: string;
   addedAt: number;
@@ -17,6 +18,8 @@ interface ReusableMintCooldown {
   nextRetryAt: number;
   lastError?: string;
 }
+
+interface BatchPathCooldown extends ReusableMintCooldown {}
 
 interface OutgoingPaymentCheck {
   id: string;
@@ -57,6 +60,10 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
       reusableMintCooldowns: useLocalStorage<
         Record<string, ReusableMintCooldown>
       >("cashu.worker.invoices.reusableMintCooldowns", {}),
+      batchPathCooldowns: useLocalStorage<Record<string, BatchPathCooldown>>(
+        "cashu.worker.invoices.batchPathCooldowns",
+        {}
+      ),
       outgoingPayments: useLocalStorage<OutgoingPaymentCheck[]>(
         "cashu.worker.outgoing.queue",
         []
@@ -226,6 +233,24 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
     reusableMintInCooldown(mintUrl: string, now: number) {
       const cooldown = this.reusableMintCooldowns[mintUrl];
       return Boolean(cooldown && cooldown.nextRetryAt > now);
+    },
+    batchPathKey(mintUrl: string, unit: string, method: PaymentMethod) {
+      return `${mintUrl}|${unit}|${method}`;
+    },
+    batchPathInCooldown(
+      mintUrl: string,
+      unit: string,
+      method: PaymentMethod,
+      now: number
+    ) {
+      const cooldown =
+        this.batchPathCooldowns[this.batchPathKey(mintUrl, unit, method)];
+      return Boolean(cooldown && cooldown.nextRetryAt > now);
+    },
+    mintSupportsBolt11Batch(mint: Pick<StoredMint, "info"> | undefined) {
+      const nut29 = mint?.info?.nuts?.[29];
+      if (!nut29) return false;
+      return !nut29.methods || nut29.methods.includes(PaymentMethod.Bolt11);
     },
     clearReusableMintCooldown(mintUrl: string) {
       if (this.reusableMintCooldowns[mintUrl]) {

--- a/src/stores/invoicesWorker.ts
+++ b/src/stores/invoicesWorker.ts
@@ -54,6 +54,16 @@ class MalformedBatchQuoteResponseError extends Error {
   }
 }
 
+class BatchMintRequestError extends Error {
+  originalError: any;
+
+  constructor(error: any) {
+    super(String(error?.message || error));
+    this.name = "BatchMintRequestError";
+    this.originalError = error;
+  }
+}
+
 export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
   state: () => {
     return {
@@ -64,6 +74,7 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
       oneDay: 1000 * 60 * 60 * 24,
       oneHour: 1000 * 60 * 60,
       reusableMintCooldownBaseInterval: 1000 * 60,
+      batchPathCooldownBaseInterval: 1000 * 60,
       // Once per day
       maxInterval: 1000 * 60 * 60 * 24,
       keepIntervalConstantForNChecks: 5,
@@ -272,6 +283,38 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
         this.batchPathCooldowns[this.batchPathKey(mintUrl, unit, method)];
       return Boolean(cooldown && cooldown.nextRetryAt > now);
     },
+    clearBatchPathCooldown(
+      mintUrl: string,
+      unit: string,
+      method: PaymentMethod
+    ) {
+      const key = this.batchPathKey(mintUrl, unit, method);
+      if (this.batchPathCooldowns[key]) {
+        delete this.batchPathCooldowns[key];
+      }
+    },
+    recordBatchPathFailure(
+      mintUrl: string,
+      unit: string,
+      method: PaymentMethod,
+      error: any,
+      now: number
+    ) {
+      const key = this.batchPathKey(mintUrl, unit, method);
+      const previous = this.batchPathCooldowns[key];
+      const failureCount = (previous?.failureCount ?? 0) + 1;
+      const retryDelay = Math.min(
+        this.batchPathCooldownBaseInterval *
+          Math.pow(2, Math.max(0, failureCount - 1)),
+        this.oneHour
+      );
+      this.batchPathCooldowns[key] = {
+        failedAt: now,
+        failureCount,
+        nextRetryAt: now + retryDelay,
+        lastError: this.errorMessage(error),
+      };
+    },
     mintSupportsBolt11Batch(mint: Pick<StoredMint, "info"> | undefined) {
       const nut29 = mint?.info?.nuts?.[29];
       if (!nut29) return false;
@@ -406,6 +449,26 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
         message.includes(" 502") ||
         message.includes(" 503") ||
         message.includes(" 504")
+      );
+    },
+    isNetworkOrRateLimitFailure(error: any) {
+      const status = Number(
+        error?.status ??
+          error?.statusCode ??
+          error?.response?.status ??
+          error?.cause?.status ??
+          error?.cause?.response?.status
+      );
+      const message = `${this.errorMessage(error)} ${
+        error?.cause ? this.errorMessage(error.cause) : ""
+      }`.toLowerCase();
+      return (
+        this.isNetworkFailure(error) ||
+        status === 429 ||
+        status >= 500 ||
+        message.includes("429") ||
+        message.includes("rate limit") ||
+        message.includes("too many requests")
       );
     },
     shouldCheckInvoice(invoice: any) {
@@ -621,50 +684,66 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
         unit,
         attempted: attempted.length,
       });
+      let mintWallet: any;
+      let responses: any[];
       try {
-        const mintWallet = await walletStore.mintWallet(mintUrl, unit);
+        mintWallet = await walletStore.mintWallet(mintUrl, unit);
         const requestedQuotes = attempted.map(
           (entry) => entry.queueEntry.quote
         );
-        const responses = await mintWallet.checkMintQuoteBatchBolt11(
-          requestedQuotes
-        );
+        responses = await mintWallet.checkMintQuoteBatchBolt11(requestedQuotes);
         this.validateBatchQuoteResponses(requestedQuotes, responses);
-        const paymentHistoryStore = usePaymentHistoryStore();
-        const paidEntries: PaidBolt11Quote[] = [];
-        for (let index = 0; index < attempted.length; index++) {
-          const entry = attempted[index];
-          const response = normalizeMintQuote(
-            responses[index],
-            PaymentMethod.Bolt11
-          );
-          entry.invoice.mintQuote = response;
-          await paymentHistoryStore.upsertMintQuote(
-            response,
-            PaymentMethod.Bolt11
-          );
-          if (response.state === MintQuoteState.UNPAID) {
+      } catch (error) {
+        await this.handleBolt11BatchFailure(
+          attempted,
+          mintUrl,
+          unit,
+          error,
+          now,
+          walletStore,
+          "quote check"
+        );
+        this.lastInvoiceCheckTime = now;
+        return;
+      }
+
+      this.clearBatchPathCooldown(mintUrl, unit, PaymentMethod.Bolt11);
+      const paymentHistoryStore = usePaymentHistoryStore();
+      const paidEntries: PaidBolt11Quote[] = [];
+      for (let index = 0; index < attempted.length; index++) {
+        const entry = attempted[index];
+        const response = normalizeMintQuote(
+          responses[index],
+          PaymentMethod.Bolt11
+        );
+        entry.invoice.mintQuote = response;
+        await paymentHistoryStore.upsertMintQuote(
+          response,
+          PaymentMethod.Bolt11
+        );
+        if (response.state === MintQuoteState.UNPAID) {
+          entry.queueEntry.lastChecked = now;
+          entry.queueEntry.checkCount += 1;
+        } else if (response.state === MintQuoteState.ISSUED) {
+          await walletStore.setInvoicePaid(entry.queueEntry.quote, {
+            mintQuote: response,
+          });
+          this.removeInvoiceFromChecker(entry.queueEntry.quote);
+        } else if (response.state === MintQuoteState.PAID) {
+          paidEntries.push({ ...entry, mintQuote: response });
+        }
+      }
+      walletStore.syncPaymentHistoryCache?.();
+      let mintedCount = 0;
+      if (paidEntries.length > 0) {
+        const { mintable, missingKey, signingKeys } =
+          this.partitionLockedPaidQuotes(paidEntries);
+        if (mintable.length > 0) {
+          for (const entry of missingKey) {
             entry.queueEntry.lastChecked = now;
             entry.queueEntry.checkCount += 1;
-          } else if (response.state === MintQuoteState.ISSUED) {
-            await walletStore.setInvoicePaid(entry.queueEntry.quote, {
-              mintQuote: response,
-            });
-            this.removeInvoiceFromChecker(entry.queueEntry.quote);
-          } else if (response.state === MintQuoteState.PAID) {
-            paidEntries.push({ ...entry, mintQuote: response });
           }
-        }
-        walletStore.syncPaymentHistoryCache?.();
-        let mintedCount = 0;
-        if (paidEntries.length > 0) {
-          const { mintable, missingKey, signingKeys } =
-            this.partitionLockedPaidQuotes(paidEntries);
-          if (mintable.length > 0) {
-            for (const entry of missingKey) {
-              entry.queueEntry.lastChecked = now;
-              entry.queueEntry.checkCount += 1;
-            }
+          try {
             await this.mintPaidBolt11Batch(
               mintable,
               signingKeys,
@@ -672,35 +751,70 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
               walletStore
             );
             mintedCount = mintable.length;
-          } else if (missingKey.length > 0) {
-            for (const entry of missingKey.slice(1)) {
-              entry.queueEntry.lastChecked = now;
-              entry.queueEntry.checkCount += 1;
-            }
-            await this.processSingleBolt11Entry(
-              missingKey[0],
+          } catch (error) {
+            if (!(error instanceof BatchMintRequestError)) throw error;
+            await this.handleBolt11BatchFailure(
+              mintable,
+              mintUrl,
+              unit,
+              error.originalError,
               now,
-              walletStore
+              walletStore,
+              "mint"
             );
+            this.lastInvoiceCheckTime = now;
+            return;
           }
+        } else if (missingKey.length > 0) {
+          for (const entry of missingKey.slice(1)) {
+            entry.queueEntry.lastChecked = now;
+            entry.queueEntry.checkCount += 1;
+          }
+          await this.processSingleBolt11Entry(missingKey[0], now, walletStore);
         }
-        console.log("Bolt11 batch quote check complete", {
-          mint: mintUrl,
-          attempted: attempted.length,
-          paid: paidEntries.length,
-          minted: mintedCount,
-        });
-      } catch (error) {
-        for (const entry of attempted) {
+      }
+      console.log("Bolt11 batch quote check complete", {
+        mint: mintUrl,
+        attempted: attempted.length,
+        paid: paidEntries.length,
+        minted: mintedCount,
+      });
+      this.lastInvoiceCheckTime = now;
+    },
+    async handleBolt11BatchFailure(
+      entries: DueBolt11Quote[],
+      mintUrl: string,
+      unit: string,
+      error: any,
+      now: number,
+      walletStore: any,
+      stage: "quote check" | "mint"
+    ) {
+      this.recordBatchPathFailure(
+        mintUrl,
+        unit,
+        PaymentMethod.Bolt11,
+        error,
+        now
+      );
+      const shouldFallback = !this.isNetworkOrRateLimitFailure(error);
+      if (shouldFallback && entries.length > 0) {
+        for (const entry of entries.slice(1)) {
           entry.queueEntry.lastChecked = now;
           entry.queueEntry.checkCount += 1;
         }
-        console.warn("Bolt11 batch quote check failed", {
-          mint: mintUrl,
-          reason: this.errorMessage(error),
-        });
+        await this.processSingleBolt11Entry(entries[0], now, walletStore);
+      } else {
+        for (const entry of entries) {
+          entry.queueEntry.lastChecked = now;
+          entry.queueEntry.checkCount += 1;
+        }
       }
-      this.lastInvoiceCheckTime = now;
+      console.warn(`Bolt11 batch ${stage} failed`, {
+        mint: mintUrl,
+        fallback: shouldFallback ? "single quote" : "backoff only",
+        reason: this.errorMessage(error),
+      });
     },
     async mintPaidBolt11Batch(
       paidEntries: PaidBolt11Quote[],
@@ -719,26 +833,30 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
 
       await uiStore.lockMutex();
       try {
-        proofs = await walletStore.retryOnceOnSignedOutputs(
-          keysetId,
-          async () => {
-            const config = {
-              keysetId,
-              proofsWeHave: mintStore.mintUnitProofs(mint, unit),
-              ...(signingKeys.length > 0 ? { privkey: signingKeys } : {}),
-            };
-            const preview = await mintWallet.prepareBatchMint(
-              PaymentMethod.Bolt11,
-              paidEntries.map((entry) => ({
-                amount: entry.mintQuote.amount,
-                quote: entry.mintQuote,
-              })),
-              config
-            );
-            return await mintWallet.completeBatchMint(preview);
-          },
-          false
-        );
+        try {
+          proofs = await walletStore.retryOnceOnSignedOutputs(
+            keysetId,
+            async () => {
+              const config = {
+                keysetId,
+                proofsWeHave: mintStore.mintUnitProofs(mint, unit),
+                ...(signingKeys.length > 0 ? { privkey: signingKeys } : {}),
+              };
+              const preview = await mintWallet.prepareBatchMint(
+                PaymentMethod.Bolt11,
+                paidEntries.map((entry) => ({
+                  amount: entry.mintQuote.amount,
+                  quote: entry.mintQuote,
+                })),
+                config
+              );
+              return await mintWallet.completeBatchMint(preview);
+            },
+            false
+          );
+        } catch (error) {
+          throw new BatchMintRequestError(error);
+        }
       } finally {
         uiStore.unlockMutex();
       }

--- a/src/stores/invoicesWorker.ts
+++ b/src/stores/invoicesWorker.ts
@@ -10,6 +10,8 @@ import {
   usePaymentHistoryStore,
 } from "src/stores/paymentHistory";
 import { MintQuoteState } from "@cashu/cashu-ts";
+import { useProofsStore } from "src/stores/proofs";
+import { useUiStore } from "src/stores/ui";
 interface InvoiceQuote {
   quote: string;
   addedAt: number;
@@ -37,6 +39,10 @@ interface OutgoingPaymentCheck {
 interface DueBolt11Quote {
   queueEntry: InvoiceQuote;
   invoice: any;
+}
+
+interface PaidBolt11Quote extends DueBolt11Quote {
+  mintQuote: Record<string, any>;
 }
 
 class MalformedBatchQuoteResponseError extends Error {
@@ -581,7 +587,7 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
         );
         this.validateBatchQuoteResponses(requestedQuotes, responses);
         const paymentHistoryStore = usePaymentHistoryStore();
-        let paidCount = 0;
+        const paidEntries: PaidBolt11Quote[] = [];
         for (let index = 0; index < attempted.length; index++) {
           const entry = attempted[index];
           const response = normalizeMintQuote(
@@ -602,14 +608,18 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
             });
             this.removeInvoiceFromChecker(entry.queueEntry.quote);
           } else if (response.state === MintQuoteState.PAID) {
-            paidCount += 1;
+            paidEntries.push({ ...entry, mintQuote: response });
           }
         }
         walletStore.syncPaymentHistoryCache?.();
+        if (paidEntries.length > 0) {
+          await this.mintPaidBolt11Batch(paidEntries, mintWallet, walletStore);
+        }
         console.log("Bolt11 batch quote check complete", {
           mint: mintUrl,
           attempted: attempted.length,
-          paid: paidCount,
+          paid: paidEntries.length,
+          minted: paidEntries.length,
         });
       } catch (error) {
         for (const entry of attempted) {
@@ -622,6 +632,52 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
         });
       }
       this.lastInvoiceCheckTime = now;
+    },
+    async mintPaidBolt11Batch(
+      paidEntries: PaidBolt11Quote[],
+      mintWallet: any,
+      walletStore: any
+    ) {
+      const { mint: mintUrl, unit } = paidEntries[0].invoice;
+      const mintStore = useMintsStore();
+      const mint = mintStore.mints.find((item) => item.url === mintUrl);
+      if (!mint) throw new Error("mint not found");
+      const keysetId = walletStore.getKeyset(mintUrl, unit);
+      const uiStore = useUiStore();
+      const proofsStore = useProofsStore();
+      let proofs: any[];
+
+      await uiStore.lockMutex();
+      try {
+        proofs = await walletStore.retryOnceOnSignedOutputs(
+          keysetId,
+          async () => {
+            const preview = await mintWallet.prepareBatchMint(
+              PaymentMethod.Bolt11,
+              paidEntries.map((entry) => ({
+                amount: entry.mintQuote.amount,
+                quote: entry.mintQuote,
+              })),
+              {
+                keysetId,
+                proofsWeHave: mintStore.mintUnitProofs(mint, unit),
+              }
+            );
+            return await mintWallet.completeBatchMint(preview);
+          },
+          false
+        );
+      } finally {
+        uiStore.unlockMutex();
+      }
+
+      await proofsStore.addProofs(proofs);
+      for (const entry of paidEntries) {
+        await walletStore.setInvoicePaid(entry.queueEntry.quote, {
+          mintQuote: entry.mintQuote,
+        });
+        this.removeInvoiceFromChecker(entry.queueEntry.quote);
+      }
     },
     async processSingleBolt11Entry(
       entry: DueBolt11Quote,

--- a/src/stores/invoicesWorker.ts
+++ b/src/stores/invoicesWorker.ts
@@ -39,6 +39,13 @@ interface DueBolt11Quote {
   invoice: any;
 }
 
+class MalformedBatchQuoteResponseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MalformedBatchQuoteResponseError";
+  }
+}
+
 export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
   state: () => {
     return {
@@ -273,6 +280,38 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
       }
       return Math.floor(maxBatchSize);
     },
+    validateBatchQuoteResponses(requestedQuotes: string[], responses: any[]) {
+      if (
+        !Array.isArray(responses) ||
+        responses.length !== requestedQuotes.length
+      ) {
+        throw new MalformedBatchQuoteResponseError(
+          `expected ${requestedQuotes.length} responses, received ${
+            Array.isArray(responses) ? responses.length : "non-array"
+          }`
+        );
+      }
+      const seen = new Set<string>();
+      responses.forEach((response, index) => {
+        const quote = response?.quote;
+        if (typeof quote !== "string" || quote.length === 0) {
+          throw new MalformedBatchQuoteResponseError(
+            `response at index ${index} is missing a quote ID`
+          );
+        }
+        if (seen.has(quote)) {
+          throw new MalformedBatchQuoteResponseError(
+            `response contains duplicate quote ID ${quote}`
+          );
+        }
+        seen.add(quote);
+        if (quote !== requestedQuotes[index]) {
+          throw new MalformedBatchQuoteResponseError(
+            `response quote mismatch at index ${index}: expected ${requestedQuotes[index]}, received ${quote}`
+          );
+        }
+      });
+    },
     clearReusableMintCooldown(mintUrl: string) {
       if (this.reusableMintCooldowns[mintUrl]) {
         delete this.reusableMintCooldowns[mintUrl];
@@ -471,8 +510,7 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
           (item: any) => item.quote === queueEntry.quote
         );
         const isBolt11 =
-          invoice?.type === undefined ||
-          invoice?.type === PaymentMethod.Bolt11;
+          invoice?.type === undefined || invoice?.type === PaymentMethod.Bolt11;
         if (!isBolt11 || !this.shouldCheckInvoice(invoice)) {
           this.quotes.splice(index, 1);
           continue;
@@ -502,12 +540,7 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
         const mint = mintStore.mints.find((item) => item.url === mintUrl);
         const canBatch =
           this.mintSupportsBolt11Batch(mint) &&
-          !this.batchPathInCooldown(
-            mintUrl,
-            unit,
-            PaymentMethod.Bolt11,
-            now
-          );
+          !this.batchPathInCooldown(mintUrl, unit, PaymentMethod.Bolt11, now);
         const limit = this.bolt11BatchSizeLimit(mint);
         const attemptSize = canBatch
           ? Math.min(entries.length, limit ?? entries.length)
@@ -516,7 +549,8 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
           entries,
           canBatch,
           attemptSize,
-          oldest: entries[0].queueEntry.lastChecked || entries[0].queueEntry.addedAt,
+          oldest:
+            entries[0].queueEntry.lastChecked || entries[0].queueEntry.addedAt,
         };
       });
       candidates.sort(
@@ -539,9 +573,13 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
       });
       try {
         const mintWallet = await walletStore.mintWallet(mintUrl, unit);
-        const responses = await mintWallet.checkMintQuoteBatchBolt11(
-          attempted.map((entry) => entry.queueEntry.quote)
+        const requestedQuotes = attempted.map(
+          (entry) => entry.queueEntry.quote
         );
+        const responses = await mintWallet.checkMintQuoteBatchBolt11(
+          requestedQuotes
+        );
+        this.validateBatchQuoteResponses(requestedQuotes, responses);
         const paymentHistoryStore = usePaymentHistoryStore();
         let paidCount = 0;
         for (let index = 0; index < attempted.length; index++) {

--- a/src/stores/invoicesWorker.ts
+++ b/src/stores/invoicesWorker.ts
@@ -12,6 +12,8 @@ import {
 import { MintQuoteState } from "@cashu/cashu-ts";
 import { useProofsStore } from "src/stores/proofs";
 import { useUiStore } from "src/stores/ui";
+import * as nobleSecp256k1 from "@noble/secp256k1";
+import { bytesToHex } from "@noble/hashes/utils";
 interface InvoiceQuote {
   quote: string;
   addedAt: number;
@@ -318,6 +320,48 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
         }
       });
     },
+    partitionLockedPaidQuotes(paidEntries: PaidBolt11Quote[]) {
+      const availableKeys = Array.from(
+        new Set(
+          paidEntries
+            .map((entry) => entry.invoice.privKey)
+            .filter((privKey): privKey is string => Boolean(privKey))
+        )
+      ).flatMap((privKey) => {
+        try {
+          return [
+            {
+              privKey,
+              pubkey: bytesToHex(
+                nobleSecp256k1.getPublicKey(privKey, true)
+              ).toLowerCase(),
+            },
+          ];
+        } catch {
+          return [];
+        }
+      });
+      const mintable: PaidBolt11Quote[] = [];
+      const missingKey: PaidBolt11Quote[] = [];
+      const signingKeys = new Set<string>();
+      for (const entry of paidEntries) {
+        const quotePubkey = entry.mintQuote.pubkey;
+        if (!quotePubkey) {
+          mintable.push(entry);
+          continue;
+        }
+        const matchingKey = availableKeys.find(
+          ({ pubkey }) => pubkey === String(quotePubkey).toLowerCase()
+        );
+        if (!matchingKey) {
+          missingKey.push(entry);
+          continue;
+        }
+        signingKeys.add(matchingKey.privKey);
+        mintable.push(entry);
+      }
+      return { mintable, missingKey, signingKeys: Array.from(signingKeys) };
+    },
     clearReusableMintCooldown(mintUrl: string) {
       if (this.reusableMintCooldowns[mintUrl]) {
         delete this.reusableMintCooldowns[mintUrl];
@@ -612,14 +656,39 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
           }
         }
         walletStore.syncPaymentHistoryCache?.();
+        let mintedCount = 0;
         if (paidEntries.length > 0) {
-          await this.mintPaidBolt11Batch(paidEntries, mintWallet, walletStore);
+          const { mintable, missingKey, signingKeys } =
+            this.partitionLockedPaidQuotes(paidEntries);
+          if (mintable.length > 0) {
+            for (const entry of missingKey) {
+              entry.queueEntry.lastChecked = now;
+              entry.queueEntry.checkCount += 1;
+            }
+            await this.mintPaidBolt11Batch(
+              mintable,
+              signingKeys,
+              mintWallet,
+              walletStore
+            );
+            mintedCount = mintable.length;
+          } else if (missingKey.length > 0) {
+            for (const entry of missingKey.slice(1)) {
+              entry.queueEntry.lastChecked = now;
+              entry.queueEntry.checkCount += 1;
+            }
+            await this.processSingleBolt11Entry(
+              missingKey[0],
+              now,
+              walletStore
+            );
+          }
         }
         console.log("Bolt11 batch quote check complete", {
           mint: mintUrl,
           attempted: attempted.length,
           paid: paidEntries.length,
-          minted: paidEntries.length,
+          minted: mintedCount,
         });
       } catch (error) {
         for (const entry of attempted) {
@@ -635,6 +704,7 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
     },
     async mintPaidBolt11Batch(
       paidEntries: PaidBolt11Quote[],
+      signingKeys: string[],
       mintWallet: any,
       walletStore: any
     ) {
@@ -652,16 +722,18 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
         proofs = await walletStore.retryOnceOnSignedOutputs(
           keysetId,
           async () => {
+            const config = {
+              keysetId,
+              proofsWeHave: mintStore.mintUnitProofs(mint, unit),
+              ...(signingKeys.length > 0 ? { privkey: signingKeys } : {}),
+            };
             const preview = await mintWallet.prepareBatchMint(
               PaymentMethod.Bolt11,
               paidEntries.map((entry) => ({
                 amount: entry.mintQuote.amount,
                 quote: entry.mintQuote,
               })),
-              {
-                keysetId,
-                proofsWeHave: mintStore.mintUnitProofs(mint, unit),
-              }
+              config
             );
             return await mintWallet.completeBatchMint(preview);
           },

--- a/src/stores/invoicesWorker.ts
+++ b/src/stores/invoicesWorker.ts
@@ -4,7 +4,12 @@ import { useLocalStorage } from "@vueuse/core";
 import { useSettingsStore } from "./settings";
 import { PaymentMethod } from "src/stores/walletTypes";
 import { useTokensStore } from "./tokens";
-import type { StoredMint } from "src/stores/mints";
+import { useMintsStore, type StoredMint } from "src/stores/mints";
+import {
+  normalizeMintQuote,
+  usePaymentHistoryStore,
+} from "src/stores/paymentHistory";
+import { MintQuoteState } from "@cashu/cashu-ts";
 interface InvoiceQuote {
   quote: string;
   addedAt: number;
@@ -27,6 +32,11 @@ interface OutgoingPaymentCheck {
   addedAt: number;
   lastChecked: number;
   checkCount: number;
+}
+
+interface DueBolt11Quote {
+  queueEntry: InvoiceQuote;
+  invoice: any;
 }
 
 export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
@@ -252,6 +262,17 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
       if (!nut29) return false;
       return !nut29.methods || nut29.methods.includes(PaymentMethod.Bolt11);
     },
+    bolt11BatchSizeLimit(mint: Pick<StoredMint, "info"> | undefined) {
+      const maxBatchSize = mint?.info?.nuts?.[29]?.max_batch_size;
+      if (
+        typeof maxBatchSize !== "number" ||
+        !Number.isFinite(maxBatchSize) ||
+        maxBatchSize <= 0
+      ) {
+        return undefined;
+      }
+      return Math.floor(maxBatchSize);
+    },
     clearReusableMintCooldown(mintUrl: string) {
       if (this.reusableMintCooldowns[mintUrl]) {
         delete this.reusableMintCooldowns[mintUrl];
@@ -375,31 +396,8 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
         return;
       }
 
-      // First process one bolt11 quote if any
-      for (let i = this.quotes.length - 1; i >= 0; i--) {
-        const q = this.quotes[i];
-        // Check if invoice is still valid/needed
-        const invoice = walletStore.invoiceHistory.find(
-          (inv) => inv.quote === q.quote
-        );
-        if (!this.shouldCheckInvoice(invoice)) {
-          this.quotes.splice(i, 1);
-          continue;
-        }
-
-        const dueTime = this.dueTime(q);
-        if (now > dueTime) {
-          try {
-            await walletStore.checkInvoiceBolt11(q.quote, false);
-            this.quotes.splice(i, 1);
-          } catch (error) {
-            q.lastChecked = now;
-            q.checkCount += 1;
-          }
-          this.lastInvoiceCheckTime = now;
-          break;
-        }
-      }
+      // First process one Bolt11 quote or one compatible Bolt11 batch.
+      await this.processBolt11Queue(now, walletStore);
 
       // Then process one bolt12 offer if any
       for (let i = this.bolt12Quotes.length - 1; i >= 0; i--) {
@@ -464,6 +462,142 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
           break;
         }
       }
+    },
+    async processBolt11Queue(now: number, walletStore: any) {
+      const dueEntries: DueBolt11Quote[] = [];
+      for (let index = this.quotes.length - 1; index >= 0; index--) {
+        const queueEntry = this.quotes[index];
+        const invoice = walletStore.invoiceHistory.find(
+          (item: any) => item.quote === queueEntry.quote
+        );
+        const isBolt11 =
+          invoice?.type === undefined ||
+          invoice?.type === PaymentMethod.Bolt11;
+        if (!isBolt11 || !this.shouldCheckInvoice(invoice)) {
+          this.quotes.splice(index, 1);
+          continue;
+        }
+        if (now > this.dueTime(queueEntry)) {
+          dueEntries.push({ queueEntry, invoice });
+        }
+      }
+      if (dueEntries.length === 0) return;
+
+      const mintStore = useMintsStore();
+      const groups = new Map<string, DueBolt11Quote[]>();
+      for (const entry of dueEntries) {
+        const key = `${entry.invoice.mint}|${entry.invoice.unit}`;
+        const group = groups.get(key) || [];
+        group.push(entry);
+        groups.set(key, group);
+      }
+
+      const candidates = Array.from(groups.values()).map((entries) => {
+        entries.sort(
+          (left, right) =>
+            (left.queueEntry.lastChecked || left.queueEntry.addedAt) -
+            (right.queueEntry.lastChecked || right.queueEntry.addedAt)
+        );
+        const { mint: mintUrl, unit } = entries[0].invoice;
+        const mint = mintStore.mints.find((item) => item.url === mintUrl);
+        const canBatch =
+          this.mintSupportsBolt11Batch(mint) &&
+          !this.batchPathInCooldown(
+            mintUrl,
+            unit,
+            PaymentMethod.Bolt11,
+            now
+          );
+        const limit = this.bolt11BatchSizeLimit(mint);
+        const attemptSize = canBatch
+          ? Math.min(entries.length, limit ?? entries.length)
+          : 1;
+        return {
+          entries,
+          canBatch,
+          attemptSize,
+          oldest: entries[0].queueEntry.lastChecked || entries[0].queueEntry.addedAt,
+        };
+      });
+      candidates.sort(
+        (left, right) =>
+          right.attemptSize - left.attemptSize || left.oldest - right.oldest
+      );
+      const selected = candidates[0];
+      const attempted = selected.entries.slice(0, selected.attemptSize);
+
+      if (!selected.canBatch) {
+        await this.processSingleBolt11Entry(attempted[0], now, walletStore);
+        return;
+      }
+
+      const { mint: mintUrl, unit } = attempted[0].invoice;
+      console.log("Bolt11 batch quote check", {
+        mint: mintUrl,
+        unit,
+        attempted: attempted.length,
+      });
+      try {
+        const mintWallet = await walletStore.mintWallet(mintUrl, unit);
+        const responses = await mintWallet.checkMintQuoteBatchBolt11(
+          attempted.map((entry) => entry.queueEntry.quote)
+        );
+        const paymentHistoryStore = usePaymentHistoryStore();
+        let paidCount = 0;
+        for (let index = 0; index < attempted.length; index++) {
+          const entry = attempted[index];
+          const response = normalizeMintQuote(
+            responses[index],
+            PaymentMethod.Bolt11
+          );
+          entry.invoice.mintQuote = response;
+          await paymentHistoryStore.upsertMintQuote(
+            response,
+            PaymentMethod.Bolt11
+          );
+          if (response.state === MintQuoteState.UNPAID) {
+            entry.queueEntry.lastChecked = now;
+            entry.queueEntry.checkCount += 1;
+          } else if (response.state === MintQuoteState.ISSUED) {
+            await walletStore.setInvoicePaid(entry.queueEntry.quote, {
+              mintQuote: response,
+            });
+            this.removeInvoiceFromChecker(entry.queueEntry.quote);
+          } else if (response.state === MintQuoteState.PAID) {
+            paidCount += 1;
+          }
+        }
+        walletStore.syncPaymentHistoryCache?.();
+        console.log("Bolt11 batch quote check complete", {
+          mint: mintUrl,
+          attempted: attempted.length,
+          paid: paidCount,
+        });
+      } catch (error) {
+        for (const entry of attempted) {
+          entry.queueEntry.lastChecked = now;
+          entry.queueEntry.checkCount += 1;
+        }
+        console.warn("Bolt11 batch quote check failed", {
+          mint: mintUrl,
+          reason: this.errorMessage(error),
+        });
+      }
+      this.lastInvoiceCheckTime = now;
+    },
+    async processSingleBolt11Entry(
+      entry: DueBolt11Quote,
+      now: number,
+      walletStore: any
+    ) {
+      try {
+        await walletStore.checkInvoiceBolt11(entry.queueEntry.quote, false);
+        this.removeInvoiceFromChecker(entry.queueEntry.quote);
+      } catch (error) {
+        entry.queueEntry.lastChecked = now;
+        entry.queueEntry.checkCount += 1;
+      }
+      this.lastInvoiceCheckTime = now;
     },
     async processOutgoingQueue(now: number, walletStore: any) {
       if (!useSettingsStore().checkSentTokens) return;

--- a/src/stores/invoicesWorker.ts
+++ b/src/stores/invoicesWorker.ts
@@ -9,7 +9,7 @@ import {
   normalizeMintQuote,
   usePaymentHistoryStore,
 } from "src/stores/paymentHistory";
-import { MintQuoteState } from "@cashu/cashu-ts";
+import { MintInfo, MintQuoteState } from "@cashu/cashu-ts";
 import { useProofsStore } from "src/stores/proofs";
 import { useUiStore } from "src/stores/ui";
 import * as nobleSecp256k1 from "@noble/secp256k1";
@@ -321,7 +321,14 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
       return !nut29.methods || nut29.methods.includes(PaymentMethod.Bolt11);
     },
     bolt11BatchSizeLimit(mint: Pick<StoredMint, "info"> | undefined) {
-      const maxBatchSize = mint?.info?.nuts?.[29]?.max_batch_size;
+      if (!mint?.info) return undefined;
+      let maxBatchSize: number | undefined;
+      try {
+        maxBatchSize = new MintInfo(mint.info).isSupported(29).params
+          ?.max_batch_size;
+      } catch {
+        return undefined;
+      }
       if (
         typeof maxBatchSize !== "number" ||
         !Number.isFinite(maxBatchSize) ||

--- a/src/stores/walletBolt11.ts
+++ b/src/stores/walletBolt11.ts
@@ -305,15 +305,17 @@ export async function checkInvoiceBolt11(
       throw new Error(`invoice state not paid: ${state}`);
     }
     const proofs = await this.mintBolt11(invoice, verbose);
-    if (hideInvoiceDetailsOnMint) {
-      this.hideInvoiceDetailsAfterReceiveSuccess(invoice.quote);
+    if (verbose) {
+      if (hideInvoiceDetailsOnMint) {
+        this.hideInvoiceDetailsAfterReceiveSuccess(invoice.quote);
+      }
+      useUiStore().vibrate();
+      notifySuccess(
+        this.t("wallet.notifications.received_lightning", {
+          amount: uIStore.formatCurrency(invoice.amount, invoice.unit),
+        })
+      );
     }
-    useUiStore().vibrate();
-    notifySuccess(
-      this.t("wallet.notifications.received_lightning", {
-        amount: uIStore.formatCurrency(invoice.amount, invoice.unit),
-      })
-    );
     return proofs;
   } catch (error) {
     console.log("Invoice still pending", invoice.quote);


### PR DESCRIPTION
  ### Summary

  - Upgrade @cashu/cashu-ts to 4.7.0.
  - Batch-check one compatible mint/unit group of due Bolt11 quotes
    per worker tick.

  - Batch-mint paid quotes while preserving unpaid and already-
    issued states.

  - Support locked quotes using matching stored private keys.
  - Validate batch response length, ordering, quote IDs, and states.
  - Add per-mint/unit/method cooldowns with conservative single-
    quote fallback.

  - Preserve existing manual and websocket single-quote flows.
  - Keep background receiving silent and payment-history dates
    intact.

  ### Reliability

  - Respect mint-advertised and cashu-ts default batch-size limits.
  - Hold the wallet mutex across batch preparation and completion.
  - Retry the complete batch operation after signed-output errors.
  - Avoid fallback request bursts for network, rate-limit, and
    server failures.
  - Persist proofs before marking invoices paid.

  ### Testing

  - Added coverage for batching, mixed states, locked quotes,
    malformed responses, cooldowns, fallbacks, persistence, history
    mirroring, and non-batch entry points.

  - npm test -- --run — 100 tests passed.
  - npm run lint — passed.
  - npm run checkformat — passed.
  - npm run build — passed.