### PR TITLE
Fix advanced settings wallet deletion

### DIFF
--- a/src/pages/settings/AdvancedSettings.vue
+++ b/src/pages/settings/AdvancedSettings.vue
@@ -8,12 +8,7 @@
       :caption="$t('Settings.advanced.developer.description')"
     >
       <!-- new seed -->
-      <q-item
-        clickable
-        v-ripple
-        @click="confirmMnemonic = true"
-        :disable="confirmMnemonic"
-      >
+      <q-item clickable v-ripple @click="confirmMnemonic = true">
         <q-item-section>
           <q-item-label>{{
             $t("Settings.advanced.developer.new_seed.button")
@@ -168,12 +163,7 @@
       </q-item>
 
       <!-- import wallet backup -->
-      <q-item
-        clickable
-        v-ripple
-        @click="confirmImport = true"
-        :disable="confirmImport"
-      >
+      <q-item clickable v-ripple @click="confirmImport = true">
         <q-item-section>
           <q-item-label>{{
             $t("Settings.advanced.developer.import_wallet.button")
@@ -223,12 +213,7 @@
       </q-item>
 
       <!-- reset wallet -->
-      <q-item
-        clickable
-        v-ripple
-        @click="confirmNuke = true"
-        :disable="confirmNuke"
-      >
+      <q-item clickable v-ripple @click="confirmNuke = true">
         <q-item-section>
           <q-item-label class="text-negative">{{
             $t("Settings.advanced.developer.reset_wallet.button")
@@ -398,9 +383,9 @@ export default defineComponent({
       // create a backup just in case
       await this.exportWalletState();
       // clear dexie tables
-      this.deleteAllTables();
+      await this.deleteAllTables();
       // clear nostr user databases
-      useNostrUserStore().clearAllDatabases();
+      await useNostrUserStore().clearAllDatabases();
       // clear mint reviews database
       try {
         const { useMintRecommendationsStore } = await import(

--- a/src/pages/settings/__tests__/AdvancedSettings.test.ts
+++ b/src/pages/settings/__tests__/AdvancedSettings.test.ts
@@ -1,0 +1,118 @@
+import { createPinia } from "pinia";
+import { mount } from "@vue/test-utils";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+const storeMocks = vi.hoisted(() => ({
+  clearNostrDatabases: vi.fn(),
+  clearMintDatabases: vi.fn(),
+}));
+
+vi.mock("quasar", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("quasar")>()),
+  Ripple: {},
+}));
+
+vi.mock("src/stores/nostrUser", () => ({
+  useNostrUserStore: () => ({
+    clearAllDatabases: storeMocks.clearNostrDatabases,
+  }),
+}));
+
+vi.mock("src/stores/mintRecommendations", () => ({
+  useMintRecommendationsStore: () => ({
+    clearAllDatabases: storeMocks.clearMintDatabases,
+  }),
+}));
+
+let AdvancedSettings: any;
+
+beforeAll(async () => {
+  (globalThis as any).windowMixin = {};
+  AdvancedSettings = (await import("../AdvancedSettings.vue")).default;
+});
+
+describe("AdvancedSettings", () => {
+  it.each(["new_seed", "import_wallet", "reset_wallet"])(
+    "keeps the %s confirmation controls enabled",
+    async (setting) => {
+      const wrapper = mount(AdvancedSettings, {
+        global: {
+          plugins: [createPinia()],
+          config: {
+            warnHandler: () => undefined,
+          },
+          mocks: {
+            $t: (key: string) => key,
+          },
+          stubs: {
+            SettingsPageShell: { template: "<div><slot /></div>" },
+            SettingsSection: { template: "<div><slot /></div>" },
+            QItem: {
+              props: { disable: Boolean },
+              emits: ["click"],
+              template:
+                '<div class="q-item" :class="{ disabled: disable }" @click="$emit(\'click\', $event)"><slot /></div>',
+            },
+            QItemSection: { template: "<div><slot /></div>" },
+            QItemLabel: { template: "<div><slot /></div>" },
+            QBtn: { template: "<button><slot /></button>" },
+          },
+        },
+      });
+
+      const row = wrapper
+        .findAll(".q-item")
+        .find((item) =>
+          item.text().includes(`Settings.advanced.developer.${setting}.button`)
+        );
+
+      expect(row).toBeDefined();
+      await row!.trigger("click");
+
+      expect(row!.classes()).not.toContain("disabled");
+      expect(
+        row!.findAll("button").every((button) => !button.attributes("disabled"))
+      ).toBe(true);
+    }
+  );
+
+  it("waits for wallet databases to clear before clearing local storage", async () => {
+    let resolveDexieClear!: () => void;
+    let resolveNostrClear!: () => void;
+    const deleteAllTables = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDexieClear = resolve;
+        })
+    );
+    storeMocks.clearNostrDatabases.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveNostrClear = resolve;
+        })
+    );
+    storeMocks.clearMintDatabases.mockResolvedValue(undefined);
+    const clearLocalStorage = vi.spyOn(localStorage, "clear");
+
+    const nukePromise = AdvancedSettings.methods.nukeWallet.call({
+      exportWalletState: vi.fn().mockResolvedValue(undefined),
+      deleteAllTables,
+    });
+
+    await vi.waitFor(() => expect(deleteAllTables).toHaveBeenCalledOnce());
+    expect(storeMocks.clearNostrDatabases).not.toHaveBeenCalled();
+    expect(clearLocalStorage).not.toHaveBeenCalled();
+
+    resolveDexieClear();
+    await vi.waitFor(() =>
+      expect(storeMocks.clearNostrDatabases).toHaveBeenCalledOnce()
+    );
+    expect(clearLocalStorage).not.toHaveBeenCalled();
+
+    resolveNostrClear();
+    await nukePromise;
+
+    expect(storeMocks.clearMintDatabases).toHaveBeenCalledOnce();
+    expect(clearLocalStorage).toHaveBeenCalledOnce();
+  });
+});

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -91,12 +91,14 @@ export const useDexieStore = defineStore("dexie", {
       // remove proofs from localstorage
       localStorage.removeItem("cashu.proofs");
     },
-    deleteAllTables: function () {
-      cashuDb.proofs.clear();
-      cashuDb.paymentHistory.clear();
-      cashuDb.mintQuotes.clear();
-      cashuDb.meltQuotes.clear();
-      cashuDb.ecashHistory.clear();
+    deleteAllTables: async function () {
+      await Promise.all([
+        cashuDb.proofs.clear(),
+        cashuDb.paymentHistory.clear(),
+        cashuDb.mintQuotes.clear(),
+        cashuDb.meltQuotes.clear(),
+        cashuDb.ecashHistory.clear(),
+      ]);
     },
   },
 });

--- a/src/stores/nostrUser.ts
+++ b/src/stores/nostrUser.ts
@@ -382,10 +382,8 @@ export const useNostrUserStore = defineStore("nostrUser", {
       this.crawlCheckpointNextIndex = 0;
       this.crawlCheckpointTotal = 0;
     },
-    clearAllDatabases: function () {
-      db.wot.clear();
-      db.follows.clear();
-      db.meta.clear();
+    clearAllDatabases: async function () {
+      await Promise.all([db.wot.clear(), db.follows.clear(), db.meta.clear()]);
     },
   },
 });


### PR DESCRIPTION
## Summary

- keep the new-seed, wallet-import, and wallet-delete confirmation actions interactive
- wait for wallet IndexedDB databases to finish clearing before clearing local storage and reloading
- add regression coverage for the confirmation controls and deletion ordering

## Testing

- `npm test -- --run src/pages/settings/__tests__/AdvancedSettings.test.ts` (4 passed)
- `npm run lint`
- `npm run build`
- `npm run test:ci` (107 passed; 5 existing P2PK failures also reproduce on `main` because the installed Cashu dependency does not expose `PaymentRequest.toP2PKOptions`)
