### PR TITLE
fix: batch NUT-29 startup reconciliation

### DIFF
--- a/src/stores/__tests__/invoicesWorker.test.js
+++ b/src/stores/__tests__/invoicesWorker.test.js
@@ -4,6 +4,7 @@ import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
 import { useMintsStore } from "src/stores/mints";
 import { usePaymentHistoryStore } from "src/stores/paymentHistory";
 import { useProofsStore } from "src/stores/proofs";
+import { useSettingsStore } from "src/stores/settings";
 import { useUiStore } from "src/stores/ui";
 import { cashuDb } from "src/stores/dexie";
 import { PaymentMethod } from "src/stores/walletTypes";
@@ -1086,4 +1087,60 @@ describe("invoices worker", () => {
       false
     );
   });
+
+  it("queues NUT-29 Bolt11 quotes without websocket reconciliation on startup", () => {
+    const worker = useInvoicesWorkerStore();
+    const mintStore = useMintsStore();
+    const settingsStore = useSettingsStore();
+    settingsStore.periodicallyCheckIncomingInvoices = true;
+    mintStore.mints = [];
+    advertiseBatchMint(mintStore, "https://mint.example");
+    vi.spyOn(worker, "startInvoiceCheckerWorker").mockImplementation(() => {});
+    const walletStore = {
+      invoiceHistory: [pendingInvoice("bolt11-q")],
+      mintOnPaidBolt11: vi.fn(async () => {}),
+    };
+
+    worker.queuePendingIncomingPayments(walletStore);
+
+    expect(worker.quotes.map((q) => q.quote)).toContain("bolt11-q");
+    expect(walletStore.mintOnPaidBolt11).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["the mint does not support NUT-29", false, true],
+    ["periodic checking is disabled", true, false],
+  ])(
+    "keeps Bolt11 websocket reconciliation when %s",
+    (_case, supportsNut29, periodicallyCheck) => {
+      const worker = useInvoicesWorkerStore();
+      const mintStore = useMintsStore();
+      const settingsStore = useSettingsStore();
+      settingsStore.periodicallyCheckIncomingInvoices = periodicallyCheck;
+      mintStore.mints = [];
+      if (supportsNut29) {
+        advertiseBatchMint(mintStore, "https://mint.example");
+      } else {
+        mintStore.mints.push({
+          url: "https://mint.example",
+          keys: [],
+          keysets: [],
+          info: { nuts: {} },
+        });
+      }
+      const walletStore = {
+        invoiceHistory: [pendingInvoice("bolt11-q")],
+        mintOnPaidBolt11: vi.fn(async () => {}),
+      };
+
+      worker.queuePendingIncomingPayments(walletStore);
+
+      expect(worker.quotes).toEqual([]);
+      expect(walletStore.mintOnPaidBolt11).toHaveBeenCalledWith(
+        "bolt11-q",
+        false,
+        false
+      );
+    }
+  );
 });

--- a/src/stores/invoicesWorker.ts
+++ b/src/stores/invoicesWorker.ts
@@ -963,6 +963,8 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
         quotesToCheck.splice(this.maxQuotesToCheckOnStartup);
       }
       const now = Date.now();
+      const settingsStore = useSettingsStore();
+      const mintStore = useMintsStore();
       this.lastPendingInvoiceCheck = now;
       for (const q of quotesToCheck) {
         try {
@@ -979,9 +981,17 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
               // Background websocket setup is best-effort; long-polling handles retries.
             });
           } else {
-            walletStore.mintOnPaidBolt11(q.quote, false, false).catch(() => {
-              // Background websocket setup is best-effort; long-polling handles retries.
-            });
+            const mint = mintStore.mints.find((item) => item.url === q.mint);
+            if (
+              settingsStore.periodicallyCheckIncomingInvoices &&
+              this.mintSupportsBolt11Batch(mint)
+            ) {
+              this.addInvoiceToChecker(q.quote);
+            } else {
+              walletStore.mintOnPaidBolt11(q.quote, false, false).catch(() => {
+                // Background websocket setup is best-effort; long-polling handles retries.
+              });
+            }
           }
         } catch (error) {
           // Background invoice checks stay silent; manual checks surface errors.


### PR DESCRIPTION
## What changed

- route restored Bolt11 quotes from NUT-29 mints into the invoice worker queue during startup reconciliation
- retain websocket reconciliation for mints without NUT-29 support and when periodic checking is disabled
- add regression coverage for each routing case

## Why

Startup reconciliation previously subscribed every restored Bolt11 quote over websockets. When several invoices had been paid while the wallet was offline, those callbacks raced the NUT-29 batch worker and minted the quotes individually.

This keeps immediate websocket feedback for interactively created invoices while allowing background startup reconciliation to use the existing batch runner.

## Validation

- `npm run test:ci` (111 tests)
- `npx eslint src/stores/invoicesWorker.ts src/stores/__tests__/invoicesWorker.test.js`
- `npx prettier --check src/stores/invoicesWorker.ts src/stores/__tests__/invoicesWorker.test.js`
- `git diff --check`
