### PR TITLE
chore: upgrade cashu-ts to 4.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@capacitor/clipboard": "^6.0.2",
         "@capacitor/core": "^6.2.0",
         "@capacitor/haptics": "^6.0.2",
-        "@cashu/cashu-ts": "^4.7.0",
+        "@cashu/cashu-ts": "^4.9.0",
         "@chenfengyuan/vue-qrcode": "^2.0.0",
         "@gandlaf21/bc-ur": "^1.1.12",
         "@nostr-dev-kit/ndk": "^2.8.1",
@@ -1972,10 +1972,9 @@
       }
     },
     "node_modules/@cashu/cashu-ts": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-4.7.0.tgz",
-      "integrity": "sha512-u/R9nHCBFugQeTKf1NCZscKp6Zblo3ubX8mFA0Ar8+lpGaHSndWmsQUsSQ7vrNGmdGtqOTMiR7hErEqVCVOY+A==",
-      "license": "MIT",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-4.9.0.tgz",
+      "integrity": "sha512-cFJj4Pr4v0HVnh5vSRO4uzx4ts57NmvMV+XfziR0pBowcRlsqOpbas9K21XIqClqZw1ODFrGsWy5pL1iBHBFhw==",
       "dependencies": {
         "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@capacitor/clipboard": "^6.0.2",
     "@capacitor/core": "^6.2.0",
     "@capacitor/haptics": "^6.0.2",
-    "@cashu/cashu-ts": "^4.7.0",
+    "@cashu/cashu-ts": "^4.9.0",
     "@chenfengyuan/vue-qrcode": "^2.0.0",
     "@gandlaf21/bc-ur": "^1.1.12",
     "@nostr-dev-kit/ndk": "^2.8.1",


### PR DESCRIPTION
## Summary

- Upgrade `@cashu/cashu-ts` from `^4.7.0` to `^4.9.0`.
- Refresh the npm lockfile to resolve `@cashu/cashu-ts` 4.9.0.

## Why

cashu-ts 4.9.0 contains the v4 backport from cashubtc/cashu-ts#970. It removes the incorrect wall-clock rejection that prevented minting an already-paid BOLT11 quote after its invoice expired. Invoice expiry is the payment deadline, not the deadline for issuing ecash after payment.

This update prevents a paid quote from becoming unclaimable solely because the invoice expired before the wallet minted it.

## Scope

This PR only updates the dependency declaration and lockfile. It does not add the new keyset-cache integration or otherwise change wallet application code.

## Validation

- `npm install --package-lock-only --ignore-scripts @cashu/cashu-ts@4.9.0`
- `npm ls --package-lock-only @cashu/cashu-ts`
- `prettier --check package.json package-lock.json`
- `git diff --check`

The full application test/build suite was not run locally because the checkout has no installed toolchain and the available environment could not accommodate the Electron/Capacitor dependency install.
