### PR TITLE
Fix BigInt wallet backup export

### DIFF
--- a/src/js/__tests__/cashu-amount.test.ts
+++ b/src/js/__tests__/cashu-amount.test.ts
@@ -1,0 +1,42 @@
+import { Amount } from "@cashu/cashu-ts";
+import { describe, expect, it } from "vitest";
+import {
+  cashuAmountToNumber,
+  normalizeCashuQuoteAmounts,
+} from "src/js/cashu-amount";
+
+describe("cashu amount persistence normalization", () => {
+  it("recovers an Amount whose prototype was stripped by structured clone", () => {
+    const persistedAmount = structuredClone(Amount.from(42));
+
+    expect(persistedAmount).toEqual({ value: 42n });
+    expect(cashuAmountToNumber(persistedAmount)).toBe(42);
+  });
+
+  it("normalizes nested quote amounts before IndexedDB persistence", () => {
+    const normalized = normalizeCashuQuoteAmounts({
+      quote: "melt-quote",
+      amount: Amount.from(100),
+      fee_reserve: Amount.from(5),
+      fee_options: [
+        { fee_index: 1, fee_reserve: Amount.from(7), estimated_blocks: 6 },
+      ],
+      change: [
+        {
+          id: "keyset-id",
+          amount: structuredClone(Amount.from(2)),
+          C_: "signature",
+        },
+      ],
+    });
+
+    expect(normalized).toEqual({
+      quote: "melt-quote",
+      amount: 100,
+      fee_reserve: 5,
+      fee_options: [{ fee_index: 1, fee_reserve: 7, estimated_blocks: 6 }],
+      change: [{ id: "keyset-id", amount: 2, C_: "signature" }],
+    });
+    expect(() => JSON.stringify(normalized)).not.toThrow();
+  });
+});

--- a/src/js/cashu-amount.ts
+++ b/src/js/cashu-amount.ts
@@ -1,0 +1,81 @@
+import { Amount, type AmountLike } from "@cashu/cashu-ts";
+
+type StructuredClonedAmount = {
+  value: AmountLike;
+};
+
+function isStructuredClonedAmount(
+  value: unknown
+): value is StructuredClonedAmount {
+  if (!value || typeof value !== "object") return false;
+
+  const keys = Object.keys(value);
+  if (
+    keys.length !== 1 ||
+    keys[0] !== "value" ||
+    !Object.prototype.hasOwnProperty.call(value, "value")
+  ) {
+    return false;
+  }
+
+  const innerValue = (value as StructuredClonedAmount).value;
+  return ["bigint", "number", "string"].includes(typeof innerValue);
+}
+
+/**
+ * Convert cashu-ts Amount values to the number representation used by the app.
+ * IndexedDB's structured clone strips Amount's prototype and leaves its
+ * bigint-backed `{ value }` property behind, so accept that legacy shape too.
+ */
+export function cashuAmountToNumber(value: unknown): number {
+  const amountLike = isStructuredClonedAmount(value) ? value.value : value;
+  return Amount.from(amountLike as AmountLike).toNumber();
+}
+
+/**
+ * Normalize every amount-bearing quote field before it crosses the app's
+ * persistence boundary.
+ */
+export function normalizeCashuQuoteAmounts<T extends Record<string, any>>(
+  quote: T
+): T {
+  const normalized: Record<string, any> = { ...quote };
+
+  for (const field of [
+    "amount",
+    "amount_paid",
+    "amount_issued",
+    "fee_reserve",
+    "fee_paid",
+  ]) {
+    if (
+      field in normalized &&
+      normalized[field] !== null &&
+      normalized[field] !== undefined
+    ) {
+      normalized[field] = cashuAmountToNumber(normalized[field]);
+    }
+  }
+
+  if (Array.isArray(normalized.fee_options)) {
+    normalized.fee_options = normalized.fee_options.map((option: any) => ({
+      ...option,
+      fee_reserve:
+        option.fee_reserve === null || option.fee_reserve === undefined
+          ? option.fee_reserve
+          : cashuAmountToNumber(option.fee_reserve),
+    }));
+  }
+
+  if (Array.isArray(normalized.change)) {
+    normalized.change = normalized.change.map((signature: any) => ({
+      ...signature,
+      amount:
+        signature.amount === null || signature.amount === undefined
+          ? signature.amount
+          : cashuAmountToNumber(signature.amount),
+    }));
+  }
+
+  return normalized as T;
+}

--- a/src/stores/__tests__/dexieAmountMigration.test.ts
+++ b/src/stores/__tests__/dexieAmountMigration.test.ts
@@ -1,0 +1,77 @@
+import "fake-indexeddb/auto";
+import { Amount } from "@cashu/cashu-ts";
+import Dexie from "dexie";
+import { afterEach, describe, expect, it } from "vitest";
+import { CashuDexie } from "src/stores/dexie";
+
+const databaseNames: string[] = [];
+
+function versionThreeSchema(db: Dexie) {
+  db.version(3).stores({
+    proofs: "secret, id, C, amount, reserved, quote",
+    paymentHistory:
+      "id, direction, quote, parentQuote, method, status, mint, unit, date, paidDate, [direction+quote], [direction+status], [method+status]",
+    mintQuotes: "quote, method, request, unit, state, expiry, pubkey",
+    meltQuotes: "quote, method, request, unit, state, expiry",
+    ecashHistory:
+      "id, status, token, mint, unit, date, paidDate, paymentRequestId, [status+date], [mint+unit]",
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(databaseNames.splice(0).map((name) => Dexie.delete(name)));
+});
+
+describe("CashuDexie amount migration", () => {
+  it("repairs structured-cloned Amount values from version 3", async () => {
+    const databaseName = `cashu-amount-migration-${crypto.randomUUID()}`;
+    databaseNames.push(databaseName);
+    const legacyDb = new Dexie(databaseName);
+    versionThreeSchema(legacyDb);
+
+    await legacyDb.open();
+    await legacyDb.table("proofs").put({
+      secret: "proof-secret",
+      id: "keyset-id",
+      C: "proof-signature",
+      amount: structuredClone(Amount.from(8)),
+      reserved: false,
+    });
+    await legacyDb.table("meltQuotes").put({
+      quote: "melt-quote",
+      method: "bolt11",
+      amount: structuredClone(Amount.from(100)),
+      fee_reserve: structuredClone(Amount.from(5)),
+      change: [
+        {
+          id: "keyset-id",
+          amount: structuredClone(Amount.from(2)),
+          C_: "change-signature",
+        },
+      ],
+    });
+    legacyDb.close();
+
+    const migratedDb = new CashuDexie(databaseName);
+    await migratedDb.open();
+
+    expect((await migratedDb.proofs.get("proof-secret"))?.amount).toBe(8);
+    expect(await migratedDb.meltQuotes.get("melt-quote")).toEqual(
+      expect.objectContaining({
+        amount: 100,
+        fee_reserve: 5,
+        change: [
+          {
+            id: "keyset-id",
+            amount: 2,
+            C_: "change-signature",
+          },
+        ],
+      })
+    );
+    const migratedQuotes = await migratedDb.meltQuotes.toArray();
+    expect(() => JSON.stringify(migratedQuotes)).not.toThrow();
+
+    migratedDb.close();
+  });
+});

--- a/src/stores/__tests__/storageBackup.test.ts
+++ b/src/stores/__tests__/storageBackup.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { parseBackupTable, stringifyBackupTable } from "src/stores/storage";
+
+describe("wallet backup table serialization", () => {
+  it("serializes bigint-bearing legacy rows without throwing", () => {
+    const serialized = stringifyBackupTable([
+      { quote: "legacy-quote", amount: { value: 21n } },
+    ]);
+
+    expect(serialized).toBe('[{"quote":"legacy-quote","amount":{"value":21}}]');
+    expect(parseBackupTable(serialized)).toEqual([
+      { quote: "legacy-quote", amount: { value: 21 } },
+    ]);
+  });
+
+  it("rejects a malformed backup table", () => {
+    expect(() => parseBackupTable('{"not":"a table"}')).toThrow(
+      "Invalid wallet backup table"
+    );
+  });
+});

--- a/src/stores/__tests__/wallet.test.js
+++ b/src/stores/__tests__/wallet.test.js
@@ -1707,10 +1707,13 @@ describe("wallet store", () => {
     expect(h.outputDataDeserialize).toHaveBeenCalledWith({
       serialized: "change-output",
     });
-    expect(createMeltChangeProofs).toHaveBeenCalledWith(
-      [{ deserialized: { serialized: "change-output" } }],
-      changeSigs
-    );
+    const [restoredOutputs, restoredChangeSigs] =
+      createMeltChangeProofs.mock.calls[0];
+    expect(restoredOutputs).toEqual([
+      { deserialized: { serialized: "change-output" } },
+    ]);
+    expect(restoredChangeSigs[0]).toMatchObject({ id: "00aa", C_: "sig" });
+    expect(restoredChangeSigs[0].amount.toNumber()).toBe(3);
     expect(h.proofsStore.addMissingProofs).toHaveBeenCalledWith(changeProofs);
     expect(wallet.invoiceHistory[0]).toMatchObject({
       status: "paid",
@@ -1760,10 +1763,13 @@ describe("wallet store", () => {
     expect(h.outputDataDeserialize).toHaveBeenCalledWith({
       serialized: "legacy-change-output",
     });
-    expect(createMeltChangeProofs).toHaveBeenCalledWith(
-      [{ deserialized: { serialized: "legacy-change-output" } }],
-      changeSigs
-    );
+    const [restoredOutputs, restoredChangeSigs] =
+      createMeltChangeProofs.mock.calls[0];
+    expect(restoredOutputs).toEqual([
+      { deserialized: { serialized: "legacy-change-output" } },
+    ]);
+    expect(restoredChangeSigs[0]).toMatchObject({ id: "00aa", C_: "sig" });
+    expect(restoredChangeSigs[0].amount.toNumber()).toBe(3);
     expect(wallet.invoiceHistory[0]).toMatchObject({
       status: "paid",
       amount: -102,

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -2,6 +2,10 @@ import { defineStore } from "pinia";
 import Dexie, { Table } from "dexie";
 import { useLocalStorage } from "@vueuse/core";
 import type { WalletProof } from "./mints";
+import {
+  cashuAmountToNumber,
+  normalizeCashuQuoteAmounts,
+} from "src/js/cashu-amount";
 
 // export interface Proof {
 //   id: string
@@ -19,8 +23,8 @@ export class CashuDexie extends Dexie {
   meltQuotes!: Table<any>;
   ecashHistory!: Table<any>;
 
-  constructor() {
-    super("db");
+  constructor(databaseName = "db") {
+    super(databaseName);
     this.version(1).stores({
       proofs: "secret, id, C, amount, reserved, quote",
     });
@@ -40,6 +44,36 @@ export class CashuDexie extends Dexie {
       ecashHistory:
         "id, status, token, mint, unit, date, paidDate, paymentRequestId, [status+date], [mint+unit]",
     });
+    this.version(4)
+      .stores({
+        proofs: "secret, id, C, amount, reserved, quote",
+        paymentHistory:
+          "id, direction, quote, parentQuote, method, status, mint, unit, date, paidDate, [direction+quote], [direction+status], [method+status]",
+        mintQuotes: "quote, method, request, unit, state, expiry, pubkey",
+        meltQuotes: "quote, method, request, unit, state, expiry",
+        ecashHistory:
+          "id, status, token, mint, unit, date, paidDate, paymentRequestId, [status+date], [mint+unit]",
+      })
+      .upgrade(async (transaction) => {
+        await transaction
+          .table("proofs")
+          .toCollection()
+          .modify((proof) => {
+            proof.amount = cashuAmountToNumber(proof.amount);
+          });
+        await transaction
+          .table("mintQuotes")
+          .toCollection()
+          .modify((quote) => {
+            Object.assign(quote, normalizeCashuQuoteAmounts(quote));
+          });
+        await transaction
+          .table("meltQuotes")
+          .toCollection()
+          .modify((quote) => {
+            Object.assign(quote, normalizeCashuQuoteAmounts(quote));
+          });
+      });
   }
 }
 

--- a/src/stores/paymentHistory.ts
+++ b/src/stores/paymentHistory.ts
@@ -1,9 +1,9 @@
 import { defineStore } from "pinia";
-import { Amount } from "@cashu/cashu-ts";
 import { liveQuery } from "dexie";
 import { cashuDb } from "./dexie";
 import { PaymentMethod } from "src/stores/walletTypes";
 import { currentDateStr } from "src/js/utils";
+import { normalizeCashuQuoteAmounts } from "src/js/cashu-amount";
 
 export type PaymentDirection = "mint" | "melt";
 export type PaymentStatus = "pending" | "paid";
@@ -100,38 +100,6 @@ type BuiltRows = {
   mintQuote?: MintQuoteRow;
   meltQuote?: MeltQuoteRow;
 };
-
-function amountToNumber(value: any): number | null | undefined {
-  if (value === undefined || value === null) return value;
-  if (typeof value === "number") return value;
-  try {
-    return Amount.from(value).toNumber();
-  } catch {
-    return Number(value);
-  }
-}
-
-function normalizeAmountFields<T extends Record<string, any>>(quote: T): T {
-  const normalized: Record<string, any> = { ...quote };
-  for (const field of [
-    "amount",
-    "amount_paid",
-    "amount_issued",
-    "fee_reserve",
-    "fee_paid",
-  ]) {
-    if (field in normalized && normalized[field] !== null) {
-      normalized[field] = amountToNumber(normalized[field]);
-    }
-  }
-  if (Array.isArray(normalized.fee_options)) {
-    normalized.fee_options = normalized.fee_options.map((option: any) => ({
-      ...option,
-      fee_reserve: amountToNumber(option.fee_reserve),
-    }));
-  }
-  return normalized as T;
-}
 
 function normalizeMethod(method?: string | PaymentMethod): QuoteMethod {
   if (
@@ -277,7 +245,7 @@ export function normalizeMintQuote(
   method: QuoteMethod
 ): MintQuoteRow {
   return compactRecord({
-    ...normalizeAmountFields(quote),
+    ...normalizeCashuQuoteAmounts(quote),
     quote: quote.quote,
     method,
   }) as MintQuoteRow;
@@ -288,7 +256,7 @@ export function normalizeMeltQuote(
   method: QuoteMethod
 ): MeltQuoteRow {
   return compactRecord({
-    ...normalizeAmountFields(quote),
+    ...normalizeCashuQuoteAmounts(quote),
     quote: quote.quote,
     method,
   }) as MeltQuoteRow;

--- a/src/stores/proofs.ts
+++ b/src/stores/proofs.ts
@@ -12,6 +12,7 @@ import {
 } from "@cashu/cashu-ts";
 import { liveQuery } from "dexie";
 import { sumProofAmounts } from "src/js/proofs";
+import { cashuAmountToNumber } from "src/js/cashu-amount";
 
 // Shape of a proof row as stored in Dexie (amount may be number or Amount).
 type DexieProofRow = ProofLike & { reserved?: boolean; quote?: string };
@@ -19,7 +20,7 @@ type DexieProofRow = ProofLike & { reserved?: boolean; quote?: string };
 function coerceWalletProofs(raw: DexieProofRow[]): WalletProof[] {
   return raw.map(({ amount, reserved, quote, ...rest }) => ({
     ...rest,
-    amount: Amount.from(amount).toNumber(),
+    amount: cashuAmountToNumber(amount),
     reserved: Boolean(reserved),
     quote,
   }));

--- a/src/stores/storage.ts
+++ b/src/stores/storage.ts
@@ -13,6 +13,23 @@ import {
 } from "./paymentHistory";
 import { cashuDb } from "./dexie";
 import { deserializeProofs, JSONInt } from "@cashu/cashu-ts";
+import { normalizeCashuQuoteAmounts } from "src/js/cashu-amount";
+
+export function stringifyBackupTable(rows: unknown[]): string {
+  const serialized = JSONInt.stringify(rows);
+  if (serialized === undefined) {
+    throw new Error("Could not serialize wallet backup table");
+  }
+  return serialized;
+}
+
+export function parseBackupTable(value: string): any[] {
+  const parsed = JSONInt.parse(value);
+  if (!Array.isArray(parsed)) {
+    throw new Error("Invalid wallet backup table");
+  }
+  return parsed;
+}
 
 export const useStorageStore = defineStore("storage", {
   state: () => ({
@@ -34,13 +51,17 @@ export const useStorageStore = defineStore("storage", {
             const proofs = deserializeProofs(backup[key]);
             await proofsStore.addProofs(proofs);
           } else if (key === "cashu.dexie.db.paymentHistory") {
-            await cashuDb.paymentHistory.bulkPut(JSON.parse(backup[key]));
+            await cashuDb.paymentHistory.bulkPut(parseBackupTable(backup[key]));
           } else if (key === "cashu.dexie.db.mintQuotes") {
-            await cashuDb.mintQuotes.bulkPut(JSON.parse(backup[key]));
+            await cashuDb.mintQuotes.bulkPut(
+              parseBackupTable(backup[key]).map(normalizeCashuQuoteAmounts)
+            );
           } else if (key === "cashu.dexie.db.meltQuotes") {
-            await cashuDb.meltQuotes.bulkPut(JSON.parse(backup[key]));
+            await cashuDb.meltQuotes.bulkPut(
+              parseBackupTable(backup[key]).map(normalizeCashuQuoteAmounts)
+            );
           } else if (key === "cashu.dexie.db.ecashHistory") {
-            await cashuDb.ecashHistory.bulkPut(JSON.parse(backup[key]));
+            await cashuDb.ecashHistory.bulkPut(parseBackupTable(backup[key]));
           } else if (key === "cashu.invoiceHistory") {
             const rows = (
               JSON.parse(backup[key]) as LegacyInvoiceHistory[]
@@ -93,16 +114,16 @@ export const useStorageStore = defineStore("storage", {
       // proofs table *magic*
       const proofs = await useProofsStore().getProofs();
       jsonToSave["cashu.dexie.db.proofs"] = JSONInt.stringify(proofs);
-      jsonToSave["cashu.dexie.db.paymentHistory"] = JSON.stringify(
+      jsonToSave["cashu.dexie.db.paymentHistory"] = stringifyBackupTable(
         await cashuDb.paymentHistory.toArray()
       );
-      jsonToSave["cashu.dexie.db.mintQuotes"] = JSON.stringify(
+      jsonToSave["cashu.dexie.db.mintQuotes"] = stringifyBackupTable(
         await cashuDb.mintQuotes.toArray()
       );
-      jsonToSave["cashu.dexie.db.meltQuotes"] = JSON.stringify(
+      jsonToSave["cashu.dexie.db.meltQuotes"] = stringifyBackupTable(
         await cashuDb.meltQuotes.toArray()
       );
-      jsonToSave["cashu.dexie.db.ecashHistory"] = JSON.stringify(
+      jsonToSave["cashu.dexie.db.ecashHistory"] = stringifyBackupTable(
         await cashuDb.ecashHistory.toArray()
       );
 

--- a/src/stores/walletMelt.ts
+++ b/src/stores/walletMelt.ts
@@ -6,6 +6,7 @@ import {
   MeltQuoteOnchainResponse,
   MeltQuoteState,
   OutputData,
+  type SerializedBlindedSignature,
   type ProofLike,
   Wallet,
   type AmountLike,
@@ -22,6 +23,7 @@ import { useMintsStore, WalletProof } from "./mints";
 import { usePaymentHistoryStore } from "./paymentHistory";
 import { useProofsStore } from "./proofs";
 import { useUiStore } from "src/stores/ui";
+import { cashuAmountToNumber } from "src/js/cashu-amount";
 
 let isUnloading = false;
 if (typeof window !== "undefined") {
@@ -34,6 +36,10 @@ type AppOnchainFeeOption = {
   fee_index: number;
   fee_reserve: number;
   estimated_blocks: number;
+};
+
+type AppBlindedSignature = Omit<SerializedBlindedSignature, "amount"> & {
+  amount: number;
 };
 
 export type AppMeltQuote = {
@@ -49,7 +55,7 @@ export type AppMeltQuote = {
   fee_options?: AppOnchainFeeOption[];
   selected_fee_index?: number | null;
   outpoint?: string | null;
-  change?: any[];
+  change?: AppBlindedSignature[];
 };
 
 type CheckMeltQuoteFn = (quoteId: string) => Promise<
@@ -73,7 +79,7 @@ const proofsStore = useProofsStore();
 
 function amountToNumber(value: AmountLike | undefined): number {
   if (value === undefined) return 0;
-  return Amount.from(value).toNumber();
+  return cashuAmountToNumber(value);
 }
 
 export function normalizeMeltQuote(
@@ -97,7 +103,12 @@ export function normalizeMeltQuote(
     payment_preimage:
       "payment_preimage" in quote ? quote.payment_preimage : null,
   };
-  if (change) normalized.change = change;
+  if (change) {
+    normalized.change = change.map((signature) => ({
+      ...signature,
+      amount: amountToNumber(signature.amount),
+    }));
+  }
   if ("fee_options" in quote) {
     normalized.fee_options = quote.fee_options.map((option) => ({
       ...option,
@@ -363,7 +374,10 @@ export async function finalizePaidMeltInvoice(
     );
     const changeProofs = mintWallet.createMeltChangeProofs(
       outputData,
-      meltQuote.change
+      meltQuote.change.map((signature) => ({
+        ...signature,
+        amount: Amount.from(signature.amount),
+      }))
     );
     if (changeProofs.length) {
       await proofsStore.addMissingProofs(changeProofs);


### PR DESCRIPTION
## Summary

- normalize cashu-ts Amount values, including nested melt change signatures, before IndexedDB persistence
- migrate existing Dexie v3 proofs and quote records whose Amount prototypes were stripped by structured clone
- serialize and restore every Dexie backup table with the bigint-safe JSONInt helpers
- rehydrate persisted melt change signature amounts before passing them back to cashu-ts

## Testing

- npm test -- --run (131 tests passed)
- npm run lint -- --no-fix
- npm run build:pwa
- make staging
- verified the staging endpoint responds with HTTP 200