### PR TITLE
Refactor invoice worker into transaction worker

### DIFF
--- a/src/components/CreateInvoiceDialog.vue
+++ b/src/components/CreateInvoiceDialog.vue
@@ -244,7 +244,6 @@ import { useUiStore } from "src/stores/ui";
 import { useMintsStore } from "src/stores/mints";
 import { useSettingsStore } from "src/stores/settings";
 import { usePriceStore } from "src/stores/price";
-import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
 import type { InvoiceHistory } from "src/stores/wallet";
 import { PaymentMethod } from "src/stores/walletTypes";
 import { mintSupportsPaymentMethod } from "src/js/mint-payment-methods";

--- a/src/components/DisplayTokenComponent.vue
+++ b/src/components/DisplayTokenComponent.vue
@@ -322,7 +322,7 @@ import { Buffer } from "buffer";
 import { UR, UREncoder } from "@gandlaf21/bc-ur";
 import { mapActions, mapState, mapWritableState } from "pinia";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
-import { useWorkersStore } from "src/stores/workers";
+import { useTransactionWorkerStore } from "src/stores/transactionWorker";
 import { useUiStore } from "src/stores/ui";
 import { useCameraStore } from "src/stores/camera";
 import { useSettingsStore } from "src/stores/settings";
@@ -388,7 +388,7 @@ export default defineComponent({
     ...mapWritableState(useSendTokensStore, ["showSendTokens", "sendData"]),
     ...mapWritableState(useCameraStore, ["hasCamera"]),
     ...mapState(useUiStore, ["ndefSupported", "webShareSupported"]),
-    ...mapState(useWorkersStore, ["tokenWorkerRunning"]),
+    ...mapState(useTransactionWorkerStore, ["outgoingPayments"]),
     ...mapState(useSettingsStore, ["nfcEncoding"]),
     // display helpers
     sumProofs: function () {
@@ -406,7 +406,10 @@ export default defineComponent({
       return this.sumProofs - Math.abs(this.sendData.historyAmount ?? 0);
     },
     runnerActive: function () {
-      return this.tokenWorkerRunning;
+      return this.outgoingPayments.some(
+        (entry) =>
+          entry.type === "token" && entry.id === this.sendData.tokensBase64
+      );
     },
     copyButtonLabel: function () {
       if (this.copyButtonCopied) {
@@ -435,7 +438,9 @@ export default defineComponent({
     },
   },
   methods: {
-    ...mapActions(useWorkersStore, ["clearAllWorkers"]),
+    ...mapActions(useTransactionWorkerStore, [
+      "removeOutgoingTokenFromChecker",
+    ]),
     ...mapActions(useTokensStore, ["deleteToken"]),
     ...mapActions(useCameraStore, ["showCamera"]),
     copyUsingMixin(text: string) {
@@ -639,10 +644,11 @@ export default defineComponent({
       this.scanningCard = false;
     },
     deleteThisToken: function () {
-      this.deleteToken(this.sendData.tokensBase64);
+      const tokenToDelete = this.sendData.tokensBase64;
+      this.removeOutgoingTokenFromChecker(tokenToDelete);
+      this.deleteToken(tokenToDelete);
       this.showSendTokens = false;
       this.showDeleteDialog = false;
-      this.clearAllWorkers();
     },
     copyTokens: async function () {
       try {

--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -164,7 +164,7 @@ import { useReceiveTokensStore } from "src/stores/receiveTokensStore";
 import { useWalletStore } from "src/stores/wallet";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import { useUiStore } from "src/stores/ui";
-import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
+import { useTransactionWorkerStore } from "src/stores/transactionWorker";
 import token from "../js/token";
 import { notify } from "src/js/notify";
 import {
@@ -276,7 +276,7 @@ export default defineComponent({
       "checkOfferAndMintBolt12",
       "checkOnchainAndMint",
     ]),
-    ...mapActions(useInvoicesWorkerStore, [
+    ...mapActions(useTransactionWorkerStore, [
       "addInvoiceToChecker",
       "addBolt12OfferToChecker",
       "addOutgoingInvoiceToChecker",

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -279,8 +279,7 @@ import { useMintsStore } from "src/stores/mints";
 import { useTokensStore } from "src/stores/tokens";
 import { getShortUrl } from "src/js/wallet-helpers";
 import { useSettingsStore } from "src/stores/settings";
-import { useWorkersStore } from "src/stores/workers";
-import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
+import { useTransactionWorkerStore } from "src/stores/transactionWorker";
 import { usePriceStore } from "src/stores/price";
 import { useCameraStore } from "src/stores/camera";
 import { useP2PKStore } from "src/stores/p2pk";
@@ -354,7 +353,6 @@ export default defineComponent({
       "currentCurrencyPrice",
     ]),
     ...mapState(useSettingsStore, ["bitcoinPriceCurrency"]),
-    ...mapState(useWorkersStore, ["tokenWorkerRunning"]),
     insufficientFunds: function (): boolean {
       if (this.sendData.amount == null) return false;
       return (
@@ -508,8 +506,7 @@ export default defineComponent({
     },
   },
   methods: {
-    ...mapActions(useWorkersStore, ["clearAllWorkers"]),
-    ...mapActions(useInvoicesWorkerStore, ["addOutgoingTokenToChecker"]),
+    ...mapActions(useTransactionWorkerStore, ["addOutgoingTokenToChecker"]),
     ...mapActions(useWalletStore, [
       "send",
       "sendToLock",

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -235,7 +235,6 @@ import { mapActions, mapState, mapWritableState } from "pinia";
 import { useMintsStore } from "src/stores/mints";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import { useReceiveTokensStore } from "src/stores/receiveTokensStore";
-import { useWorkersStore } from "src/stores/workers";
 import { useTokensStore } from "src/stores/tokens";
 import { useWalletStore } from "src/stores/wallet";
 import { useUiStore } from "src/stores/ui";
@@ -252,7 +251,7 @@ import { useDexieStore } from "src/stores/dexie";
 import { useStorageStore } from "src/stores/storage";
 import ReceiveTokenDialog from "src/components/ReceiveTokenDialog.vue";
 import { useWelcomeStore } from "../stores/welcome";
-import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
+import { useTransactionWorkerStore } from "src/stores/transactionWorker";
 import { notifyError, notify } from "../js/notify";
 
 import {
@@ -338,10 +337,6 @@ export default {
       "payInvoiceData",
     ]),
     ...mapWritableState(useMintsStore, ["addMintData", "showAddMintDialog"]),
-    ...mapWritableState(useWorkersStore, [
-      "invoiceCheckListener",
-      "tokensCheckSpendableListener",
-    ]),
     ...mapState(useTokensStore, ["historyTokens"]),
     ...mapState(usePRStore, ["enablePaymentRequest"]),
     ...mapWritableState(useCameraStore, ["camera", "hasCamera"]),
@@ -372,7 +367,6 @@ export default {
       "setProofs",
       "getKeysForKeyset",
     ]),
-    ...mapActions(useWorkersStore, ["clearAllWorkers", "invoiceCheckWorker"]),
     ...mapActions(useTokensStore, ["setTokenPaid", "initEcashHistory"]),
     ...mapActions(useWalletStore, [
       "setInvoicePaid",
@@ -396,9 +390,9 @@ export default {
     ...mapActions(useDexieStore, ["migrateToDexie"]),
     ...mapActions(useStorageStore, ["checkLocalStorage"]),
     ...mapActions(usePRStore, ["createPaymentRequest"]),
-    ...mapActions(useInvoicesWorkerStore, [
-      "startInvoiceCheckerWorker",
-      "checkPendingInvoices",
+    ...mapActions(useTransactionWorkerStore, [
+      "startTransactionWorker",
+      "checkPendingTransactions",
     ]),
     // TOKEN METHODS
     getProofs: function (decoded_token) {
@@ -708,11 +702,11 @@ export default {
       this.subscribeToNip17DirectMessages();
     }
 
-    // start invoice checker worker
-    this.startInvoiceCheckerWorker();
+    // Start background transaction reconciliation.
+    this.startTransactionWorker();
 
     // reconnect all websockets
-    this.checkPendingInvoices();
+    this.checkPendingTransactions();
   },
 };
 </script>

--- a/src/stores/__tests__/npubcash.test.ts
+++ b/src/stores/__tests__/npubcash.test.ts
@@ -2,7 +2,7 @@ import { NDKPrivateKeySigner } from "@nostr-dev-kit/ndk";
 import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
-import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
+import { useTransactionWorkerStore } from "src/stores/transactionWorker";
 import { useMintsStore } from "src/stores/mints";
 import { useNostrStore } from "src/stores/nostr";
 import { useNpubCashStore } from "src/stores/npubcash";
@@ -247,9 +247,9 @@ describe("npub.cash store", () => {
     mintsStore.mints = [
       { url: mintUrl, keys: [], keysets: [], info: { nuts: { 29: {} } } },
     ];
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     worker.quotes = [];
-    vi.spyOn(worker, "startInvoiceCheckerWorker").mockImplementation(() => {});
+    vi.spyOn(worker, "startTransactionWorker").mockImplementation(() => {});
     const walletStore = useWalletStore();
     walletStore.invoiceHistory = [];
     vi.spyOn(walletStore, "addPaymentHistory").mockImplementation(
@@ -312,7 +312,7 @@ describe("npub.cash store", () => {
     store.claimAutomatically = true;
     const settingsStore = useSettingsStore();
     settingsStore.periodicallyCheckIncomingInvoices = false;
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     worker.quotes = [];
     const walletStore = useWalletStore();
     walletStore.invoiceHistory = [];

--- a/src/stores/__tests__/transactionWorker.test.js
+++ b/src/stores/__tests__/transactionWorker.test.js
@@ -1,6 +1,6 @@
 import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
+import { useTransactionWorkerStore } from "src/stores/transactionWorker";
 import { useMintsStore } from "src/stores/mints";
 import { usePaymentHistoryStore } from "src/stores/paymentHistory";
 import { useProofsStore } from "src/stores/proofs";
@@ -52,14 +52,14 @@ function unpaidResponse(quote) {
   };
 }
 
-describe("invoices worker", () => {
+describe("transaction worker", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     await cashuDb.paymentHistory.clear();
     await cashuDb.mintQuotes.clear();
 
-    const worker = useInvoicesWorkerStore();
-    worker.stopInvoiceCheckerWorker();
+    const worker = useTransactionWorkerStore();
+    worker.stopTransactionWorker();
     worker.quotes = [];
     worker.bolt12Quotes = [];
     worker.onchainQuotes = [];
@@ -69,7 +69,6 @@ describe("invoices worker", () => {
     worker.mintLaneInFlight = {};
     worker.mintLastRequestAt = {};
     worker.mintQuoteClaims = {};
-    worker.lastPendingInvoiceCheck = 0;
 
     useMintsStore().mints = [];
     useTokensStore().historyTokens = [];
@@ -80,7 +79,7 @@ describe("invoices worker", () => {
   });
 
   afterEach(() => {
-    useInvoicesWorkerStore().stopInvoiceCheckerWorker();
+    useTransactionWorkerStore().stopTransactionWorker();
   });
 
   it.each([
@@ -89,13 +88,13 @@ describe("invoices worker", () => {
     [{ nuts: { 29: { methods: ["bolt12"] } } }, false],
     [{ nuts: {} }, false],
   ])("detects advertised Bolt11 batch support", (info, expected) => {
-    expect(useInvoicesWorkerStore().mintSupportsBolt11Batch({ info })).toBe(
+    expect(useTransactionWorkerStore().mintSupportsBolt11Batch({ info })).toBe(
       expected
     );
   });
 
   it("uses the normalized batch cap", () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
 
     expect(worker.bolt11BatchSizeLimit({ info: { nuts: { 29: {} } } })).toBe(
       100
@@ -107,11 +106,23 @@ describe("invoices worker", () => {
       date: new Date(Date.now() - 30 * 24 * 60 * 60 * 1_000).toISOString(),
     });
 
-    expect(useInvoicesWorkerStore().shouldCheckInvoice(oldInvoice)).toBe(true);
+    expect(useTransactionWorkerStore().shouldCheckInvoice(oldInvoice)).toBe(
+      true
+    );
+  });
+
+  it("starts for sent-token checks when incoming polling is disabled", () => {
+    const worker = useTransactionWorkerStore();
+    useSettingsStore().periodicallyCheckIncomingInvoices = false;
+    useSettingsStore().checkSentTokens = true;
+
+    worker.startTransactionWorker();
+
+    expect(worker.transactionCheckListener).not.toBeNull();
   });
 
   it("continues other mint lanes while one mint is still pending", async () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const now = Date.now();
     advertiseBatchMint(mintStore, "https://slow.example");
@@ -163,7 +174,7 @@ describe("invoices worker", () => {
       syncPaymentHistoryCache: vi.fn(),
     };
 
-    const firstDispatch = worker.processQuotes(walletStore);
+    const firstDispatch = worker.processTransactions(walletStore);
     await vi.waitFor(() =>
       expect(checkOutgoingInvoice).toHaveBeenCalledWith("fast-out-1", false)
     );
@@ -173,7 +184,7 @@ describe("invoices worker", () => {
 
     worker.mintLastRequestAt["https://fast.example"] =
       Date.now() - worker.checkInterval;
-    const secondDispatch = worker.processQuotes(walletStore);
+    const secondDispatch = worker.processTransactions(walletStore);
     await vi.waitFor(() =>
       expect(checkOutgoingInvoice).toHaveBeenCalledWith("fast-out-2", false)
     );
@@ -183,8 +194,76 @@ describe("invoices worker", () => {
     await Promise.all([firstDispatch, secondDispatch]);
   });
 
+  it("processes sent ecash through independent per-mint lanes", async () => {
+    const worker = useTransactionWorkerStore();
+    const now = Date.now();
+    const slowMint = "https://slow.example";
+    const fastMint = "https://fast.example";
+    useTokensStore().historyTokens = [
+      {
+        token: "slow-token",
+        amount: -10,
+        date: new Date(now).toISOString(),
+        status: "pending",
+        mint: slowMint,
+        unit: "sat",
+      },
+      {
+        token: "fast-token",
+        amount: -10,
+        date: new Date(now).toISOString(),
+        status: "pending",
+        mint: fastMint,
+        unit: "sat",
+      },
+    ];
+    worker.outgoingPayments = [
+      {
+        id: "slow-token",
+        type: "token",
+        addedAt: now - 20_000,
+        lastChecked: 0,
+        checkCount: 0,
+      },
+      {
+        id: "fast-token",
+        type: "token",
+        addedAt: now - 10_000,
+        lastChecked: 0,
+        checkCount: 0,
+      },
+    ];
+    let resolveSlowCheck;
+    const slowCheck = new Promise((resolve) => {
+      resolveSlowCheck = resolve;
+    });
+    const checkTokenSpendable = vi.fn((historyToken) =>
+      historyToken.token === "slow-token" ? slowCheck : Promise.resolve(false)
+    );
+    const walletStore = {
+      invoiceHistory: [],
+      checkTokenSpendable,
+    };
+
+    const processing = worker.processTransactions(walletStore);
+    await vi.waitFor(() =>
+      expect(checkTokenSpendable).toHaveBeenCalledWith(
+        expect.objectContaining({ token: "fast-token" }),
+        false
+      )
+    );
+    expect(worker.mintLaneInFlight[slowMint]).toBe(true);
+
+    resolveSlowCheck(false);
+    await processing;
+    expect(checkTokenSpendable).toHaveBeenCalledTimes(2);
+    expect(
+      worker.outgoingPayments.every((entry) => entry.checkCount === 1)
+    ).toBe(true);
+  });
+
   it("never overlaps work within the same mint lane", async () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const now = Date.now();
     mintStore.mints.push({
@@ -210,22 +289,22 @@ describe("invoices worker", () => {
       checkInvoiceBolt11,
     };
 
-    const firstDispatch = worker.processQuotes(walletStore);
+    const firstDispatch = worker.processTransactions(walletStore);
     await vi.waitFor(() => expect(checkInvoiceBolt11).toHaveBeenCalledOnce());
     worker.mintLastRequestAt["https://mint.example"] = 0;
-    await worker.processQuotes(walletStore);
+    await worker.processTransactions(walletStore);
 
     expect(checkInvoiceBolt11).toHaveBeenCalledOnce();
     resolveFirst();
     await firstDispatch;
 
     worker.mintLastRequestAt["https://mint.example"] = 0;
-    await worker.processQuotes(walletStore);
+    await worker.processTransactions(walletStore);
     expect(checkInvoiceBolt11).toHaveBeenCalledTimes(2);
   });
 
   it("rate-limits completed requests per mint, not globally", async () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const now = Date.now();
     mintStore.mints.push({
@@ -246,20 +325,20 @@ describe("invoices worker", () => {
       checkInvoiceBolt11,
     };
 
-    await worker.processQuotes(walletStore);
-    await worker.processQuotes(walletStore);
+    await worker.processTransactions(walletStore);
+    await worker.processTransactions(walletStore);
     expect(checkInvoiceBolt11).toHaveBeenCalledOnce();
 
     worker.mintLastRequestAt["https://mint.example"] =
       Date.now() - worker.checkInterval;
-    await worker.processQuotes(walletStore);
+    await worker.processTransactions(walletStore);
     expect(checkInvoiceBolt11).toHaveBeenCalledTimes(2);
     expect(checkInvoiceBolt11.mock.calls[0][0]).toBe("first-q");
     expect(checkInvoiceBolt11.mock.calls[1][0]).toBe("second-q");
   });
 
   it("batch-checks every due quote for a mint in one request", async () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const now = Date.now();
     advertiseBatchMint(mintStore, "https://mint.example");
@@ -282,7 +361,7 @@ describe("invoices worker", () => {
       syncPaymentHistoryCache: vi.fn(),
     };
 
-    await worker.processQuotes(walletStore);
+    await worker.processTransactions(walletStore);
 
     expect(checkMintQuoteBatchBolt11).toHaveBeenCalledWith([
       "first-q",
@@ -293,7 +372,7 @@ describe("invoices worker", () => {
   });
 
   it("honors the mint's batch cap and selects the oldest quotes", async () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const now = Date.now();
     advertiseBatchMint(mintStore, "https://mint.example", {
@@ -318,7 +397,7 @@ describe("invoices worker", () => {
       syncPaymentHistoryCache: vi.fn(),
     };
 
-    await worker.processQuotes(walletStore);
+    await worker.processTransactions(walletStore);
 
     expect(checkMintQuoteBatchBolt11).toHaveBeenCalledWith([
       "old-q",
@@ -330,7 +409,7 @@ describe("invoices worker", () => {
   });
 
   it("does not hold the wallet mutex during a mint's batch request", async () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const now = Date.now();
     const slowMint = "https://slow.example";
@@ -378,7 +457,7 @@ describe("invoices worker", () => {
       syncPaymentHistoryCache: vi.fn(),
     };
 
-    const processing = worker.processQuotes(walletStore);
+    const processing = worker.processTransactions(walletStore);
     await vi.waitFor(() =>
       expect(completeBatchMintByMint[slowMint]).toHaveBeenCalledOnce()
     );
@@ -391,7 +470,7 @@ describe("invoices worker", () => {
   });
 
   it("batch-mints paid quotes and retains unpaid quotes", async () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const now = Date.now();
     advertiseBatchMint(mintStore, "https://mint.example");
@@ -428,7 +507,7 @@ describe("invoices worker", () => {
       syncPaymentHistoryCache: vi.fn(),
     };
 
-    await worker.processQuotes(walletStore);
+    await worker.processTransactions(walletStore);
 
     expect(mintWallet.prepareBatchMint).toHaveBeenCalledOnce();
     expect(addProofs).toHaveBeenCalledOnce();
@@ -442,7 +521,7 @@ describe("invoices worker", () => {
   });
 
   it("does not batch-mint a quote already issued by its WebSocket callback", async () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const now = Date.now();
     advertiseBatchMint(mintStore, "https://mint.example");
@@ -470,7 +549,7 @@ describe("invoices worker", () => {
       syncPaymentHistoryCache: vi.fn(),
     };
 
-    await worker.processQuotes(walletStore);
+    await worker.processTransactions(walletStore);
 
     expect(checkMintQuoteBatchBolt11).toHaveBeenCalledTimes(2);
     expect(prepareBatchMint).not.toHaveBeenCalled();
@@ -484,7 +563,7 @@ describe("invoices worker", () => {
   });
 
   it("falls back to singles when a mint's batch path is broken", async () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const now = Date.now();
     advertiseBatchMint(mintStore, "https://mint.example");
@@ -506,7 +585,7 @@ describe("invoices worker", () => {
       }),
     };
 
-    await worker.processQuotes(walletStore);
+    await worker.processTransactions(walletStore);
 
     expect(walletStore.checkInvoiceBolt11).not.toHaveBeenCalled();
     expect(worker.quotes.every((entry) => entry.checkCount === 1)).toBe(true);
@@ -523,7 +602,7 @@ describe("invoices worker", () => {
     worker.quotes.forEach((entry) => {
       entry.lastChecked = 0;
     });
-    await worker.processQuotes(walletStore);
+    await worker.processTransactions(walletStore);
 
     expect(checkMintQuoteBatchBolt11).toHaveBeenCalledOnce();
     expect(walletStore.checkInvoiceBolt11).toHaveBeenCalledWith(
@@ -533,7 +612,7 @@ describe("invoices worker", () => {
   });
 
   it("keeps network failures on the mint-wide cooldown", async () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const now = Date.now();
     advertiseBatchMint(mintStore, "https://mint.example");
@@ -547,7 +626,7 @@ describe("invoices worker", () => {
       })),
     };
 
-    await worker.processQuotes(walletStore);
+    await worker.processTransactions(walletStore);
 
     expect(worker.reusableMintCooldowns["https://mint.example"]).toEqual(
       expect.objectContaining({ failureCount: 1 })
@@ -560,7 +639,7 @@ describe("invoices worker", () => {
   });
 
   it("does not dispatch sent-token checks when the privacy setting is off", async () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const now = Date.now();
     useSettingsStore().checkSentTokens = false;
@@ -584,14 +663,14 @@ describe("invoices worker", () => {
       checkOutgoingInvoice: vi.fn(),
     };
 
-    await worker.processQuotes(walletStore);
+    await worker.processTransactions(walletStore);
     await worker.processOutgoingQueue(now, walletStore);
 
     expect(walletStore.checkOutgoingInvoice).not.toHaveBeenCalled();
   });
 
   it("backs off only the failing mint", async () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const now = Date.now();
     advertiseBatchMint(mintStore, "https://offline.example");
@@ -621,7 +700,7 @@ describe("invoices worker", () => {
       checkInvoiceBolt11,
     };
 
-    await worker.processQuotes(walletStore);
+    await worker.processTransactions(walletStore);
 
     expect(worker.reusableMintCooldowns["https://offline.example"]).toEqual(
       expect.objectContaining({ failureCount: 1 })
@@ -633,8 +712,8 @@ describe("invoices worker", () => {
   });
 
   it("preserves queue metadata when WebSockets add the same fallback twice", () => {
-    const worker = useInvoicesWorkerStore();
-    vi.spyOn(worker, "startInvoiceCheckerWorker").mockImplementation(() => {});
+    const worker = useTransactionWorkerStore();
+    vi.spyOn(worker, "startTransactionWorker").mockImplementation(() => {});
     worker.quotes = [
       queuedQuote("bolt11-q", 100, { lastChecked: 200, checkCount: 7 }),
     ];
@@ -654,7 +733,7 @@ describe("invoices worker", () => {
   });
 
   it("queues all startup batches but caps and WebSocket-checks single quotes", () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const settingsStore = useSettingsStore();
     const batchMintUrl = "https://batch.example";
@@ -682,7 +761,7 @@ describe("invoices worker", () => {
       keysets: [],
       info: { nuts: {} },
     });
-    vi.spyOn(worker, "startInvoiceCheckerWorker").mockImplementation(() => {});
+    vi.spyOn(worker, "startTransactionWorker").mockImplementation(() => {});
     const walletStore = {
       invoiceHistory: [...batchInvoices, ...singleInvoices],
       mintOnPaidBolt11: vi.fn(async () => {}),
@@ -703,10 +782,9 @@ describe("invoices worker", () => {
   });
 
   it("immediately starts one startup batch lane for every mint", async () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     useSettingsStore().periodicallyCheckIncomingInvoices = false;
-    worker.lastPendingInvoiceCheck = Date.now() + 60_000;
     advertiseBatchMint(mintStore, "https://mint-a.example");
     advertiseBatchMint(mintStore, "https://mint-b.example");
     worker.quotes = [
@@ -721,7 +799,7 @@ describe("invoices worker", () => {
       failureCount: 3,
       nextRetryAt: Date.now() + 60_000,
     };
-    vi.spyOn(worker, "startInvoiceCheckerWorker").mockImplementation(() => {});
+    vi.spyOn(worker, "startTransactionWorker").mockImplementation(() => {});
     vi.spyOn(usePaymentHistoryStore(), "upsertMintQuote").mockResolvedValue();
     const batchChecks = new Map();
     const walletStore = {
@@ -738,7 +816,7 @@ describe("invoices worker", () => {
       syncPaymentHistoryCache: vi.fn(),
     };
 
-    await worker.checkPendingInvoices(walletStore);
+    await worker.checkPendingTransactions(walletStore);
 
     expect(batchChecks.get("https://mint-a.example")).toHaveBeenCalledWith([
       "a-q",
@@ -764,9 +842,9 @@ describe("invoices worker", () => {
   });
 
   it("keeps reusable WebSockets and worker queues active together", () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const now = new Date().toISOString();
-    vi.spyOn(worker, "startInvoiceCheckerWorker").mockImplementation(() => {});
+    vi.spyOn(worker, "startTransactionWorker").mockImplementation(() => {});
     const walletStore = {
       invoiceHistory: [
         pendingInvoice("bolt12-q", {
@@ -807,7 +885,7 @@ describe("invoices worker", () => {
   });
 
   it("checks reusable quotes on startup when periodic polling is off", async () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const settingsStore = useSettingsStore();
     settingsStore.periodicallyCheckIncomingInvoices = false;
     settingsStore.checkSentTokens = false;
@@ -850,7 +928,7 @@ describe("invoices worker", () => {
       syncPaymentHistoryCache: vi.fn(),
     };
 
-    await worker.checkPendingInvoices(walletStore);
+    await worker.checkPendingTransactions(walletStore);
 
     expect(bolt12Check).toHaveBeenCalledWith("bolt12-q");
     expect(onchainCheck).toHaveBeenCalledWith("onchain-q");
@@ -860,11 +938,11 @@ describe("invoices worker", () => {
     expect(worker.onchainQuotes.map((entry) => entry.quote)).toEqual([
       "onchain-q",
     ]);
-    expect(worker.invoiceCheckListener).toBeNull();
+    expect(worker.transactionCheckListener).toBeNull();
   });
 
   it("persists an on-chain probe with no mintable delta", async () => {
-    const worker = useInvoicesWorkerStore();
+    const worker = useTransactionWorkerStore();
     const now = Date.now();
     const invoice = pendingInvoice("onchain-q", {
       amount: 0,

--- a/src/stores/__tests__/wallet.test.js
+++ b/src/stores/__tests__/wallet.test.js
@@ -53,7 +53,7 @@ const h = vi.hoisted(() => {
     periodicallyCheckIncomingInvoices: true,
     useWebsockets: true,
   };
-  const invoicesWorkerStore = {
+  const transactionWorkerStore = {
     addInvoice: vi.fn(),
     removeInvoice: vi.fn(),
     addInvoiceToChecker: vi.fn(),
@@ -65,7 +65,6 @@ const h = vi.hoisted(() => {
     waitForMintQuoteRelease: vi.fn(async () => {}),
   };
   const workersStore = {
-    checkTokenSpendableWorker: vi.fn(),
     invoiceCheckWorker: vi.fn(),
   };
   const mintsStore = {
@@ -145,7 +144,7 @@ const h = vi.hoisted(() => {
     p2pkStore,
     prStore,
     settingsStore,
-    invoicesWorkerStore,
+    transactionWorkerStore,
     workersStore,
     mintsStore,
     priceStore,
@@ -257,8 +256,8 @@ vi.mock("src/stores/workers", () => ({
   useWorkersStore: () => h.workersStore,
 }));
 
-vi.mock("src/stores/invoicesWorker", () => ({
-  useInvoicesWorkerStore: () => h.invoicesWorkerStore,
+vi.mock("src/stores/transactionWorker", () => ({
+  useTransactionWorkerStore: () => h.transactionWorkerStore,
 }));
 
 vi.mock("src/stores/settings", () => ({
@@ -961,9 +960,9 @@ describe("wallet store", () => {
     await wallet.mintOnPaidBolt12("bolt12-q");
     await websocket.onUpdate()({ state: "PAID" });
 
-    expect(h.invoicesWorkerStore.addBolt12OfferToChecker).toHaveBeenCalledWith(
-      "bolt12-q"
-    );
+    expect(
+      h.transactionWorkerStore.addBolt12OfferToChecker
+    ).toHaveBeenCalledWith("bolt12-q");
     expect(websocket.connection.createSubscription).toHaveBeenCalledWith(
       { kind: "bolt12_mint_quote", filters: ["bolt12-q"] },
       expect.any(Function),
@@ -1014,10 +1013,9 @@ describe("wallet store", () => {
     await wallet.mintOnPaidOnchain("onchain-q");
     await websocket.onUpdate()({ state: "PAID" });
 
-    expect(h.invoicesWorkerStore.addOnchainQuoteToChecker).toHaveBeenCalledWith(
-      "onchain-q",
-      true
-    );
+    expect(
+      h.transactionWorkerStore.addOnchainQuoteToChecker
+    ).toHaveBeenCalledWith("onchain-q", true);
     expect(websocket.connection.createSubscription).toHaveBeenCalledWith(
       { kind: "onchain_mint_quote", filters: ["onchain-q"] },
       expect.any(Function),
@@ -1083,7 +1081,7 @@ describe("wallet store", () => {
     });
 
     expect(
-      h.invoicesWorkerStore.addOutgoingTokenToChecker
+      h.transactionWorkerStore.addOutgoingTokenToChecker
     ).toHaveBeenCalledWith("cashu-token", true);
     expect(mintWalletSpy).toHaveBeenCalledWith("https://mint-b.example", "sat");
     expect(wallet.activeWallet).not.toHaveBeenCalled();
@@ -1097,6 +1095,33 @@ describe("wallet store", () => {
       expect.any(Function),
       expect.any(Function)
     );
+  });
+
+  it("uses only the transaction worker when sent-token WebSockets are unavailable", async () => {
+    const wallet = useWalletStore();
+    h.settingsStore.useWebsockets = false;
+    h.mintsStore.mints = [
+      {
+        url: "https://mint-b.example",
+        keys: [{ id: "00bb" }],
+        keysets: [{ id: "00bb", unit: "sat", active: true }],
+        info: { nuts: {} },
+      },
+    ];
+    const mintWalletSpy = vi.spyOn(wallet, "mintWallet");
+
+    await wallet.onTokenPaid({
+      token: "cashu-token-no-websocket",
+      amount: -1,
+      mint: "https://mint-b.example",
+      unit: "sat",
+      status: "pending",
+    });
+
+    expect(
+      h.transactionWorkerStore.addOutgoingTokenToChecker
+    ).toHaveBeenCalledWith("cashu-token-no-websocket", true);
+    expect(mintWalletSpy).not.toHaveBeenCalled();
   });
 
   it("deduplicates sent-token websocket setup and spent checks", async () => {

--- a/src/stores/__tests__/workers.test.ts
+++ b/src/stores/__tests__/workers.test.ts
@@ -3,28 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   walletStore: {
     checkInvoiceBolt11: vi.fn(),
-    checkTokenSpendable: vi.fn(),
   },
-  settingsStore: {
-    checkSentTokens: true,
-  },
-  sendTokensStore: {
-    showSendTokens: true,
-  },
-  tokensStore: {},
 }));
 
 vi.mock("src/stores/wallet", () => ({
   useWalletStore: () => mocks.walletStore,
-}));
-vi.mock("src/stores/settings", () => ({
-  useSettingsStore: () => mocks.settingsStore,
-}));
-vi.mock("src/stores/sendTokensStore", () => ({
-  useSendTokensStore: () => mocks.sendTokensStore,
-}));
-vi.mock("src/stores/tokens", () => ({
-  useTokensStore: () => mocks.tokensStore,
 }));
 
 import { useWorkersStore } from "src/stores/workers";
@@ -37,8 +20,6 @@ describe("legacy workers", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
-    mocks.settingsStore.checkSentTokens = true;
-    mocks.sendTokensStore.showSendTokens = true;
   });
 
   afterEach(() => {
@@ -73,34 +54,5 @@ describe("legacy workers", () => {
     await flushPromises();
 
     expect(mocks.walletStore.checkInvoiceBolt11).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not overlap sent-token checks", async () => {
-    const worker = useWorkersStore();
-    worker.checkInterval = 100;
-    let resolveFirstCheck!: (paid: boolean) => void;
-    mocks.walletStore.checkTokenSpendable
-      .mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            resolveFirstCheck = resolve;
-          })
-      )
-      .mockResolvedValue(false);
-
-    await worker.checkTokenSpendableWorker({ token: "token-id" } as any);
-    vi.advanceTimersByTime(100);
-    await flushPromises();
-    vi.advanceTimersByTime(100);
-    await flushPromises();
-
-    expect(mocks.walletStore.checkTokenSpendable).toHaveBeenCalledOnce();
-
-    resolveFirstCheck(false);
-    await flushPromises();
-    vi.advanceTimersByTime(100);
-    await flushPromises();
-
-    expect(mocks.walletStore.checkTokenSpendable).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -5,7 +5,7 @@ import { defineStore } from "pinia";
 import { date } from "quasar";
 import { nip19 } from "nostr-tools";
 import { notifyApiError, notifyError } from "src/js/notify";
-import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
+import { useTransactionWorkerStore } from "src/stores/transactionWorker";
 import { useMintsStore } from "src/stores/mints";
 import { useNostrStore } from "src/stores/nostr";
 import { useSettingsStore } from "src/stores/settings";
@@ -303,7 +303,7 @@ export const useNpubCashStore = defineStore("npubCash", {
       if (!this.enabled) {
         return;
       }
-      const invoicesWorkerStore = useInvoicesWorkerStore();
+      const transactionWorkerStore = useTransactionWorkerStore();
       const settingsStore = useSettingsStore();
       const walletStore = useWalletStore();
       const mintsStore = useMintsStore();
@@ -358,10 +358,10 @@ export const useNpubCashStore = defineStore("npubCash", {
               const mint = mintsStore.mints.find(
                 (item) => item.url === quote.mintUrl
               );
-              if (invoicesWorkerStore.mintSupportsBolt11Batch(mint)) {
-                invoicesWorkerStore.addBatchInvoiceToChecker(quote.quoteId);
+              if (transactionWorkerStore.mintSupportsBolt11Batch(mint)) {
+                transactionWorkerStore.addBatchInvoiceToChecker(quote.quoteId);
               } else {
-                invoicesWorkerStore.addInvoiceToChecker(quote.quoteId);
+                transactionWorkerStore.addInvoiceToChecker(quote.quoteId);
               }
             } else {
               await walletStore.mintOnPaidBolt11(quote.quoteId);

--- a/src/stores/transactionWorker.ts
+++ b/src/stores/transactionWorker.ts
@@ -98,7 +98,7 @@ function amountToNumber(value: any) {
   return Amount.from(value).toNumber();
 }
 
-export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
+export const useTransactionWorkerStore = defineStore("transactionWorker", {
   state: () => ({
     // Requests are rate-limited independently for every mint URL.
     checkInterval: 5_000,
@@ -110,14 +110,16 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
     maxAge: 14 * 24 * 60 * 60 * 1_000,
     oneHour: 60 * 60 * 1_000,
 
-    invoiceCheckListener: null as NodeJS.Timeout | null,
-    invoiceWorkerRunning: false,
+    transactionCheckListener: null as NodeJS.Timeout | null,
+    transactionWorkerRunning: false,
 
     // Lane state is ephemeral so a restart immediately retries pending work.
     mintLaneInFlight: {} as Record<string, boolean>,
     mintLastRequestAt: {} as Record<string, number>,
     mintQuoteClaims: {} as Record<string, boolean>,
 
+    // These keys intentionally retain their old names so existing queues
+    // survive the store rename.
     quotes: useLocalStorage<InvoiceQuote[]>(
       "cashu.worker.invoices.quotesQueue",
       []
@@ -147,34 +149,34 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
 
     maxSingleBolt11QuotesToCheckOnStartup: 10,
     maxOutgoingPaymentsToCheckOnStartup: 10,
-    lastPendingInvoiceCheck: useLocalStorage<number>(
-      "cashu.worker.invoices.lastPendingInvoiceCheck",
-      0
-    ),
-    checkPendingInvoicesInterval: 10_000,
   }),
 
   actions: {
-    startInvoiceCheckerWorker(force = false) {
-      if (!force && !useSettingsStore().periodicallyCheckIncomingInvoices) {
+    startTransactionWorker(force = false) {
+      const settingsStore = useSettingsStore();
+      if (
+        !force &&
+        !settingsStore.periodicallyCheckIncomingInvoices &&
+        !settingsStore.checkSentTokens
+      ) {
         return;
       }
-      if (this.invoiceCheckListener) return;
+      if (this.transactionCheckListener) return;
 
-      this.invoiceWorkerRunning = true;
-      this.invoiceCheckListener = setInterval(() => {
-        void this.processQuotes().catch((error) => {
-          console.error("Invoice worker dispatch failed", error);
+      this.transactionWorkerRunning = true;
+      this.transactionCheckListener = setInterval(() => {
+        void this.processTransactions().catch((error) => {
+          console.error("Transaction worker dispatch failed", error);
         });
       }, this.workerTickInterval);
     },
 
-    stopInvoiceCheckerWorker() {
-      if (this.invoiceCheckListener) {
-        clearInterval(this.invoiceCheckListener);
-        this.invoiceCheckListener = null;
+    stopTransactionWorker() {
+      if (this.transactionCheckListener) {
+        clearInterval(this.transactionCheckListener);
+        this.transactionCheckListener = null;
       }
-      this.invoiceWorkerRunning = false;
+      this.transactionWorkerRunning = false;
     },
 
     addInvoiceToChecker(quote: string, forceStart = false) {
@@ -199,7 +201,7 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
           existing.lastChecked = 0;
           existing.checkCount = 0;
         }
-        this.startInvoiceCheckerWorker(forceStart);
+        this.startTransactionWorker(forceStart);
         return;
       }
 
@@ -222,7 +224,7 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
         checkCount: 0,
         ...(usesBatchPath ? { usesBatchPath: true } : {}),
       });
-      this.startInvoiceCheckerWorker(forceStart);
+      this.startTransactionWorker(forceStart);
     },
 
     removeInvoiceFromChecker(quote: string) {
@@ -267,7 +269,7 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
           checkCount: 0,
         });
       }
-      this.startInvoiceCheckerWorker(forceStart);
+      this.startTransactionWorker(forceStart);
     },
 
     addOutgoingInvoiceToChecker(quote: string, forceStart = false) {
@@ -307,7 +309,7 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
           checkCount: 0,
         });
       }
-      this.startInvoiceCheckerWorker(forceStart);
+      this.startTransactionWorker(forceStart);
     },
 
     removeOutgoingPaymentFromChecker(type: "invoice" | "token", id: string) {
@@ -473,7 +475,10 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
       return now >= Math.max(lastRequestAt + this.checkInterval, cooldownUntil);
     },
 
-    async processQuotes(walletStore?: any, prioritizeBolt11Batch = false) {
+    async processTransactions(
+      walletStore?: any,
+      prioritizeBolt11Batch = false
+    ) {
       const activeWalletStore = walletStore ?? useWalletStore();
       const settingsStore = useSettingsStore();
       const checkIncoming = settingsStore.periodicallyCheckIncomingInvoices;
@@ -1193,7 +1198,7 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
       );
     },
 
-    async checkPendingInvoices(walletStore?: any) {
+    async checkPendingTransactions(walletStore?: any) {
       if (!useSettingsStore().checkInvoicesOnStartup) return;
 
       const activeWalletStore = walletStore ?? useWalletStore();
@@ -1217,8 +1222,6 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
         this.shouldCheckInvoice(invoice)
       );
       let singleBolt11QuotesQueued = 0;
-      this.lastPendingInvoiceCheck = Date.now();
-
       for (const invoice of pending) {
         try {
           if (invoice.type === PaymentMethod.Bolt12) {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -9,8 +9,7 @@ import { useUiStore } from "src/stores/ui";
 import { useP2PKStore } from "src/stores/p2pk";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import { usePRStore } from "./payment-request";
-import { useWorkersStore } from "./workers";
-import { useInvoicesWorkerStore } from "./invoicesWorker";
+import { useTransactionWorkerStore } from "./transactionWorker";
 
 import {
   requestMintBolt11,
@@ -1095,7 +1094,7 @@ export const useWalletStore = defineStore("wallet", {
         );
         return;
       }
-      useInvoicesWorkerStore().addOutgoingTokenToChecker?.(
+      useTransactionWorkerStore().addOutgoingTokenToChecker?.(
         historyToken.token,
         true
       );
@@ -1114,9 +1113,8 @@ export const useWalletStore = defineStore("wallet", {
         )
       ) {
         console.log(
-          "Websockets not supported, kicking off token check worker."
+          "Websockets not supported; the transaction worker will continue checking the token."
         );
-        useWorkersStore().checkTokenSpendableWorker(historyToken);
         return;
       }
 
@@ -1186,10 +1184,9 @@ export const useWalletStore = defineStore("wallet", {
       } catch (error) {
         cleanup();
         console.error(
-          "Error in websocket subscription. Starting invoices worker.",
+          "Error in websocket subscription. The transaction worker remains active.",
           error
         );
-        useWorkersStore().checkTokenSpendableWorker(historyToken);
       } finally {
         this.activeWebsocketConnections--;
       }
@@ -1239,7 +1236,10 @@ export const useWalletStore = defineStore("wallet", {
       } catch (error) {
         console.error("Could not persist outgoing payment history", error);
       }
-      useInvoicesWorkerStore().addOutgoingInvoiceToChecker?.(quote.quote, true);
+      useTransactionWorkerStore().addOutgoingInvoiceToChecker?.(
+        quote.quote,
+        true
+      );
     },
     removeOutgoingInvoiceFromHistory: async function (quote: string) {
       const index = this.invoiceHistory.findIndex((i) => i.quote === quote);

--- a/src/stores/walletBolt11.ts
+++ b/src/stores/walletBolt11.ts
@@ -18,7 +18,7 @@ import {
   notifyError,
 } from "src/js/notify";
 import type { InvoiceHistory } from "./wallet";
-import { useInvoicesWorkerStore } from "./invoicesWorker";
+import { useTransactionWorkerStore } from "./transactionWorker";
 import * as bolt11Decoder from "light-bolt11-decoder";
 import * as _ from "underscore";
 import { date } from "quasar";
@@ -104,14 +104,16 @@ export async function mintBolt11(
     throw new Error("mint not found");
   }
 
-  const invoicesWorkerStore = useInvoicesWorkerStore();
+  const transactionWorkerStore = useTransactionWorkerStore();
   while (true) {
-    await invoicesWorkerStore.waitForMintQuoteRelease(
+    await transactionWorkerStore.waitForMintQuoteRelease(
       invoice.mint,
       invoice.quote
     );
     await uIStore.lockMutex();
-    if (!invoicesWorkerStore.mintQuoteIsClaimed(invoice.mint, invoice.quote)) {
+    if (
+      !transactionWorkerStore.mintQuoteIsClaimed(invoice.mint, invoice.quote)
+    ) {
       break;
     }
     uIStore.unlockMutex();
@@ -158,7 +160,7 @@ export async function mintBolt11(
 
     // update UI
     await this.setInvoicePaid(invoice.quote);
-    useInvoicesWorkerStore().removeInvoiceFromChecker(invoice.quote);
+    useTransactionWorkerStore().removeInvoiceFromChecker(invoice.quote);
 
     return proofs;
   } catch (error: any) {

--- a/src/stores/walletBolt12.ts
+++ b/src/stores/walletBolt12.ts
@@ -7,7 +7,6 @@ import * as nobleSecp256k1 from "@noble/secp256k1";
 import { bytesToHex } from "@noble/hashes/utils";
 import { notifyApiError, notify, notifySuccess } from "src/js/notify";
 import type { InvoiceHistory } from "./wallet";
-import { useInvoicesWorkerStore } from "./invoicesWorker";
 import { mintOnPaidGeneric } from "./walletWebsocket";
 import { PaymentMethod } from "src/stores/walletTypes";
 import { usePriceStore } from "./price";

--- a/src/stores/walletMelt.ts
+++ b/src/stores/walletMelt.ts
@@ -17,7 +17,7 @@ import {
   notifySuccess,
   notifyWarning,
 } from "src/js/notify";
-import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
+import { useTransactionWorkerStore } from "src/stores/transactionWorker";
 import { PaymentMethod } from "src/stores/walletTypes";
 import { useMintsStore, WalletProof } from "./mints";
 import { usePaymentHistoryStore } from "./paymentHistory";
@@ -319,7 +319,7 @@ export async function checkOutgoingInvoiceGeneric(
     } else if (meltQuote.state == MeltQuoteState.UNPAID) {
       await useProofsStore().setReserved(proofs, false);
       await this.removeOutgoingInvoiceFromHistory(quote);
-      useInvoicesWorkerStore().removeOutgoingInvoiceFromChecker?.(quote);
+      useTransactionWorkerStore().removeOutgoingInvoiceFromChecker?.(quote);
       notifyWarning(this.t("wallet.notifications.lightning_payment_failed"));
     } else if (meltQuote.state == MeltQuoteState.PAID) {
       const finalizeData = await this.finalizePaidMeltInvoice(
@@ -340,7 +340,7 @@ export async function checkOutgoingInvoiceGeneric(
           })
         );
       }
-      useInvoicesWorkerStore().removeOutgoingInvoiceFromChecker?.(quote);
+      useTransactionWorkerStore().removeOutgoingInvoiceFromChecker?.(quote);
     }
   } catch (error: any) {
     if (verbose) {

--- a/src/stores/walletOnchain.ts
+++ b/src/stores/walletOnchain.ts
@@ -19,7 +19,7 @@ import {
 import type { InvoiceHistory } from "./wallet";
 import { PaymentMethod } from "src/stores/walletTypes";
 import { mintOnPaidGeneric } from "./walletWebsocket";
-import { useInvoicesWorkerStore } from "./invoicesWorker";
+import { useTransactionWorkerStore } from "./transactionWorker";
 import { onchainNetwork } from "src/js/onchain";
 import { type AppMeltQuote, normalizeMeltQuote } from "./walletMelt";
 import { createSubpaymentHistoryQuote } from "src/js/invoice-history";
@@ -346,7 +346,7 @@ export async function checkOutgoingOnchain(
     if (meltQuote.state === MeltQuoteState.UNPAID) {
       await proofsStore.setReserved(proofs, false);
       await this.removeOutgoingInvoiceFromHistory(quote);
-      useInvoicesWorkerStore().removeOutgoingInvoiceFromChecker?.(quote);
+      useTransactionWorkerStore().removeOutgoingInvoiceFromChecker?.(quote);
       notifyWarning(this.t("wallet.notifications.lightning_payment_failed"));
     }
 
@@ -364,7 +364,7 @@ export async function checkOutgoingOnchain(
           amount: uIStore.formatCurrency(finalizeData.amountPaid, invoice.unit),
         })
       );
-      useInvoicesWorkerStore().removeOutgoingInvoiceFromChecker?.(quote);
+      useTransactionWorkerStore().removeOutgoingInvoiceFromChecker?.(quote);
     }
   } catch (error: any) {
     if (verbose && error?.message !== "Payment pending") {

--- a/src/stores/walletWebsocket.ts
+++ b/src/stores/walletWebsocket.ts
@@ -1,4 +1,4 @@
-import { useInvoicesWorkerStore } from "./invoicesWorker";
+import { useTransactionWorkerStore } from "./transactionWorker";
 import { useSettingsStore } from "src/stores/settings";
 import { useWorkersStore } from "./workers";
 import { useUiStore } from "src/stores/ui";
@@ -39,7 +39,7 @@ const mintOnPaidConfigs: Record<IncomingMintMethod, MintOnPaidConfig> = {
     command: "bolt11_mint_quote",
     oneShot: true,
     addToChecker: (quoteId: string) =>
-      useInvoicesWorkerStore().addInvoiceToChecker(quoteId),
+      useTransactionWorkerStore().addInvoiceToChecker(quoteId),
     onPaid: async (walletStore: any, _quoteId, invoice) =>
       walletStore.mintBolt11(invoice, false),
   },
@@ -47,7 +47,7 @@ const mintOnPaidConfigs: Record<IncomingMintMethod, MintOnPaidConfig> = {
     command: "bolt12_mint_quote",
     oneShot: false,
     addToChecker: (quoteId: string) =>
-      useInvoicesWorkerStore().addBolt12OfferToChecker(quoteId),
+      useTransactionWorkerStore().addBolt12OfferToChecker(quoteId),
     onPaid: async (
       walletStore: any,
       quoteId,
@@ -65,7 +65,7 @@ const mintOnPaidConfigs: Record<IncomingMintMethod, MintOnPaidConfig> = {
     command: "onchain_mint_quote",
     oneShot: false,
     addToChecker: (quoteId: string) =>
-      useInvoicesWorkerStore().addOnchainQuoteToChecker(quoteId, true),
+      useTransactionWorkerStore().addOnchainQuoteToChecker(quoteId, true),
     onPaid: async (
       walletStore: any,
       quoteId,

--- a/src/stores/workers.ts
+++ b/src/stores/workers.ts
@@ -1,18 +1,11 @@
 import { defineStore } from "pinia";
-import { useWalletStore } from "src/stores/wallet"; // invoiceData,
-import { useUiStore } from "src/stores/ui"; // showInvoiceDetails
-import { useSendTokensStore } from "src/stores/sendTokensStore"; // showSendTokens and sendData
-import { useSettingsStore } from "./settings";
-import { HistoryToken, useTokensStore } from "./tokens";
+import { useWalletStore } from "src/stores/wallet";
 export const useWorkersStore = defineStore("workers", {
   state: () => {
     return {
       invoiceCheckListener: null as NodeJS.Timeout | null,
-      tokensCheckSpendableListener: null as NodeJS.Timeout | null,
       invoiceWorkerRunning: false,
-      tokenWorkerRunning: false,
       invoiceWorkerProcessing: false,
-      tokenWorkerProcessing: false,
       checkInterval: 5000,
     };
   },
@@ -24,11 +17,6 @@ export const useWorkersStore = defineStore("workers", {
         clearInterval(this.invoiceCheckListener);
         this.invoiceCheckListener = null;
         this.invoiceWorkerRunning = false;
-      }
-      if (this.tokensCheckSpendableListener) {
-        clearInterval(this.tokensCheckSpendableListener);
-        this.tokensCheckSpendableListener = null;
-        this.tokenWorkerRunning = false;
       }
     },
     invoiceCheckWorker: async function (quote: string) {
@@ -60,49 +48,6 @@ export const useWorkersStore = defineStore("workers", {
           console.log("invoiceCheckWorker: not paid yet");
         } finally {
           this.invoiceWorkerProcessing = false;
-        }
-      }, this.checkInterval);
-    },
-    checkTokenSpendableWorker: async function (historyToken: HistoryToken) {
-      const settingsStore = useSettingsStore();
-      if (!settingsStore.checkSentTokens) {
-        console.log(
-          "settingsStore.checkSentTokens is disabled, not kicking off checkTokenSpendableWorker"
-        );
-        return;
-      }
-      console.log("### kicking off checkTokenSpendableWorker");
-      const walletStore = useWalletStore();
-      const sendTokensStore = useSendTokensStore();
-      let nInterval = 0;
-      this.clearAllWorkers();
-      this.tokenWorkerRunning = true;
-      this.tokensCheckSpendableListener = setInterval(async () => {
-        if (this.tokenWorkerProcessing) return;
-        this.tokenWorkerProcessing = true;
-        try {
-          nInterval += 1;
-          // exit loop after 30s
-          if (nInterval > 10) {
-            console.log("### stopping token check worker");
-            this.clearAllWorkers();
-            return;
-          }
-          console.log("### checkTokenSpendableWorker setInterval", nInterval);
-          const paid = await walletStore.checkTokenSpendable(
-            historyToken,
-            false
-          );
-          if (paid) {
-            console.log("### stopping token check worker");
-            this.clearAllWorkers();
-            sendTokensStore.showSendTokens = false;
-          }
-        } catch (error) {
-          console.log("checkTokenSpendableWorker: some error", error);
-          this.clearAllWorkers();
-        } finally {
-          this.tokenWorkerProcessing = false;
         }
       }, this.checkInterval);
     },


### PR DESCRIPTION
## Summary

- rename the invoice worker/store to the transaction worker to reflect its incoming and outgoing responsibilities
- remove the duplicate legacy sent-token polling worker
- keep sent-token WebSockets and the persistent per-mint transaction worker as complementary paths
- start the transaction worker when sent-token checks are enabled, even if incoming periodic checks are disabled
- retain existing local-storage keys so persisted queues and cooldowns survive the rename
- update consumers and regression tests for the consolidated worker

This PR intentionally does not change Bolt12 or on-chain quote scheduling policy.

## Validation

- 133 tests passed
- ESLint passed
- production build passed
- formatting and diff checks passed