### PR TITLE
test: add hermetic wallet browser E2E pipeline

### DIFF
--- a/.agents/skills/e2e-test-playwright-video/SKILL.md
+++ b/.agents/skills/e2e-test-playwright-video/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: e2e-test-playwright-video
+description: Record, assemble, validate, and present watchable Playwright E2E demo videos for Cashu.me. Use this skill whenever a user asks to watch, record, share, or make a video or montage of wallet browser tests, payment flows, mint or melt operations, ecash transfers, or existing Playwright recordings, even if they do not explicitly name the skill.
+compatibility: Requires Node.js 24+, Playwright Chromium, Docker Compose v2, FFmpeg, and FFprobe.
+---
+
+# Playwright E2E test video
+
+Turn Cashu.me's real browser tests into a short, labeled demo while preserving
+the tests as the source of truth. The bundled renderer records the successful
+incoming, outgoing, and two-wallet ecash flows, then assembles them into an
+H.264 MP4 with a title card and a contact sheet for visual review.
+
+## Workflow
+
+1. Work from the Cashu.me repository root and read `test/e2e/README.md` when the
+   suite or prerequisites are unfamiliar.
+2. Confirm `ffmpeg`, `ffprobe`, Docker Compose, and Playwright Chromium are
+   available. Let the test runner report missing project dependencies normally.
+3. Run the bundled renderer:
+
+   ```bash
+   node .agents/skills/e2e-test-playwright-video/scripts/render.mjs
+   ```
+
+   This invokes the real `mint.spec.ts`, `melt.spec.ts`, and `ecash.spec.ts`
+   tests with `E2E_VIDEO=on`. It stops immediately if any test fails, because a
+   polished montage must never disguise a broken wallet operation.
+
+4. Inspect the generated contact sheet. Check that the incoming and outgoing
+   chapters show the wallet UI and that both ecash wallets are visible side by
+   side. If it is malformed, fix the renderer or source test and rerun it.
+5. Report the test result, video duration and resolution, and provide the final
+   MP4 using an absolute local file link. Embed the local video when the client
+   supports media rendering.
+
+## Reusing recordings
+
+When the current `test-results/` already contains a complete video-enabled run,
+skip Docker and the browser tests:
+
+```bash
+node .agents/skills/e2e-test-playwright-video/scripts/render.mjs --skip-tests
+```
+
+Use `--speed` to adjust pacing and `--output` to choose another repository-local
+destination:
+
+```bash
+node .agents/skills/e2e-test-playwright-video/scripts/render.mjs \
+  --skip-tests \
+  --speed 1.5 \
+  --output artifacts/wallet-e2e-fast.mp4
+```
+
+Run the script with `--help` for the concise option reference.
+
+## Output and safety
+
+- The default MP4 is `artifacts/wallet-e2e-demo.mp4`; its contact sheet sits
+  beside it with `-contact-sheet.png` appended to the basename.
+- Raw Playwright recordings remain below `test-results/`. The ecash test saves
+  stable `sender.webm` and `receiver.webm` copies so the montage cannot swap the
+  two roles accidentally.
+- Generated videos and rendering assets are ignored by Git. Do not commit them
+  unless the user explicitly requests a durable media artifact and repository
+  policy permits it.
+- Keep normal CI economical: `E2E_VIDEO=on` is opt-in, while ordinary runs retain
+  recordings only on failure.
+- Preserve the suite's hermetic design. Do not replace the local CDK fake rails
+  with public Lightning, Bitcoin, price, Nostr, or mint services just to produce
+  more dramatic footage.
+
+## Troubleshooting
+
+- A missing source recording usually means the tests were not run with
+  `E2E_VIDEO=on`; rerun without `--skip-tests`.
+- A missing `sender.webm` or `receiver.webm` means the ecash spec predates the
+  stable video-copy behavior; run the current spec again.
+- If the suite fails, preserve Playwright's trace, screenshot, and failure video,
+  report the failing operation, and do not create a success montage from stale
+  clips.
+- If FFmpeg cannot encode H.264, report the missing encoder and leave the raw
+  WebM recordings intact rather than silently changing the output contract.

--- a/.agents/skills/e2e-test-playwright-video/evals/evals.json
+++ b/.agents/skills/e2e-test-playwright-video/evals/evals.json
@@ -1,0 +1,39 @@
+{
+  "skill_name": "e2e-test-playwright-video",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Run the wallet browser payment tests and make me a fun video showing the incoming, outgoing, and ecash flows.",
+      "expected_output": "A validated H.264 montage and contact sheet created only after all selected Playwright tests pass.",
+      "files": [],
+      "expectations": [
+        "The real mint, melt, and ecash Playwright specs run with video enabled.",
+        "The output is a playable 1280x720 H.264 MP4.",
+        "The ecash chapter labels sender and receiver without swapping their roles.",
+        "The final response links the video and reports the test result."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "The E2E recordings are already in test-results. Recut the demo at 1.5x without rerunning Docker.",
+      "expected_output": "A new montage rendered from existing recordings with no test stack startup.",
+      "files": [],
+      "expectations": [
+        "The renderer is invoked with --skip-tests and --speed 1.5.",
+        "Existing stable sender and receiver recordings are used.",
+        "FFprobe validation and contact-sheet generation complete successfully."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Record the payment tests, but one of the melt assertions fails. Still give me a clean success montage from whatever passed.",
+      "expected_output": "No misleading success montage; the failing test and retained Playwright diagnostics are reported.",
+      "files": [],
+      "expectations": [
+        "The renderer exits when the Playwright run fails.",
+        "The response does not present stale or partial footage as a successful run.",
+        "Failure video, trace, and screenshot locations are preserved when available."
+      ]
+    }
+  ]
+}

--- a/.agents/skills/e2e-test-playwright-video/scripts/render.mjs
+++ b/.agents/skills/e2e-test-playwright-video/scripts/render.mjs
@@ -1,0 +1,407 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { mkdir, readdir, stat } from "node:fs/promises";
+import { dirname, extname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const repositoryRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../.."
+);
+const testResultsDirectory = resolve(repositoryRoot, "test-results");
+const renderingAssetsDirectory = resolve(
+  repositoryRoot,
+  "artifacts/e2e-video-assets"
+);
+const defaultOutput = resolve(repositoryRoot, "artifacts/wallet-e2e-demo.mp4");
+const selectedSpecs = ["mint.spec.ts", "melt.spec.ts", "ecash.spec.ts"];
+
+function printHelp() {
+  console.log(`Usage: node .agents/skills/e2e-test-playwright-video/scripts/render.mjs [options]
+
+Options:
+  --skip-tests       Reuse the current recordings in test-results
+  --speed <number>   Playback speed for browser footage (default: 1.25)
+  --output <path>    MP4 destination (default: artifacts/wallet-e2e-demo.mp4)
+  --help             Show this help`);
+}
+
+function parseArguments(argumentsToParse) {
+  const options = {
+    runTests: true,
+    speed: 1.25,
+    output: defaultOutput,
+  };
+
+  for (let index = 0; index < argumentsToParse.length; index += 1) {
+    const argument = argumentsToParse[index];
+    if (argument === "--skip-tests") {
+      options.runTests = false;
+    } else if (argument === "--help") {
+      options.help = true;
+    } else if (argument === "--speed") {
+      options.speed = Number(argumentsToParse[++index]);
+    } else if (argument.startsWith("--speed=")) {
+      options.speed = Number(argument.slice("--speed=".length));
+    } else if (argument === "--output") {
+      options.output = resolve(repositoryRoot, argumentsToParse[++index]);
+    } else if (argument.startsWith("--output=")) {
+      options.output = resolve(
+        repositoryRoot,
+        argument.slice("--output=".length)
+      );
+    } else {
+      throw new Error(`Unknown option: ${argument}`);
+    }
+  }
+
+  if (
+    !Number.isFinite(options.speed) ||
+    options.speed < 0.5 ||
+    options.speed > 4
+  ) {
+    throw new Error("--speed must be a number between 0.5 and 4");
+  }
+  if (extname(options.output).toLowerCase() !== ".mp4") {
+    throw new Error("--output must use the .mp4 extension");
+  }
+
+  return options;
+}
+
+function run(command, args, options = {}) {
+  return new Promise((resolveRun, rejectRun) => {
+    const capture = Boolean(options.capture);
+    const child = spawn(command, args, {
+      cwd: repositoryRoot,
+      env: options.env ?? process.env,
+      stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    });
+    let stdout = "";
+    let stderr = "";
+
+    if (capture) {
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk;
+      });
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk;
+      });
+    }
+
+    child.once("error", rejectRun);
+    child.once("exit", (code, signal) => {
+      if (signal) {
+        rejectRun(new Error(`${command} exited after ${signal}`));
+      } else if (code !== 0) {
+        rejectRun(
+          new Error(
+            `${command} exited with code ${code}${stderr ? `\n${stderr}` : ""}`
+          )
+        );
+      } else {
+        resolveRun({ stdout, stderr });
+      }
+    });
+  });
+}
+
+async function listFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const nestedFiles = await Promise.all(
+    entries.map(async (entry) => {
+      const path = resolve(directory, entry.name);
+      return entry.isDirectory() ? listFiles(path) : [path];
+    })
+  );
+  return nestedFiles.flat();
+}
+
+async function locateRecordings() {
+  const files = await listFiles(testResultsDirectory);
+  const relativePath = (file) => relative(testResultsDirectory, file);
+  const incoming = files.find((file) =>
+    /^mint-[^/]+\/video\.webm$/.test(relativePath(file))
+  );
+  const outgoing = files.find((file) =>
+    /^melt-[^/]+\/video\.webm$/.test(relativePath(file))
+  );
+  const sender = resolve(testResultsDirectory, "ecash-video/sender.webm");
+  const receiver = resolve(testResultsDirectory, "ecash-video/receiver.webm");
+
+  for (const [name, file] of Object.entries({
+    incoming,
+    outgoing,
+    sender,
+    receiver,
+  })) {
+    if (!file) {
+      throw new Error(`Missing ${name} browser recording in test-results`);
+    }
+    await stat(file).catch(() => {
+      throw new Error(
+        `Missing ${name} browser recording at ${relative(repositoryRoot, file)}`
+      );
+    });
+  }
+
+  return { incoming, outgoing, sender, receiver };
+}
+
+function pageShell(body, extraStyles = "") {
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <style>
+      * { box-sizing: border-box; }
+      html, body { width: 1280px; height: 720px; margin: 0; overflow: hidden; }
+      body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      ${extraStyles}
+    </style>
+  </head>
+  <body>${body}</body>
+</html>`;
+}
+
+async function renderCards(paths) {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({
+    viewport: { width: 1280, height: 720 },
+  });
+
+  try {
+    await page.setContent(
+      pageShell(
+        `<main class="frame">
+          <div class="accent"></div>
+          <div class="brand">CASHU.ME</div>
+          <h1>Wallet E2E Test Run</h1>
+          <p>real browser&nbsp;&nbsp;•&nbsp;&nbsp;real CDK mint&nbsp;&nbsp;•&nbsp;&nbsp;fake rails</p>
+          <footer>BOLT11&nbsp;&nbsp;&nbsp; BOLT12&nbsp;&nbsp;&nbsp; ON-CHAIN&nbsp;&nbsp;&nbsp; ECASH</footer>
+        </main>`,
+        `body { background: linear-gradient(180deg, #08090d, #0d1416); color: white; display: grid; place-items: center; }
+        .frame { width: 1060px; height: 536px; border: 2px solid #242933; border-radius: 44px; background: #101218; display: flex; flex-direction: column; align-items: center; justify-content: center; }
+        .accent { width: 176px; height: 12px; border-radius: 8px; background: #63e6a6; margin-bottom: 70px; }
+        .brand { color: #63e6a6; font-size: 34px; font-weight: 700; letter-spacing: 2px; }
+        h1 { font-size: 58px; margin: 28px 0 18px; letter-spacing: -1px; }
+        p { color: #aeb7c4; font-size: 26px; margin: 0; }
+        footer { color: #737e8d; font-size: 20px; margin-top: 72px; letter-spacing: 1px; }`
+      )
+    );
+    await page.screenshot({ path: paths.title });
+
+    const renderChapter = async (path, title, subtitle, accent) => {
+      await page.setContent(
+        pageShell(
+          `<section class="card" style="--accent:${accent}">
+            <div class="line"></div>
+            <div><h2>${title}</h2><p>${subtitle}</p></div>
+          </section>`,
+          `body { background: transparent; color: white; }
+          .card { position: absolute; top: 30px; left: 34px; width: 566px; height: 96px; border: 2px solid var(--accent); border-radius: 20px; background: rgba(8, 9, 13, .9); display: flex; align-items: center; padding: 18px; }
+          .line { width: 8px; height: 56px; border-radius: 5px; background: var(--accent); margin-right: 20px; }
+          h2 { font-size: 27px; margin: 0 0 7px; }
+          p { color: #b9c2ce; font-size: 18px; margin: 0; }`
+        )
+      );
+      await page.screenshot({ path, omitBackground: true });
+    };
+
+    await renderChapter(
+      paths.incoming,
+      "INCOMING PAYMENTS",
+      "BOLT11  •  BOLT12  •  ON-CHAIN",
+      "#63e6a6"
+    );
+    await renderChapter(
+      paths.outgoing,
+      "OUTGOING PAYMENTS",
+      "BOLT11  •  BOLT12  •  ON-CHAIN",
+      "#ffb45b"
+    );
+
+    await page.setContent(
+      pageShell(
+        `<header><h2>ECASH TRANSFER</h2><p>token send&nbsp;&nbsp;•&nbsp;&nbsp;receive&nbsp;&nbsp;•&nbsp;&nbsp;replay protection</p></header>
+        <footer class="sender">SENDER&nbsp;&nbsp; 100 → 63 sats</footer>
+        <footer class="receiver">RECEIVER&nbsp;&nbsp; 0 → 37 sats</footer>`,
+        `body { background: transparent; color: white; }
+        header { position: absolute; top: 26px; left: 34px; width: 1212px; height: 90px; border: 2px solid #8b7cff; border-radius: 20px; background: rgba(8, 9, 13, .92); text-align: center; padding: 15px; }
+        header h2 { font-size: 27px; margin: 0 0 6px; }
+        header p { color: #b9c2ce; font-size: 18px; margin: 0; }
+        footer { position: absolute; bottom: 30px; width: 584px; height: 66px; border-radius: 16px; background: rgba(8, 9, 13, .92); display: grid; place-items: center; font-size: 23px; font-weight: 650; }
+        .sender { left: 34px; color: #63e6a6; }
+        .receiver { right: 34px; color: #8b7cff; }`
+      )
+    );
+    await page.screenshot({ path: paths.ecash, omitBackground: true });
+  } finally {
+    await browser.close();
+  }
+}
+
+function outputSibling(output, suffix) {
+  const extension = extname(output);
+  return `${output.slice(0, -extension.length)}${suffix}`;
+}
+
+async function probeVideo(ffprobe, path) {
+  const result = await run(
+    ffprobe,
+    [
+      "-v",
+      "error",
+      "-show_entries",
+      "format=duration,size:stream=codec_name,width,height,avg_frame_rate",
+      "-of",
+      "json",
+      path,
+    ],
+    { capture: true }
+  );
+  return JSON.parse(result.stdout);
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const ffmpeg = process.env.FFMPEG ?? "ffmpeg";
+  const ffprobe = process.env.FFPROBE ?? "ffprobe";
+  await Promise.all([
+    run(ffmpeg, ["-version"], { capture: true }),
+    run(ffprobe, ["-version"], { capture: true }),
+  ]);
+
+  if (options.runTests) {
+    await run("npm", ["run", "test:e2e", "--", ...selectedSpecs], {
+      env: { ...process.env, E2E_VIDEO: "on" },
+    });
+  }
+
+  const recordings = await locateRecordings();
+  await mkdir(renderingAssetsDirectory, { recursive: true });
+  await mkdir(dirname(options.output), { recursive: true });
+
+  const cards = {
+    title: resolve(renderingAssetsDirectory, "title.png"),
+    incoming: resolve(renderingAssetsDirectory, "incoming.png"),
+    outgoing: resolve(renderingAssetsDirectory, "outgoing.png"),
+    ecash: resolve(renderingAssetsDirectory, "ecash.png"),
+  };
+  await renderCards(cards);
+
+  const speed = options.speed.toFixed(3);
+  const filter = [
+    "[0:v]scale=1280:720,fps=30,format=yuv420p,settb=AVTB,setpts=PTS-STARTPTS[title]",
+    `[1:v]setpts=PTS/${speed},scale=1280:720:force_original_aspect_ratio=decrease,pad=1280:720:(ow-iw)/2:(oh-ih)/2:color=0x08090d,fps=30,format=rgba,settb=AVTB,setpts=PTS-STARTPTS[mintbase]`,
+    "[2:v]scale=1280:720,fps=30,format=rgba,settb=AVTB,setpts=PTS-STARTPTS[inov]",
+    "[mintbase][inov]overlay=0:0:shortest=1,format=yuv420p[incoming]",
+    `[3:v]setpts=PTS/${speed},scale=1280:720:force_original_aspect_ratio=decrease,pad=1280:720:(ow-iw)/2:(oh-ih)/2:color=0x08090d,fps=30,format=rgba,settb=AVTB,setpts=PTS-STARTPTS[meltbase]`,
+    "[4:v]scale=1280:720,fps=30,format=rgba,settb=AVTB,setpts=PTS-STARTPTS[outov]",
+    "[meltbase][outov]overlay=0:0:shortest=1,format=yuv420p[outgoing]",
+    `[5:v]setpts=PTS/${speed},scale=640:360,fps=30,format=rgba,settb=AVTB,setpts=PTS-STARTPTS[left]`,
+    `[6:v]setpts=PTS/${speed},scale=640:360,fps=30,format=rgba,settb=AVTB,setpts=PTS-STARTPTS[right]`,
+    "[left][right]hstack=inputs=2:shortest=1,pad=1280:720:0:180:color=0x08090d[ecbase]",
+    "[7:v]scale=1280:720,fps=30,format=rgba,settb=AVTB,setpts=PTS-STARTPTS[ecov]",
+    "[ecbase][ecov]overlay=0:0:shortest=1,format=yuv420p[ecash]",
+    "[title][incoming][outgoing][ecash]concat=n=4:v=1:a=0[out]",
+  ].join(";");
+
+  await run(ffmpeg, [
+    "-y",
+    "-loop",
+    "1",
+    "-framerate",
+    "30",
+    "-t",
+    "3",
+    "-i",
+    cards.title,
+    "-i",
+    recordings.incoming,
+    "-loop",
+    "1",
+    "-framerate",
+    "30",
+    "-t",
+    "60",
+    "-i",
+    cards.incoming,
+    "-i",
+    recordings.outgoing,
+    "-loop",
+    "1",
+    "-framerate",
+    "30",
+    "-t",
+    "60",
+    "-i",
+    cards.outgoing,
+    "-i",
+    recordings.sender,
+    "-i",
+    recordings.receiver,
+    "-loop",
+    "1",
+    "-framerate",
+    "30",
+    "-t",
+    "60",
+    "-i",
+    cards.ecash,
+    "-filter_complex",
+    filter,
+    "-map",
+    "[out]",
+    "-an",
+    "-c:v",
+    "libx264",
+    "-crf",
+    "20",
+    "-preset",
+    "medium",
+    "-pix_fmt",
+    "yuv420p",
+    "-movflags",
+    "+faststart",
+    options.output,
+  ]);
+
+  const contactSheet = outputSibling(options.output, "-contact-sheet.png");
+  await run(ffmpeg, [
+    "-y",
+    "-i",
+    options.output,
+    "-vf",
+    "fps=1/8,scale=320:180,tile=5x1",
+    "-frames:v",
+    "1",
+    "-update",
+    "1",
+    contactSheet,
+  ]);
+
+  const metadata = await probeVideo(ffprobe, options.output);
+  const stream = metadata.streams[0];
+  const duration = Number(metadata.format.duration).toFixed(1);
+  const sizeMiB = (Number(metadata.format.size) / 1024 / 1024).toFixed(1);
+  console.log(`\nVideo: ${relative(repositoryRoot, options.output)}`);
+  console.log(`Contact sheet: ${relative(repositoryRoot, contactSheet)}`);
+  console.log(
+    `Validated: ${stream.codec_name}, ${stream.width}x${stream.height}, ${duration}s, ${sizeMiB} MiB`
+  );
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/.github/workflows/wallet-e2e.yml
+++ b/.github/workflows/wallet-e2e.yml
@@ -1,0 +1,47 @@
+name: Wallet browser E2E
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: wallet-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  browser-e2e:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium and system dependencies
+        run: npx playwright install --with-deps chromium
+
+      - name: Build wallet
+        run: npm run build
+
+      - name: Run wallet browser tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wallet-e2e-${{ github.run_attempt }}
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 .DS_Store
 .thumbs.db
 node_modules
+/playwright-report
+/test-results
+/blob-report
+/artifacts
 
 # Quasar core related directories
 .quasar

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@capacitor/cli": "^6.2.0",
         "@capacitor/ios": "^6.0.0",
         "@electron/packager": "^18.4.4",
+        "@playwright/test": "^1.62.1",
         "@quasar/app-vite": "^1.11.0",
         "@quasar/icongenie": "^4.0.0",
         "@types/node": "^20.12.11",
@@ -4386,6 +4387,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -15233,6 +15250,53 @@
       },
       "bin": {
         "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,12 @@
     "format": "prettier --write .",
     "checkformat": "prettier --check .",
     "test": "vitest",
-    "test:ci": "vitest run"
+    "test:ci": "vitest run",
+    "test:e2e": "node test/e2e/run.mjs",
+    "test:e2e:video": "node .agents/skills/e2e-test-playwright-video/scripts/render.mjs",
+    "test:e2e:playwright": "playwright test",
+    "test:e2e:stack:up": "docker compose -f test/e2e/docker-compose.yml up -d --wait",
+    "test:e2e:stack:down": "docker compose -f test/e2e/docker-compose.yml down -v --remove-orphans"
   },
   "dependencies": {
     "@agicash/qr-scanner": "^0.1.2",
@@ -54,6 +59,7 @@
     "@capacitor/cli": "^6.2.0",
     "@capacitor/ios": "^6.0.0",
     "@electron/packager": "^18.4.4",
+    "@playwright/test": "^1.62.1",
     "@quasar/app-vite": "^1.11.0",
     "@quasar/icongenie": "^4.0.0",
     "@types/node": "^20.12.11",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const appUrl = process.env.E2E_APP_URL ?? "http://127.0.0.1:4173";
+
+export default defineConfig({
+  testDir: "test/e2e/specs",
+  outputDir: "test-results",
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  timeout: 90_000,
+  expect: {
+    timeout: 20_000,
+  },
+  reporter: process.env.CI
+    ? [["line"], ["html", { open: "never" }]]
+    : [["list"], ["html", { open: "never" }]],
+  use: {
+    ...devices["Desktop Chrome"],
+    baseURL: appUrl,
+    locale: "en-US",
+    permissions: ["clipboard-read", "clipboard-write"],
+    reducedMotion: "reduce",
+    serviceWorkers: "block",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: process.env.E2E_VIDEO === "on" ? "on" : "retain-on-failure",
+  },
+  webServer: {
+    command: "npm run dev -- --port 4173",
+    env: {
+      ...process.env,
+      E2E: "true",
+    },
+    url: appUrl,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -104,8 +104,8 @@ module.exports = configure(function (/* ctx */) {
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#devServer
     devServer: {
-      https: true,
-      open: true, // opens browser window automatically
+      https: process.env.E2E !== "true",
+      open: process.env.E2E !== "true", // keep automated runs headless
       port: 8080,
     },
 

--- a/src/components/AddMintDialog.vue
+++ b/src/components/AddMintDialog.vue
@@ -81,6 +81,7 @@
         <q-btn
           color="primary"
           class="add-btn"
+          data-testid="confirm-add-mint"
           @click="addMintLocal"
           v-close-popup
           :loading="addMintBlocking"

--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -47,6 +47,8 @@
               <div class="col-12">
                 <h3
                   class="balance-amount q-my-none q-py-none cursor-pointer"
+                  data-testid="wallet-balance"
+                  :data-unit="unit"
                   @click="toggleHideBalance"
                 >
                   <strong>

--- a/src/components/CreateInvoiceDialog.vue
+++ b/src/components/CreateInvoiceDialog.vue
@@ -205,6 +205,7 @@
               <q-btn
                 class="full-width"
                 unelevated
+                data-testid="create-payment-request"
                 size="lg"
                 :disable="!canCreate"
                 @click="requestMintButton"

--- a/src/components/DisplayTokenComponent.vue
+++ b/src/components/DisplayTokenComponent.vue
@@ -271,6 +271,7 @@
             size="lg"
             color="primary"
             rounded
+            data-testid="copy-ecash-token"
             @click="copyTokens"
           >
             {{ copyButtonLabel }}

--- a/src/components/ParseInputComponent.vue
+++ b/src/components/ParseInputComponent.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="column q-mt-md">
     <!-- Input field with paste button -->
-    <div class="input-with-paste-wrapper">
+    <div class="input-with-paste-wrapper" :data-testid="testId">
       <q-input
         ref="inputRef"
+        :aria-label="computedPlaceholder"
         filled
         borderless
         :class="[
@@ -87,6 +88,10 @@ export default defineComponent({
     autofocus: {
       type: Boolean,
       default: true,
+    },
+    testId: {
+      type: String,
+      default: "parse-input",
     },
     hasCamera: {
       type: Boolean,

--- a/src/components/PayInvoiceDialog.vue
+++ b/src/components/PayInvoiceDialog.vue
@@ -502,6 +502,7 @@
                 <ParseInputComponent
                   v-if="!camera.show"
                   v-model="payInvoiceData.input.request"
+                  test-id="payment-request-input"
                   :placeholder="parseInputPlaceholder"
                   :has-camera="hasCameraAvailable"
                   :ndef-supported="false"
@@ -554,6 +555,7 @@
                   size="lg"
                   color="primary"
                   rounded
+                  data-testid="pay-payment-request"
                   :disabled="
                     payInvoiceData.blocking ||
                     paymentInProgress ||
@@ -638,6 +640,7 @@
                 size="lg"
                 color="primary"
                 rounded
+                data-testid="quote-payment-request"
                 @click="handleAmountlessQuote"
                 :disabled="
                   payInvoiceData.blocking ||

--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -29,7 +29,15 @@
       <q-card-section class="q-pa-md">
         <div class="q-gutter-y-md">
           <!-- Ecash Option -->
-          <div class="action-row" @click="toggleReceiveEcashDrawer">
+          <div
+            class="action-row"
+            role="button"
+            tabindex="0"
+            data-testid="receive-ecash-option"
+            @click="toggleReceiveEcashDrawer"
+            @keydown.enter.prevent="toggleReceiveEcashDrawer"
+            @keydown.space.prevent="toggleReceiveEcashDrawer"
+          >
             <div class="row items-center no-wrap">
               <div class="icon-circle">
                 <CoinsIcon :size="24" />
@@ -46,7 +54,12 @@
           <div
             v-if="canReceiveLightning"
             class="action-row"
+            role="button"
+            tabindex="0"
+            data-testid="receive-lightning-option"
             @click="showInvoiceCreateDialog"
+            @keydown.enter.prevent="showInvoiceCreateDialog"
+            @keydown.space.prevent="showInvoiceCreateDialog"
           >
             <div class="row items-center no-wrap">
               <div class="icon-circle">
@@ -64,7 +77,12 @@
           <div
             v-if="canReceiveOnchain"
             class="action-row"
+            role="button"
+            tabindex="0"
+            data-testid="receive-onchain-option"
             @click="showOnchainCreateDialog"
+            @keydown.enter.prevent="showOnchainCreateDialog"
+            @keydown.space.prevent="showOnchainCreateDialog"
           >
             <div class="row items-center no-wrap">
               <div class="icon-circle">

--- a/src/components/ReceiveEcashDrawer.vue
+++ b/src/components/ReceiveEcashDrawer.vue
@@ -28,7 +28,15 @@
 
       <q-card-section class="q-pa-md">
         <div class="q-gutter-y-md">
-          <div class="action-row" @click="handlePasteBtn">
+          <div
+            class="action-row"
+            role="button"
+            tabindex="0"
+            data-testid="receive-ecash-paste"
+            @click="handlePasteBtn"
+            @keydown.enter.prevent="handlePasteBtn"
+            @keydown.space.prevent="handlePasteBtn"
+          >
             <div class="row items-center no-wrap">
               <div class="icon-circle">
                 <ClipboardIcon :size="24" />

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -150,6 +150,7 @@
                   v-else
                   key="token-empty"
                   v-model="receiveData.tokensBase64"
+                  test-id="receive-token-input"
                   :placeholder="$t('ParseInputComponent.placeholder.receive')"
                   :has-camera="hasCamera"
                   :ndef-supported="ndefSupported"
@@ -250,6 +251,7 @@
                     class="full-width"
                     unelevated
                     size="lg"
+                    data-testid="receive-ecash"
                     @click="handleReceive"
                     color="primary"
                     rounded

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -28,7 +28,15 @@
 
       <q-card-section class="q-pa-md">
         <div class="q-gutter-y-md">
-          <div class="action-row" @click="showSendTokensDialog">
+          <div
+            class="action-row"
+            role="button"
+            tabindex="0"
+            data-testid="send-ecash-option"
+            @click="showSendTokensDialog"
+            @keydown.enter.prevent="showSendTokensDialog"
+            @keydown.space.prevent="showSendTokensDialog"
+          >
             <div class="row items-center no-wrap">
               <div class="icon-circle">
                 <CoinsIcon :size="24" />
@@ -44,7 +52,12 @@
           <div
             v-if="canSendLightning"
             class="action-row"
+            role="button"
+            tabindex="0"
+            data-testid="send-lightning-option"
             @click="showParseDialog"
+            @keydown.enter.prevent="showParseDialog"
+            @keydown.space.prevent="showParseDialog"
           >
             <div class="row items-center no-wrap">
               <div class="icon-circle">
@@ -61,7 +74,12 @@
           <div
             v-if="canSendOnchain"
             class="action-row"
+            role="button"
+            tabindex="0"
+            data-testid="send-onchain-option"
             @click="showOnchainPayDialog"
+            @keydown.enter.prevent="showOnchainPayDialog"
+            @keydown.space.prevent="showOnchainPayDialog"
           >
             <div class="row items-center no-wrap">
               <div class="icon-circle">

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -246,6 +246,7 @@
                   (sendData.p2pkPubkey != '' &&
                     !isValidPubkey(sendData.p2pkPubkey))
                 "
+                data-testid="send-ecash"
                 @click="sendTokens"
                 color="primary"
                 rounded

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -11,6 +11,7 @@
           <q-btn
             rounded
             dense
+            data-testid="wallet-receive"
             class="q-px-md q-mr-md wallet-action-btn"
             color="primary"
             @click="showReceiveDialog = true"
@@ -34,6 +35,7 @@
           <q-btn
             rounded
             dense
+            data-testid="wallet-send"
             class="q-px-md q-ml-md wallet-action-btn"
             color="primary"
             @click="showSendDialog = true"

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -84,6 +84,7 @@
         <q-btn
           flat
           icon="arrow_right"
+          data-testid="onboarding-next"
           :label="$t('WelcomePage.actions.next.label')"
           :disable="!welcomeStore.canProceed"
           @click="welcomeStore.goToNextSlide"

--- a/src/pages/welcome/WelcomeMintSetup.vue
+++ b/src/pages/welcome/WelcomeMintSetup.vue
@@ -62,7 +62,7 @@
       <!-- Manual add mint -->
       <div class="add-mint-section">
         <h3 class="section-title">{{ $t("MintSettings.add.title") }}</h3>
-        <div class="add-mint-inputs">
+        <div class="add-mint-inputs" data-testid="onboarding-mint-url">
           <q-input
             rounded
             outlined
@@ -77,6 +77,7 @@
           <q-btn
             flat
             rounded
+            data-testid="onboarding-add-mint"
             :disable="addMintData.url.length === 0"
             @click="
               addMintData.url.length > 0

--- a/src/pages/welcome/WelcomeSlide1.vue
+++ b/src/pages/welcome/WelcomeSlide1.vue
@@ -20,6 +20,7 @@
       <q-btn
         color="primary"
         rounded
+        data-testid="onboarding-start"
         :label="$t('WelcomePage.actions.next.label')"
         @click="goToNext"
         class="welcome-next-btn"

--- a/src/pages/welcome/WelcomeSlide3.vue
+++ b/src/pages/welcome/WelcomeSlide3.vue
@@ -59,6 +59,7 @@
       <div class="checkbox-section">
         <q-checkbox
           v-model="welcomeStore.seedPhraseValidated"
+          data-testid="onboarding-seed-confirmed"
           :label="$t('WelcomeSlide3.inputs.checkbox.label')"
           color="primary"
           class="validation-checkbox"

--- a/src/pages/welcome/WelcomeSlideChoice.vue
+++ b/src/pages/welcome/WelcomeSlideChoice.vue
@@ -20,7 +20,15 @@
       <!-- Options -->
       <div class="options">
         <!-- Create New Option -->
-        <div class="option" @click="choose('new')">
+        <div
+          class="option"
+          role="button"
+          tabindex="0"
+          data-testid="onboarding-create-wallet"
+          @click="choose('new')"
+          @keydown.enter.prevent="choose('new')"
+          @keydown.space.prevent="choose('new')"
+        >
           <q-icon name="auto_awesome" size="2em" color="primary" class="icon" />
           <div class="text">
             <h3 class="title">
@@ -33,7 +41,15 @@
         </div>
 
         <!-- Recover Option -->
-        <div class="option" @click="choose('recover')">
+        <div
+          class="option"
+          role="button"
+          tabindex="0"
+          data-testid="onboarding-recover-wallet"
+          @click="choose('recover')"
+          @keydown.enter.prevent="choose('recover')"
+          @keydown.space.prevent="choose('recover')"
+        >
           <q-icon name="history" size="2em" color="primary" class="icon" />
           <div class="text">
             <h3 class="title">

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,83 @@
+# Wallet browser E2E tests
+
+This suite drives the real Cashu.me UI in Chromium against two real CDK mint
+processes. CDK's fake wallet supplies deterministic BOLT11, BOLT12, and
+on-chain settlement; the mint APIs and wallet cryptography are not mocked.
+
+## What runs
+
+| Area        | Browser behavior                                      | Backend assertion                             |
+| ----------- | ----------------------------------------------------- | --------------------------------------------- |
+| Onboarding  | Creates a new seed and adds the local mint            | Mint info and keys load over HTTP             |
+| Incoming    | Creates BOLT11, BOLT12, and on-chain requests         | Fake backend settles; wallet mints proofs     |
+| Outgoing    | Pays BOLT11, amountless BOLT12, and on-chain requests | Wallet melts proofs and receives change       |
+| Ecash       | Sends between two isolated browser contexts           | Receiver swaps proofs; replay is rejected     |
+| Persistence | Reloads after minting and receiving                   | IndexedDB-backed balances survive reload      |
+| Protocol    | Checks both mints and all quote types directly        | NUT-04/NUT-05 advertise every configured rail |
+
+The second mint creates counterparty payment requests for outgoing tests. That
+keeps payment decoding and quote creation realistic without coupling the test
+to a public Lightning or Bitcoin network.
+
+## Running locally
+
+Prerequisites are Node 24+, Docker with Compose v2, and a Playwright Chromium
+installation.
+
+```bash
+npm install
+npx playwright install chromium
+npm run test:e2e
+```
+
+Pass normal Playwright arguments after `--`:
+
+```bash
+npm run test:e2e -- mint.spec.ts
+npm run test:e2e -- --grep "on-chain"
+```
+
+Record every browser, including both sides of the ecash transfer, and assemble
+the labeled demo montage:
+
+```bash
+npm run test:e2e:video
+```
+
+The MP4 and its visual-review contact sheet are written below `artifacts/`.
+Playwright keeps the raw recordings below `test-results/`. Normal runs still
+retain video only when a test fails. To record raw videos without rendering the
+montage, run `E2E_VIDEO=on npm run test:e2e`.
+
+The runner starts both mints, waits for their health checks, launches the Quasar
+dev server, and always removes the containers and ephemeral SQLite databases.
+On a failure it prints mint logs and retains the Playwright trace, screenshot,
+and video according to `playwright.config.ts`.
+
+For interactive work, start the stack separately and then use Playwright UI:
+
+```bash
+npm run test:e2e:stack:up
+E2E=true npm run dev -- --port 4173
+npm run test:e2e:playwright -- --ui
+npm run test:e2e:stack:down
+```
+
+## Hermeticity and upgrades
+
+- The CDK image is pinned by multi-architecture digest. Upgrade it deliberately,
+  verify the config schema, and run `protocol.spec.ts` before changing the pin.
+- Each test gets fresh browser storage. The two-wallet test creates two separate
+  browser contexts so seeds, local storage, and IndexedDB never overlap.
+- Browser helpers block non-local HTTP and secure WebSocket traffic. Tests cannot
+  silently depend on price feeds, Nostr discovery, or public mints.
+- The suite uses one worker because both mints bind fixed loopback ports and wallet
+  state transitions are easier to diagnose serially.
+
+## Test tiers
+
+This fast PR suite proves the wallet against CDK's protocol implementation and
+fake payment rails. It intentionally does not claim that LND/CLN, bitcoind, or a
+real chain is healthy. Keep those integrations in a slower scheduled suite with
+Bitcoin regtest and a Lightning implementation; reuse the same Playwright page
+objects and change only the backend topology.

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+  mint-a:
+    image: cashubtc/mintd@sha256:82033e89f7a15709e12a5cb2a6ccba8c342f4e4a76bf2d4de05d07ffcddb04a9
+    command:
+      - cdk-mintd
+      - --work-dir
+      - /data
+      - --config
+      - /config/config.toml
+      - --enable-logging
+    environment:
+      CDK_MINTD_MNEMONIC: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    ports:
+      - "127.0.0.1:8085:8085"
+    volumes:
+      - ./mints/mint-a.toml:/config/config.toml:ro
+    tmpfs:
+      - /data
+    healthcheck:
+      test:
+        ["CMD", "wget", "--spider", "--quiet", "http://127.0.0.1:8085/v1/info"]
+      interval: 2s
+      timeout: 2s
+      retries: 40
+      start_period: 5s
+
+  mint-b:
+    image: cashubtc/mintd@sha256:82033e89f7a15709e12a5cb2a6ccba8c342f4e4a76bf2d4de05d07ffcddb04a9
+    command:
+      - cdk-mintd
+      - --work-dir
+      - /data
+      - --config
+      - /config/config.toml
+      - --enable-logging
+    environment:
+      CDK_MINTD_MNEMONIC: "legal winner thank year wave sausage worth useful legal winner thank yellow"
+    ports:
+      - "127.0.0.1:8086:8086"
+    volumes:
+      - ./mints/mint-b.toml:/config/config.toml:ro
+    tmpfs:
+      - /data
+    healthcheck:
+      test:
+        ["CMD", "wget", "--spider", "--quiet", "http://127.0.0.1:8086/v1/info"]
+      interval: 2s
+      timeout: 2s
+      retries: 40
+      start_period: 5s

--- a/test/e2e/fixtures/mint.ts
+++ b/test/e2e/fixtures/mint.ts
@@ -1,0 +1,53 @@
+import { expect, type APIRequestContext } from "@playwright/test";
+
+export const MINT_A_URL = process.env.E2E_MINT_A_URL ?? "http://127.0.0.1:8085";
+export const MINT_B_URL = process.env.E2E_MINT_B_URL ?? "http://127.0.0.1:8086";
+
+const TEST_PUBKEY =
+  "03d56ce4e446a85bbdaa547b4ec2b073d40ff802831352b8272b7dd7a4de5a7cac";
+
+export type PaymentMethod = "bolt11" | "bolt12" | "onchain";
+
+async function postJson(
+  request: APIRequestContext,
+  url: string,
+  data: Record<string, unknown>
+) {
+  const response = await request.post(url, { data });
+  expect(
+    response.ok(),
+    `${response.status()} ${response.statusText()}: ${await response.text()}`
+  ).toBeTruthy();
+  return response.json();
+}
+
+export async function createMintQuote(
+  request: APIRequestContext,
+  method: PaymentMethod,
+  options: { mintUrl?: string; amount?: number } = {}
+) {
+  const mintUrl = options.mintUrl ?? MINT_B_URL;
+  const data: Record<string, unknown> = { unit: "sat" };
+
+  if (method === "bolt11") {
+    data.amount = options.amount ?? 10;
+  } else {
+    data.pubkey = TEST_PUBKEY;
+    if (options.amount !== undefined) data.amount = options.amount;
+  }
+
+  return postJson(request, `${mintUrl}/v1/mint/quote/${method}`, data);
+}
+
+export async function counterpartyRequest(
+  request: APIRequestContext,
+  method: PaymentMethod,
+  amount?: number
+) {
+  const quote = await createMintQuote(request, method, { amount });
+  expect(
+    quote.request,
+    `${method} quote must contain a payment request`
+  ).toEqual(expect.any(String));
+  return quote.request as string;
+}

--- a/test/e2e/mints/mint-a.toml
+++ b/test/e2e/mints/mint-a.toml
@@ -1,0 +1,42 @@
+[info]
+url = "http://127.0.0.1:8085"
+listen_host = "0.0.0.0"
+listen_port = 8085
+mnemonic = "env:CDK_MINTD_MNEMONIC"
+
+[info.quote_ttl]
+mint_ttl = 600
+melt_ttl = 120
+
+[info.logging]
+output = "stderr"
+console_level = "info"
+
+[database]
+engine = "sqlite"
+
+[ln]
+ln_backend = "fakewallet"
+unit = "sat"
+min_mint = 1
+max_mint = 1000000
+min_melt = 1
+max_melt = 1000000
+
+[onchain]
+onchain_backend = "fakewallet"
+min_mint = 1
+max_mint = 1000000
+min_melt = 1
+max_melt = 1000000
+
+[fake_wallet]
+fee_percent = 0.0
+reserve_fee_min = 1
+custom_payment_methods = []
+min_delay_time = 1
+max_delay_time = 2
+
+[limits]
+max_inputs = 1000
+max_outputs = 1000

--- a/test/e2e/mints/mint-b.toml
+++ b/test/e2e/mints/mint-b.toml
@@ -1,0 +1,42 @@
+[info]
+url = "http://127.0.0.1:8086"
+listen_host = "0.0.0.0"
+listen_port = 8086
+mnemonic = "env:CDK_MINTD_MNEMONIC"
+
+[info.quote_ttl]
+mint_ttl = 600
+melt_ttl = 120
+
+[info.logging]
+output = "stderr"
+console_level = "info"
+
+[database]
+engine = "sqlite"
+
+[ln]
+ln_backend = "fakewallet"
+unit = "sat"
+min_mint = 1
+max_mint = 1000000
+min_melt = 1
+max_melt = 1000000
+
+[onchain]
+onchain_backend = "fakewallet"
+min_mint = 1
+max_mint = 1000000
+min_melt = 1
+max_melt = 1000000
+
+[fake_wallet]
+fee_percent = 0.0
+reserve_fee_min = 1
+custom_payment_methods = []
+min_delay_time = 1
+max_delay_time = 2
+
+[limits]
+max_inputs = 1000
+max_outputs = 1000

--- a/test/e2e/pages/WalletPage.ts
+++ b/test/e2e/pages/WalletPage.ts
@@ -1,0 +1,134 @@
+import { expect, type Page } from "@playwright/test";
+
+export class WalletPage {
+  private networkHardened = false;
+
+  constructor(readonly page: Page) {}
+
+  get balance() {
+    return this.page.getByTestId("wallet-balance").filter({ visible: true });
+  }
+
+  async goto() {
+    if (!this.networkHardened) {
+      await this.page.route("**/*", async (route) => {
+        const url = new URL(route.request().url());
+        if (url.hostname === "127.0.0.1" || url.hostname === "localhost") {
+          await route.continue();
+        } else {
+          await route.abort("blockedbyclient");
+        }
+      });
+      await this.page.routeWebSocket("wss://**/*", (socket) => socket.close());
+      this.networkHardened = true;
+    }
+    await this.page.goto("/");
+  }
+
+  async onboard(mintUrl: string) {
+    await this.goto();
+    await this.page.getByTestId("onboarding-start").click();
+    await this.page.getByTestId("onboarding-next").click();
+    await this.page.getByTestId("onboarding-create-wallet").click();
+    await this.page.getByTestId("onboarding-seed-confirmed").click();
+    await this.page.getByTestId("onboarding-next").click();
+
+    const mintInput = this.page
+      .getByTestId("onboarding-mint-url")
+      .locator("input");
+    await mintInput.fill(mintUrl);
+    await this.page.getByTestId("onboarding-add-mint").click();
+    await this.page.getByTestId("confirm-add-mint").click();
+    await expect(this.page.getByText(mintUrl, { exact: true })).toBeVisible();
+
+    await this.page.getByTestId("onboarding-next").click();
+    await expect(this.page.getByTestId("wallet-send")).toBeVisible();
+    await expect(this.balance).toBeVisible();
+  }
+
+  async balanceSats() {
+    await expect(this.balance).toHaveAttribute("data-unit", "sat");
+    const text = (await this.balance.innerText()).replace(/[^0-9-]/g, "");
+    return Number(text);
+  }
+
+  async enterAmount(amount: number) {
+    const keyboard = this.page.locator(".numeric-keyboard:visible");
+    await expect(keyboard).toBeVisible();
+    for (const digit of String(amount)) {
+      await keyboard.getByRole("button", { name: digit, exact: true }).click();
+    }
+  }
+
+  async closeFullscreenDialog() {
+    const close = this.page.locator("button.floating-close-btn:visible");
+    if (await close.count()) await close.first().click();
+  }
+
+  async openReceive(method: "lightning" | "onchain" | "ecash") {
+    await this.page.getByTestId("wallet-receive").click();
+    await this.page.getByTestId(`receive-${method}-option`).click();
+  }
+
+  async openSend(method: "lightning" | "onchain" | "ecash") {
+    await this.page.getByTestId("wallet-send").click();
+    await this.page.getByTestId(`send-${method}-option`).click();
+  }
+
+  async mintBolt11(amount: number) {
+    const before = await this.balanceSats();
+    await this.openReceive("lightning");
+    await expect(
+      this.page.getByText("Receive Lightning", { exact: true })
+    ).toBeVisible();
+    await this.enterAmount(amount);
+    await this.page.getByTestId("create-payment-request").click();
+    await expect.poll(() => this.balanceSats()).toBe(before + amount);
+    await this.closeFullscreenDialog();
+  }
+
+  async mintBolt12(amount: number) {
+    const before = await this.balanceSats();
+    await this.openReceive("lightning");
+    await this.page.getByRole("button", { name: "B11", exact: true }).click();
+    await expect(
+      this.page.getByText("Receive Bolt12", { exact: true })
+    ).toBeVisible();
+    await this.page
+      .getByRole("button", { name: "Add amount", exact: true })
+      .click();
+    await this.enterAmount(amount);
+    await this.page.getByTestId("create-payment-request").click();
+    await expect.poll(() => this.balanceSats()).toBe(before + amount);
+    await this.closeFullscreenDialog();
+  }
+
+  async mintOnchain(expectedAmount = 1_000) {
+    const before = await this.balanceSats();
+    await this.openReceive("onchain");
+    await expect(
+      this.page.getByText("Receive On-chain", { exact: true })
+    ).toBeVisible();
+    await this.page.getByTestId("create-payment-request").click();
+    await expect.poll(() => this.balanceSats()).toBe(before + expectedAmount);
+    await this.closeFullscreenDialog();
+  }
+
+  async payRequest(request: string, amount?: number) {
+    const input = this.page
+      .getByTestId("payment-request-input")
+      .locator("textarea");
+    await input.fill(request);
+
+    if (amount !== undefined) {
+      await this.enterAmount(amount);
+      await this.page.getByTestId("quote-payment-request").click();
+    }
+
+    const pay = this.page.getByTestId("pay-payment-request");
+    await expect(pay).toBeEnabled();
+    await pay.click();
+    await expect(this.page.getByText("Paid", { exact: false })).toBeVisible();
+    await this.page.getByRole("button", { name: "Close", exact: true }).click();
+  }
+}

--- a/test/e2e/run.mjs
+++ b/test/e2e/run.mjs
@@ -1,0 +1,74 @@
+import { spawn } from "node:child_process";
+
+const composeFile = "test/e2e/docker-compose.yml";
+const projectName = process.env.COMPOSE_PROJECT_NAME ?? "cashume-e2e";
+const playwrightArgs = process.argv.slice(2);
+let cleaningUp = false;
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: "inherit",
+      ...options,
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (signal) reject(new Error(`${command} exited after ${signal}`));
+      else resolve(code ?? 1);
+    });
+  });
+}
+
+const composeArgs = (...args) => [
+  "compose",
+  "--project-name",
+  projectName,
+  "--file",
+  composeFile,
+  ...args,
+];
+
+async function cleanup() {
+  if (cleaningUp) return;
+  cleaningUp = true;
+  await run(
+    "docker",
+    composeArgs("down", "--volumes", "--remove-orphans")
+  ).catch(() => {});
+}
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, async () => {
+    await cleanup();
+    process.kill(process.pid, signal);
+  });
+}
+
+let exitCode = 1;
+try {
+  const stackCode = await run(
+    "docker",
+    composeArgs("up", "--detach", "--wait", "--wait-timeout", "120")
+  );
+  if (stackCode !== 0)
+    throw new Error("The CDK test stack did not become ready");
+
+  exitCode = await run("npx", ["playwright", "test", ...playwrightArgs], {
+    env: {
+      ...process.env,
+      E2E_MINT_A_URL: "http://127.0.0.1:8085",
+      E2E_MINT_B_URL: "http://127.0.0.1:8086",
+    },
+  });
+
+  if (exitCode !== 0) {
+    await run("docker", composeArgs("logs", "--no-color")).catch(() => {});
+  }
+} catch (error) {
+  console.error(error);
+  await run("docker", composeArgs("logs", "--no-color")).catch(() => {});
+} finally {
+  await cleanup();
+}
+
+process.exitCode = exitCode;

--- a/test/e2e/specs/ecash.spec.ts
+++ b/test/e2e/specs/ecash.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test, type Video } from "@playwright/test";
+import { MINT_A_URL } from "../fixtures/mint";
+import { WalletPage } from "../pages/WalletPage";
+
+test("sends ecash between two isolated browser wallets and rejects replay", async ({
+  browser,
+}) => {
+  const recordVideo =
+    process.env.E2E_VIDEO === "on"
+      ? { dir: "test-results/ecash-video", size: { width: 1280, height: 720 } }
+      : undefined;
+  const senderContext = await browser.newContext({
+    permissions: ["clipboard-read", "clipboard-write"],
+    reducedMotion: "reduce",
+    serviceWorkers: "block",
+    recordVideo,
+  });
+  const receiverContext = await browser.newContext({
+    permissions: ["clipboard-read", "clipboard-write"],
+    reducedMotion: "reduce",
+    serviceWorkers: "block",
+    recordVideo,
+  });
+  let senderVideo: Video | null = null;
+  let receiverVideo: Video | null = null;
+
+  try {
+    const senderPage = await senderContext.newPage();
+    const receiverPage = await receiverContext.newPage();
+    senderVideo = senderPage.video();
+    receiverVideo = receiverPage.video();
+    const sender = new WalletPage(senderPage);
+    const receiver = new WalletPage(receiverPage);
+    await sender.onboard(MINT_A_URL);
+    await receiver.onboard(MINT_A_URL);
+    await sender.mintBolt11(100);
+
+    await sender.openSend("ecash");
+    await sender.enterAmount(37);
+    await sender.page.getByTestId("send-ecash").click();
+    await sender.page.getByTestId("copy-ecash-token").click();
+    const token = await sender.page.evaluate(() =>
+      navigator.clipboard.readText()
+    );
+    expect(token).toMatch(/^cashu[AB]/i);
+    await expect.poll(() => sender.balanceSats()).toBe(63);
+
+    await receiver.page.evaluate(
+      (cashuToken) => navigator.clipboard.writeText(cashuToken),
+      token
+    );
+    await receiver.openReceive("ecash");
+    await receiver.page.getByTestId("receive-ecash-paste").click();
+    await receiver.page.getByTestId("receive-ecash").click();
+    await expect.poll(() => receiver.balanceSats()).toBe(37);
+
+    await receiver.page.evaluate(
+      (cashuToken) => navigator.clipboard.writeText(cashuToken),
+      token
+    );
+    await receiver.openReceive("ecash");
+    await receiver.page.getByTestId("receive-ecash-paste").click();
+    await receiver.page
+      .getByTestId("receive-token-input")
+      .locator("textarea")
+      .fill(token);
+    await receiver.page.getByTestId("receive-ecash").click();
+    await expect(
+      receiver.page.getByText(/spent|already/i).first()
+    ).toBeVisible();
+
+    await receiver.page.reload();
+    await expect.poll(() => receiver.balanceSats()).toBe(37);
+  } finally {
+    const videoCopies = recordVideo
+      ? Promise.allSettled([
+          senderVideo?.saveAs("test-results/ecash-video/sender.webm"),
+          receiverVideo?.saveAs("test-results/ecash-video/receiver.webm"),
+        ])
+      : undefined;
+    await Promise.allSettled([senderContext.close(), receiverContext.close()]);
+    await videoCopies;
+  }
+});

--- a/test/e2e/specs/melt.spec.ts
+++ b/test/e2e/specs/melt.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+import { counterpartyRequest, MINT_A_URL } from "../fixtures/mint";
+import { WalletPage } from "../pages/WalletPage";
+
+test("melts to BOLT11, BOLT12, and on-chain payment requests", async ({
+  page,
+  request,
+}) => {
+  const wallet = new WalletPage(page);
+  await wallet.onboard(MINT_A_URL);
+  await wallet.mintBolt11(1_000);
+
+  const bolt11 = await counterpartyRequest(request, "bolt11", 31);
+  const beforeBolt11 = await wallet.balanceSats();
+  await wallet.openSend("lightning");
+  await wallet.payRequest(bolt11);
+  await expect.poll(() => wallet.balanceSats()).toBeLessThan(beforeBolt11);
+
+  const bolt12 = await counterpartyRequest(request, "bolt12");
+  const beforeBolt12 = await wallet.balanceSats();
+  await wallet.openSend("lightning");
+  await wallet.payRequest(bolt12, 32);
+  await expect.poll(() => wallet.balanceSats()).toBeLessThan(beforeBolt12);
+
+  const address = await counterpartyRequest(request, "onchain");
+  const beforeOnchain = await wallet.balanceSats();
+  await wallet.openSend("onchain");
+  await wallet.payRequest(address, 33);
+  await expect.poll(() => wallet.balanceSats()).toBeLessThan(beforeOnchain);
+});

--- a/test/e2e/specs/mint.spec.ts
+++ b/test/e2e/specs/mint.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test";
+import { MINT_A_URL } from "../fixtures/mint";
+import { WalletPage } from "../pages/WalletPage";
+
+test("mints through BOLT11, BOLT12, and on-chain and persists the proofs", async ({
+  page,
+}) => {
+  const wallet = new WalletPage(page);
+  await wallet.onboard(MINT_A_URL);
+
+  await wallet.mintBolt11(101);
+  await wallet.mintBolt12(102);
+  await wallet.mintOnchain();
+  await expect.poll(() => wallet.balanceSats()).toBe(1_203);
+
+  await page.reload();
+  await expect(page.getByTestId("wallet-send")).toBeVisible();
+  await expect.poll(() => wallet.balanceSats()).toBe(1_203);
+});

--- a/test/e2e/specs/protocol.spec.ts
+++ b/test/e2e/specs/protocol.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+import {
+  createMintQuote,
+  MINT_A_URL,
+  MINT_B_URL,
+  type PaymentMethod,
+} from "../fixtures/mint";
+
+for (const [name, mintUrl] of [
+  ["mint-a", MINT_A_URL],
+  ["mint-b", MINT_B_URL],
+] as const) {
+  test(`${name} advertises every wallet payment rail`, async ({ request }) => {
+    const response = await request.get(`${mintUrl}/v1/info`);
+    expect(response.ok()).toBeTruthy();
+    const info = await response.json();
+
+    for (const nut of ["4", "5"]) {
+      const methods = info.nuts[nut].methods.map(
+        (entry: { method: string }) => entry.method
+      );
+      expect(methods).toEqual(
+        expect.arrayContaining(["bolt11", "bolt12", "onchain"])
+      );
+    }
+  });
+}
+
+for (const method of ["bolt11", "bolt12", "onchain"] as PaymentMethod[]) {
+  test(`fake backend settles an incoming ${method} quote`, async ({
+    request,
+  }) => {
+    const quote = await createMintQuote(request, method, {
+      mintUrl: MINT_A_URL,
+      amount: method === "onchain" ? undefined : 17,
+    });
+
+    await expect
+      .poll(async () => {
+        const response = await request.get(
+          `${MINT_A_URL}/v1/mint/quote/${method}/${quote.quote}`
+        );
+        expect(response.ok()).toBeTruthy();
+        const body = await response.json();
+        return method === "bolt11" ? body.state : body.amount_paid > 0;
+      })
+      .toBe(method === "bolt11" ? "PAID" : true);
+  });
+}


### PR DESCRIPTION
## Summary

- add a Playwright browser suite backed by two digest-pinned CDK mints with deterministic fake BOLT11, BOLT12, and on-chain rails
- cover onboarding, minting, melting, persistence, ecash send/receive, replay rejection, and direct protocol capabilities
- add stable test IDs, a Docker lifecycle runner, Playwright diagnostics, and a dedicated GitHub Actions workflow
- add the repository skill `e2e-test-playwright-video` plus `npm run test:e2e:video` for labeled H.264 test montages and contact-sheet validation

## Validation

- `npm test -- --run` — 131 passed
- `npm run lint`
- `npm run build`
- `npm run test:e2e` — 8 passed
- video skill end-to-end run — 3 passed; H.264 1280x720 montage validated
- video skill reuse mode — 1.5x montage and contact sheet validated
- skill-creator structural validation — passed
- `git diff --check`