### PR TITLE
Unify incoming mint quote batching

### DIFF
--- a/src/stores/__tests__/npubcash.test.ts
+++ b/src/stores/__tests__/npubcash.test.ts
@@ -250,6 +250,9 @@ describe("npub.cash store", () => {
     const worker = useTransactionWorkerStore();
     worker.quotes = [];
     vi.spyOn(worker, "startTransactionWorker").mockImplementation(() => {});
+    const processNow = vi
+      .spyOn(worker, "processIncomingTransactionsNow")
+      .mockResolvedValue();
     const walletStore = useWalletStore();
     walletStore.invoiceHistory = [];
     vi.spyOn(walletStore, "addPaymentHistory").mockImplementation(
@@ -274,7 +277,7 @@ describe("npub.cash store", () => {
                 quoteId: "npub-q-1",
                 request: "lnbc1",
                 amount: 10,
-                state: "PAID",
+                state: "UNPAID",
                 locked: false,
               },
               {
@@ -303,17 +306,26 @@ describe("npub.cash store", () => {
       "npub-q-2",
     ]);
     expect(worker.quotes.every((quote) => quote.usesBatchPath)).toBe(true);
+    expect(walletStore.invoiceHistory[0].mintQuote?.state).toBe("UNPAID");
+    expect(processNow).toHaveBeenCalledOnce();
   });
 
-  it("keeps direct npub.cash claiming when periodic checking is disabled", async () => {
+  it("uses the worker immediately when periodic checking is disabled", async () => {
     const mintUrl = "https://mint.example";
     const store = useNpubCashStore();
     store.enabled = true;
     store.claimAutomatically = true;
     const settingsStore = useSettingsStore();
     settingsStore.periodicallyCheckIncomingInvoices = false;
+    useMintsStore().mints = [
+      { url: mintUrl, keys: [], keysets: [], info: { nuts: { 29: {} } } },
+    ];
     const worker = useTransactionWorkerStore();
     worker.quotes = [];
+    vi.spyOn(worker, "startTransactionWorker").mockImplementation(() => {});
+    const processNow = vi
+      .spyOn(worker, "processIncomingTransactionsNow")
+      .mockResolvedValue();
     const walletStore = useWalletStore();
     walletStore.invoiceHistory = [];
     vi.spyOn(walletStore, "addPaymentHistory").mockImplementation(
@@ -350,7 +362,10 @@ describe("npub.cash store", () => {
 
     await store.synchronizeQuotes();
 
-    expect(worker.quotes).toEqual([]);
-    expect(mintOnPaid).toHaveBeenCalledWith("npub-q-1");
+    expect(worker.quotes).toEqual([
+      expect.objectContaining({ quote: "npub-q-1", usesBatchPath: true }),
+    ]);
+    expect(mintOnPaid).not.toHaveBeenCalled();
+    expect(processNow).toHaveBeenCalledOnce();
   });
 });

--- a/src/stores/__tests__/npubcash.test.ts
+++ b/src/stores/__tests__/npubcash.test.ts
@@ -238,6 +238,7 @@ describe("npub.cash store", () => {
 
   it("queues restored npub.cash quotes for background reconciliation", async () => {
     const mintUrl = "https://mint.example";
+    const now = Math.floor(Date.now() / 1_000);
     const store = useNpubCashStore();
     store.enabled = true;
     store.claimAutomatically = true;
@@ -270,9 +271,9 @@ describe("npub.cash store", () => {
           data: {
             quotes: [
               {
-                createdAt: 1_700_000_001,
-                paidAt: 1_700_000_002,
-                expiresAt: 1_700_003_600,
+                createdAt: now - 3,
+                paidAt: now - 2,
+                expiresAt: now + 3_600,
                 mintUrl,
                 quoteId: "npub-q-1",
                 request: "lnbc1",
@@ -281,9 +282,9 @@ describe("npub.cash store", () => {
                 locked: false,
               },
               {
-                createdAt: 1_700_000_003,
-                paidAt: 1_700_000_004,
-                expiresAt: 1_700_003_600,
+                createdAt: now - 1,
+                paidAt: now,
+                expiresAt: now + 3_600,
                 mintUrl,
                 quoteId: "npub-q-2",
                 request: "lnbc2",
@@ -312,6 +313,7 @@ describe("npub.cash store", () => {
 
   it("uses the worker immediately when periodic checking is disabled", async () => {
     const mintUrl = "https://mint.example";
+    const now = Math.floor(Date.now() / 1_000);
     const store = useNpubCashStore();
     store.enabled = true;
     store.claimAutomatically = true;
@@ -343,9 +345,9 @@ describe("npub.cash store", () => {
           data: {
             quotes: [
               {
-                createdAt: 1_700_000_001,
-                paidAt: 1_700_000_002,
-                expiresAt: 1_700_003_600,
+                createdAt: now - 1,
+                paidAt: now,
+                expiresAt: now + 3_600,
                 mintUrl,
                 quoteId: "npub-q-1",
                 request: "lnbc1",

--- a/src/stores/__tests__/transactionWorker.test.js
+++ b/src/stores/__tests__/transactionWorker.test.js
@@ -68,7 +68,6 @@ describe("transaction worker", () => {
     worker.batchPathCooldowns = {};
     worker.mintLaneInFlight = {};
     worker.mintLastRequestAt = {};
-    worker.incomingMintLaneDrainRequested = {};
     worker.mintQuoteClaims = {};
 
     useMintsStore().mints = [];
@@ -321,7 +320,7 @@ describe("transaction worker", () => {
     expect(checkInvoiceBolt11).toHaveBeenCalledTimes(2);
   });
 
-  it("drains newly arrived quotes after the active mint-lane request", async () => {
+  it("leaves newly arrived quotes queued until the mint lane is ready", async () => {
     const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const now = Date.now();
@@ -353,11 +352,19 @@ describe("transaction worker", () => {
     resolveFirst();
     await activeRequest;
 
+    expect(checkInvoiceBolt11).toHaveBeenCalledOnce();
+    expect(worker.quotes.map((entry) => entry.quote)).toEqual(["new-q"]);
+
+    await worker.processIncomingTransactionsNow(walletStore);
+    expect(checkInvoiceBolt11).toHaveBeenCalledOnce();
+
+    worker.mintLastRequestAt["https://mint.example"] = 0;
+    await worker.processIncomingTransactionsNow(walletStore);
     expect(checkInvoiceBolt11).toHaveBeenCalledTimes(2);
     expect(checkInvoiceBolt11).toHaveBeenLastCalledWith("new-q", false);
   });
 
-  it("switches an active outgoing lane to an immediate incoming drain", async () => {
+  it("paces incoming work that arrives during an outgoing mint job", async () => {
     const worker = useTransactionWorkerStore();
     const now = Date.now();
     useSettingsStore().periodicallyCheckIncomingInvoices = false;
@@ -393,6 +400,10 @@ describe("transaction worker", () => {
     resolveOutgoing();
     await activeRequest;
 
+    expect(checkInvoiceBolt11).not.toHaveBeenCalled();
+
+    worker.mintLastRequestAt["https://mint.example"] = 0;
+    await worker.processIncomingTransactionsNow(walletStore);
     expect(checkInvoiceBolt11).toHaveBeenCalledWith("incoming-q", false);
   });
 
@@ -1022,7 +1033,7 @@ describe("transaction worker", () => {
     );
   });
 
-  it("drains every startup batch through the worker's batch cap", async () => {
+  it("paces startup batches through the worker's batch cap", async () => {
     const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const mintUrl = "https://mint.example";
@@ -1045,8 +1056,15 @@ describe("transaction worker", () => {
 
     await worker.checkPendingTransactions(walletStore);
 
-    expect(checkMintQuoteBatchBolt11).toHaveBeenCalledTimes(2);
+    expect(checkMintQuoteBatchBolt11).toHaveBeenCalledOnce();
     expect(checkMintQuoteBatchBolt11.mock.calls[0][0]).toHaveLength(2);
+
+    await worker.processTransactions(walletStore, true);
+    expect(checkMintQuoteBatchBolt11).toHaveBeenCalledOnce();
+
+    worker.mintLastRequestAt[mintUrl] = 0;
+    await worker.processTransactions(walletStore, true);
+    expect(checkMintQuoteBatchBolt11).toHaveBeenCalledTimes(2);
     expect(checkMintQuoteBatchBolt11.mock.calls.flat(2).sort()).toEqual([
       "q-1",
       "q-2",

--- a/src/stores/__tests__/transactionWorker.test.js
+++ b/src/stores/__tests__/transactionWorker.test.js
@@ -128,6 +128,57 @@ describe("transaction worker", () => {
     );
   });
 
+  it("keeps month-old quotes out of batches and checks them singly", async () => {
+    const worker = useTransactionWorkerStore();
+    const mintStore = useMintsStore();
+    const mintUrl = "https://mint.example";
+    const now = Date.now();
+    advertiseBatchMint(mintStore, mintUrl);
+    vi.spyOn(worker, "startTransactionWorker").mockImplementation(() => {});
+    vi.spyOn(usePaymentHistoryStore(), "upsertMintQuote").mockResolvedValue();
+
+    const oldInvoice = pendingInvoice("old-q", {
+      date: new Date(now - 31 * 24 * 60 * 60 * 1_000).toISOString(),
+    });
+    const recentInvoice = pendingInvoice("recent-q", {
+      date: new Date(now - 24 * 60 * 60 * 1_000).toISOString(),
+    });
+    worker.queueIncomingMintQuote(oldInvoice);
+    worker.queueIncomingMintQuote(recentInvoice);
+
+    expect(
+      worker.quotes.find((entry) => entry.quote === "old-q").usesBatchPath
+    ).toBeUndefined();
+    expect(
+      worker.quotes.find((entry) => entry.quote === "recent-q").usesBatchPath
+    ).toBe(true);
+
+    // Simulate a persisted queue from an older app version that marked every
+    // quote for batching. Job construction must still enforce the age limit.
+    worker.quotes.find((entry) => entry.quote === "old-q").usesBatchPath = true;
+
+    const checkMintQuoteBatchBolt11 = vi.fn(async (quotes) =>
+      quotes.map(unpaidResponse)
+    );
+    const checkInvoiceBolt11 = vi.fn(async () => {});
+    const walletStore = {
+      invoiceHistory: [oldInvoice, recentInvoice],
+      mintWallet: vi.fn(async () => ({ checkMintQuoteBatchBolt11 })),
+      checkInvoiceBolt11,
+      syncPaymentHistoryCache: vi.fn(),
+    };
+
+    await worker.processTransactions(walletStore, true);
+
+    expect(checkMintQuoteBatchBolt11).toHaveBeenCalledWith(["recent-q"]);
+    expect(checkInvoiceBolt11).not.toHaveBeenCalled();
+
+    worker.mintLastRequestAt[mintUrl] = 0;
+    await worker.processTransactions(walletStore);
+
+    expect(checkInvoiceBolt11).toHaveBeenCalledWith("old-q", false);
+  });
+
   it("starts for sent-token checks when incoming polling is disabled", () => {
     const worker = useTransactionWorkerStore();
     useSettingsStore().periodicallyCheckIncomingInvoices = false;
@@ -930,12 +981,15 @@ describe("transaction worker", () => {
     const settingsStore = useSettingsStore();
     const batchMintUrl = "https://batch.example";
     const singleMintUrl = "https://single.example";
+    const recentDate = new Date(
+      Date.now() - 6 * 24 * 60 * 60 * 1_000
+    ).toISOString();
     const oldDate = new Date(
       Date.now() - 30 * 24 * 60 * 60 * 1_000
     ).toISOString();
     const batchInvoices = Array.from({ length: 55 }, (_, index) =>
       pendingInvoice(`batch-q-${index}`, {
-        date: oldDate,
+        date: recentDate,
         mint: batchMintUrl,
       })
     );

--- a/src/stores/__tests__/transactionWorker.test.js
+++ b/src/stores/__tests__/transactionWorker.test.js
@@ -68,6 +68,7 @@ describe("transaction worker", () => {
     worker.batchPathCooldowns = {};
     worker.mintLaneInFlight = {};
     worker.mintLastRequestAt = {};
+    worker.incomingMintLaneDrainRequested = {};
     worker.mintQuoteClaims = {};
 
     useMintsStore().mints = [];
@@ -92,6 +93,23 @@ describe("transaction worker", () => {
       expected
     );
   });
+
+  it.each([
+    [PaymentMethod.Bolt12, [PaymentMethod.Bolt12], true],
+    [PaymentMethod.Onchain, [PaymentMethod.Onchain], true],
+    [PaymentMethod.Bolt12, [PaymentMethod.Bolt11], false],
+    [PaymentMethod.Onchain, undefined, false],
+  ])(
+    "detects batch support per payment method",
+    (method, methods, expected) => {
+      expect(
+        useTransactionWorkerStore().mintSupportsBatch(
+          { info: { nuts: { 29: methods ? { methods } : {} } } },
+          method
+        )
+      ).toBe(expected);
+    }
+  );
 
   it("uses the normalized batch cap", () => {
     const worker = useTransactionWorkerStore();
@@ -303,6 +321,81 @@ describe("transaction worker", () => {
     expect(checkInvoiceBolt11).toHaveBeenCalledTimes(2);
   });
 
+  it("drains newly arrived quotes after the active mint-lane request", async () => {
+    const worker = useTransactionWorkerStore();
+    const mintStore = useMintsStore();
+    const now = Date.now();
+    mintStore.mints.push({
+      url: "https://mint.example",
+      keys: [],
+      keysets: [],
+      info: { nuts: {} },
+    });
+    worker.quotes = [queuedQuote("first-q", now - 20_000)];
+    let resolveFirst;
+    const firstPending = new Promise((resolve) => {
+      resolveFirst = resolve;
+    });
+    const checkInvoiceBolt11 = vi
+      .fn()
+      .mockReturnValueOnce(firstPending)
+      .mockResolvedValueOnce(undefined);
+    const walletStore = {
+      invoiceHistory: [pendingInvoice("first-q"), pendingInvoice("new-q")],
+      checkInvoiceBolt11,
+    };
+
+    const activeRequest = worker.processTransactions(walletStore);
+    await vi.waitFor(() => expect(checkInvoiceBolt11).toHaveBeenCalledOnce());
+    worker.addInvoiceToChecker("new-q");
+    await worker.processIncomingTransactionsNow(walletStore);
+
+    resolveFirst();
+    await activeRequest;
+
+    expect(checkInvoiceBolt11).toHaveBeenCalledTimes(2);
+    expect(checkInvoiceBolt11).toHaveBeenLastCalledWith("new-q", false);
+  });
+
+  it("switches an active outgoing lane to an immediate incoming drain", async () => {
+    const worker = useTransactionWorkerStore();
+    const now = Date.now();
+    useSettingsStore().periodicallyCheckIncomingInvoices = false;
+    worker.outgoingPayments = [
+      {
+        id: "outgoing-q",
+        type: "invoice",
+        addedAt: now - 20_000,
+        lastChecked: 0,
+        checkCount: 0,
+      },
+    ];
+    let resolveOutgoing;
+    const outgoingPending = new Promise((resolve) => {
+      resolveOutgoing = resolve;
+    });
+    const checkOutgoingInvoice = vi.fn(() => outgoingPending);
+    const checkInvoiceBolt11 = vi.fn(async () => {});
+    const walletStore = {
+      invoiceHistory: [
+        pendingInvoice("outgoing-q", { amount: -10 }),
+        pendingInvoice("incoming-q"),
+      ],
+      checkOutgoingInvoice,
+      checkInvoiceBolt11,
+    };
+
+    const activeRequest = worker.processTransactions(walletStore);
+    await vi.waitFor(() => expect(checkOutgoingInvoice).toHaveBeenCalledOnce());
+    worker.addInvoiceToChecker("incoming-q");
+    await worker.processIncomingTransactionsNow(walletStore);
+
+    resolveOutgoing();
+    await activeRequest;
+
+    expect(checkInvoiceBolt11).toHaveBeenCalledWith("incoming-q", false);
+  });
+
   it("rate-limits completed requests per mint, not globally", async () => {
     const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
@@ -333,8 +426,8 @@ describe("transaction worker", () => {
       Date.now() - worker.checkInterval;
     await worker.processTransactions(walletStore);
     expect(checkInvoiceBolt11).toHaveBeenCalledTimes(2);
-    expect(checkInvoiceBolt11.mock.calls[0][0]).toBe("first-q");
-    expect(checkInvoiceBolt11.mock.calls[1][0]).toBe("second-q");
+    expect(checkInvoiceBolt11.mock.calls[0][0]).toBe("second-q");
+    expect(checkInvoiceBolt11.mock.calls[1][0]).toBe("first-q");
   });
 
   it("batch-checks every due quote for a mint in one request", async () => {
@@ -364,14 +457,14 @@ describe("transaction worker", () => {
     await worker.processTransactions(walletStore);
 
     expect(checkMintQuoteBatchBolt11).toHaveBeenCalledWith([
-      "first-q",
-      "second-q",
       "third-q",
+      "second-q",
+      "first-q",
     ]);
     expect(worker.quotes.every((entry) => entry.checkCount === 1)).toBe(true);
   });
 
-  it("honors the mint's batch cap and selects the oldest quotes", async () => {
+  it("honors the mint's batch cap and selects the newest quotes", async () => {
     const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
     const now = Date.now();
@@ -400,11 +493,11 @@ describe("transaction worker", () => {
     await worker.processTransactions(walletStore);
 
     expect(checkMintQuoteBatchBolt11).toHaveBeenCalledWith([
-      "old-q",
+      "new-q",
       "middle-q",
     ]);
     expect(
-      worker.quotes.find((entry) => entry.quote === "new-q").checkCount
+      worker.quotes.find((entry) => entry.quote === "old-q").checkCount
     ).toBe(0);
   });
 
@@ -520,6 +613,94 @@ describe("transaction worker", () => {
     ]);
   });
 
+  it.each([PaymentMethod.Bolt12, PaymentMethod.Onchain])(
+    "batch-checks and batch-mints paid %s quotes",
+    async (method) => {
+      const worker = useTransactionWorkerStore();
+      const mintStore = useMintsStore();
+      const mintUrl = "https://mint.example";
+      const now = Date.now();
+      advertiseBatchMint(mintStore, mintUrl, { methods: [method] });
+      mintStore.mints[0].keysets = [{ id: "00aa", unit: "sat", active: true }];
+      const queue = [
+        queuedQuote("old-q", now - 20_000, { usesBatchPath: true }),
+        queuedQuote("new-q", now - 10_000, { usesBatchPath: true }),
+      ];
+      if (method === PaymentMethod.Bolt12) {
+        worker.bolt12Quotes = queue;
+      } else {
+        worker.onchainQuotes = queue;
+      }
+
+      vi.spyOn(usePaymentHistoryStore(), "upsertMintQuote").mockResolvedValue();
+      const addProofs = vi
+        .spyOn(useProofsStore(), "addProofs")
+        .mockResolvedValue();
+      vi.spyOn(useUiStore(), "lockMutex").mockResolvedValue();
+      vi.spyOn(useUiStore(), "unlockMutex").mockImplementation(() => {});
+
+      const checkBatch = vi.fn(async (...args) => {
+        const quotes = args.at(-1);
+        const issued = checkBatch.mock.calls.length >= 3 ? 10 : 0;
+        return quotes.map((quote) => ({
+          quote,
+          amount: null,
+          amount_paid: 10,
+          amount_issued: issued,
+          state: "PAID",
+          request: `${method}-${quote}`,
+          unit: "sat",
+        }));
+      });
+      const mintWallet = {
+        ...(method === PaymentMethod.Bolt12
+          ? { checkMintQuoteBatchBolt12: checkBatch }
+          : { checkMintQuoteBatch: checkBatch }),
+        prepareBatchMint: vi.fn(async () => ({ preview: true })),
+        completeBatchMint: vi.fn(async () => [
+          { amount: 10, secret: "proof-1" },
+          { amount: 10, secret: "proof-2" },
+        ]),
+      };
+      const walletStore = {
+        invoiceHistory: [
+          pendingInvoice("old-q", { amount: 0, type: method }),
+          pendingInvoice("new-q", { amount: 0, type: method }),
+        ],
+        invoiceData: {},
+        mintWallet: vi.fn(async () => mintWallet),
+        getKeyset: vi.fn(() => "00aa"),
+        retryOnceOnSignedOutputs: vi.fn(
+          async (_keysetId, operation) => await operation()
+        ),
+        setInvoicePaid: vi.fn(),
+        addPaymentHistory: vi.fn(),
+        syncPaymentHistoryCache: vi.fn(),
+      };
+
+      await worker.processIncomingTransactionsNow(walletStore);
+
+      if (method === PaymentMethod.Bolt12) {
+        expect(checkBatch).toHaveBeenNthCalledWith(1, ["new-q", "old-q"]);
+      } else {
+        expect(checkBatch).toHaveBeenNthCalledWith(1, method, [
+          "new-q",
+          "old-q",
+        ]);
+      }
+      expect(mintWallet.prepareBatchMint).toHaveBeenCalledWith(
+        method,
+        [
+          expect.objectContaining({ amount: 10 }),
+          expect.objectContaining({ amount: 10 }),
+        ],
+        expect.objectContaining({ keysetId: "00aa" })
+      );
+      expect(addProofs).toHaveBeenCalledOnce();
+      expect(walletStore.setInvoicePaid).toHaveBeenCalledTimes(2);
+    }
+  );
+
   it("does not batch-mint a quote already issued by its WebSocket callback", async () => {
     const worker = useTransactionWorkerStore();
     const mintStore = useMintsStore();
@@ -572,8 +753,8 @@ describe("transaction worker", () => {
       queuedQuote("second-q", now - 10_000),
     ];
     const checkMintQuoteBatchBolt11 = vi.fn(async () => [
-      unpaidResponse("second-q"),
       unpaidResponse("first-q"),
+      unpaidResponse("second-q"),
     ]);
     const walletStore = {
       invoiceHistory: [pendingInvoice("first-q"), pendingInvoice("second-q")],
@@ -839,6 +1020,38 @@ describe("transaction worker", () => {
       false,
       false
     );
+  });
+
+  it("drains every startup batch through the worker's batch cap", async () => {
+    const worker = useTransactionWorkerStore();
+    const mintStore = useMintsStore();
+    const mintUrl = "https://mint.example";
+    advertiseBatchMint(mintStore, mintUrl, { max_batch_size: 2 });
+    vi.spyOn(worker, "startTransactionWorker").mockImplementation(() => {});
+    vi.spyOn(usePaymentHistoryStore(), "upsertMintQuote").mockResolvedValue();
+    const checkMintQuoteBatchBolt11 = vi.fn(async (quotes) =>
+      quotes.map(unpaidResponse)
+    );
+    const walletStore = {
+      invoiceHistory: [
+        pendingInvoice("q-1"),
+        pendingInvoice("q-2"),
+        pendingInvoice("q-3"),
+      ],
+      mintWallet: vi.fn(async () => ({ checkMintQuoteBatchBolt11 })),
+      mintOnPaidBolt11: vi.fn(async () => {}),
+      syncPaymentHistoryCache: vi.fn(),
+    };
+
+    await worker.checkPendingTransactions(walletStore);
+
+    expect(checkMintQuoteBatchBolt11).toHaveBeenCalledTimes(2);
+    expect(checkMintQuoteBatchBolt11.mock.calls[0][0]).toHaveLength(2);
+    expect(checkMintQuoteBatchBolt11.mock.calls.flat(2).sort()).toEqual([
+      "q-1",
+      "q-2",
+      "q-3",
+    ]);
   });
 
   it("keeps reusable WebSockets and worker queues active together", () => {

--- a/src/stores/__tests__/transactionWorker.test.js
+++ b/src/stores/__tests__/transactionWorker.test.js
@@ -1072,9 +1072,12 @@ describe("transaction worker", () => {
     ]);
   });
 
-  it("keeps reusable WebSockets and worker queues active together", () => {
+  it("keeps reusable WebSockets and batch worker queues active together", () => {
     const worker = useTransactionWorkerStore();
     const now = new Date().toISOString();
+    advertiseBatchMint(useMintsStore(), "https://mint.example", {
+      methods: [PaymentMethod.Bolt12, PaymentMethod.Onchain],
+    });
     vi.spyOn(worker, "startTransactionWorker").mockImplementation(() => {});
     const walletStore = {
       invoiceHistory: [
@@ -1100,9 +1103,11 @@ describe("transaction worker", () => {
     expect(worker.bolt12Quotes.map((entry) => entry.quote)).toEqual([
       "bolt12-q",
     ]);
+    expect(worker.bolt12Quotes[0].usesBatchPath).toBe(true);
     expect(worker.onchainQuotes.map((entry) => entry.quote)).toEqual([
       "onchain-q",
     ]);
+    expect(worker.onchainQuotes[0].usesBatchPath).toBe(true);
     expect(walletStore.mintOnPaidBolt12).toHaveBeenCalledWith(
       "bolt12-q",
       false,

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -1,5 +1,5 @@
+import type { MintQuoteState } from "@cashu/cashu-ts";
 import NDK, { NDKEvent } from "@nostr-dev-kit/ndk";
-import { MintQuoteState } from "@cashu/cashu-ts";
 import { StorageSerializers, useLocalStorage } from "@vueuse/core";
 import { defineStore } from "pinia";
 import { date } from "quasar";
@@ -8,7 +8,6 @@ import { notifyApiError, notifyError } from "src/js/notify";
 import { useTransactionWorkerStore } from "src/stores/transactionWorker";
 import { useMintsStore } from "src/stores/mints";
 import { useNostrStore } from "src/stores/nostr";
-import { useSettingsStore } from "src/stores/settings";
 import { useWalletStore } from "src/stores/wallet";
 
 type NpubCashUser = {
@@ -42,7 +41,7 @@ type NpubCashQuote = {
   quoteId: string;
   request: string;
   amount: number;
-  state: string;
+  state: MintQuoteState;
   locked: boolean;
 };
 
@@ -304,9 +303,7 @@ export const useNpubCashStore = defineStore("npubCash", {
         return;
       }
       const transactionWorkerStore = useTransactionWorkerStore();
-      const settingsStore = useSettingsStore();
       const walletStore = useWalletStore();
-      const mintsStore = useMintsStore();
       const since = this.lastCheck ? `?since=${this.lastCheck}` : "";
       const quoteUrl = `${NPUB_CASH_BASE_URL}/api/v2/wallet/quotes`;
       try {
@@ -320,6 +317,7 @@ export const useNpubCashStore = defineStore("npubCash", {
           return;
         }
         let latestQuoteTime: number | undefined;
+        let queuedQuotes = false;
         for (const quote of responseData.data.quotes) {
           if (
             walletStore.invoiceHistory.find(
@@ -331,7 +329,7 @@ export const useNpubCashStore = defineStore("npubCash", {
           if (!latestQuoteTime || latestQuoteTime < quote.createdAt) {
             latestQuoteTime = quote.createdAt;
           }
-          await walletStore.addPaymentHistory({
+          const invoice = {
             label: "Zap",
             mint: quote.mintUrl,
             memo: "",
@@ -342,34 +340,30 @@ export const useNpubCashStore = defineStore("npubCash", {
               new Date(quote.createdAt * 1000),
               "YYYY-MM-DD HH:mm:ss"
             ),
-            status: "pending",
+            status: "pending" as const,
             unit: "sat",
             mintQuote: {
               request: quote.request,
               quote: quote.quoteId,
-              state: MintQuoteState.PAID,
+              state: quote.state,
               expiry: quote.expiresAt,
               amount: quote.amount,
               unit: "sat",
             },
-          });
+          };
+          await walletStore.addPaymentHistory(invoice);
           if (this.claimAutomatically) {
-            if (settingsStore.periodicallyCheckIncomingInvoices) {
-              const mint = mintsStore.mints.find(
-                (item) => item.url === quote.mintUrl
-              );
-              if (transactionWorkerStore.mintSupportsBolt11Batch(mint)) {
-                transactionWorkerStore.addBatchInvoiceToChecker(quote.quoteId);
-              } else {
-                transactionWorkerStore.addInvoiceToChecker(quote.quoteId);
-              }
-            } else {
-              await walletStore.mintOnPaidBolt11(quote.quoteId);
-            }
+            transactionWorkerStore.queueIncomingMintQuote(invoice);
+            queuedQuotes = true;
           }
         }
         if (latestQuoteTime) {
           this.lastCheck = latestQuoteTime;
+        }
+        if (queuedQuotes) {
+          await transactionWorkerStore.processIncomingTransactionsNow(
+            walletStore
+          );
         }
       } catch (error) {
         console.error(error);

--- a/src/stores/transactionWorker.ts
+++ b/src/stores/transactionWorker.ts
@@ -1465,7 +1465,11 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
 
           this.queueIncomingMintQuote(invoice);
 
-          if (!supportsBatch || !periodicChecks) {
+          if (
+            method !== PaymentMethod.Bolt11 ||
+            !supportsBatch ||
+            !periodicChecks
+          ) {
             void this.startMintQuoteWebsocket(
               walletStore,
               method,

--- a/src/stores/transactionWorker.ts
+++ b/src/stores/transactionWorker.ts
@@ -14,6 +14,13 @@ import {
 } from "src/stores/paymentHistory";
 import { useProofsStore } from "src/stores/proofs";
 import { useUiStore } from "src/stores/ui";
+import { currentDateStr } from "src/js/utils";
+import { createSubpaymentHistoryQuote } from "src/js/invoice-history";
+
+type IncomingPaymentMethod =
+  | PaymentMethod.Bolt11
+  | PaymentMethod.Bolt12
+  | PaymentMethod.Onchain;
 
 interface InvoiceQuote {
   quote: string;
@@ -38,32 +45,29 @@ interface OutgoingPaymentCheck {
   checkCount: number;
 }
 
-interface DueBolt11Quote {
+interface DueMintQuote {
   queueEntry: InvoiceQuote;
   invoice: any;
 }
 
-interface PaidBolt11Quote extends DueBolt11Quote {
+interface MintableQuote extends DueMintQuote {
   mintQuote: Record<string, any>;
+  mintAmount: number;
 }
 
 type MintJob =
   | {
-      kind: "bolt11-batch";
+      kind: "incoming-batch";
       mintUrl: string;
       unit: string;
-      entries: DueBolt11Quote[];
+      method: IncomingPaymentMethod;
+      entries: DueMintQuote[];
     }
   | {
-      kind: "bolt11-single";
+      kind: "incoming-single";
       mintUrl: string;
-      entry: DueBolt11Quote;
-    }
-  | {
-      kind: "bolt12" | "onchain";
-      mintUrl: string;
-      entry: InvoiceQuote;
-      invoice: any;
+      method: IncomingPaymentMethod;
+      entry: DueMintQuote;
     }
   | {
       kind: "outgoing-invoice";
@@ -93,6 +97,16 @@ function queueAge(entry: { lastChecked: number; addedAt: number }) {
   return entry.lastChecked || entry.addedAt;
 }
 
+// New payments get one prompt check. Retried payments then return to the
+// least-recently-checked order so a stream of new payments cannot starve them.
+function queueOrder(entry: InvoiceQuote) {
+  return entry.checkCount === 0 ? -entry.addedAt : queueAge(entry);
+}
+
+function compareQueueEntries(left: InvoiceQuote, right: InvoiceQuote) {
+  return queueOrder(left) - queueOrder(right);
+}
+
 function amountToNumber(value: any) {
   if (value === undefined || value === null) return 0;
   return Amount.from(value).toNumber();
@@ -116,6 +130,7 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
     // Lane state is ephemeral so a restart immediately retries pending work.
     mintLaneInFlight: {} as Record<string, boolean>,
     mintLastRequestAt: {} as Record<string, number>,
+    incomingMintLaneDrainRequested: {} as Record<string, boolean>,
     mintQuoteClaims: {} as Record<string, boolean>,
 
     // These keys intentionally retain their old names so existing queues
@@ -180,20 +195,27 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
     },
 
     addInvoiceToChecker(quote: string, forceStart = false) {
-      this.addBolt11QuoteToChecker(quote, forceStart, false);
+      this.addMintQuoteToChecker(
+        PaymentMethod.Bolt11,
+        quote,
+        forceStart,
+        false
+      );
     },
 
     addBatchInvoiceToChecker(quote: string, forceStart = false) {
-      this.addBolt11QuoteToChecker(quote, forceStart, true);
+      this.addMintQuoteToChecker(PaymentMethod.Bolt11, quote, forceStart, true);
     },
 
-    addBolt11QuoteToChecker(
+    addMintQuoteToChecker(
+      method: IncomingPaymentMethod,
       quote: string,
       forceStart: boolean,
       usesBatchPath: boolean
     ) {
       if (!quote) return;
-      const existing = this.quotes.find((entry) => entry.quote === quote);
+      const queue = this.mintQuoteQueue(method);
+      const existing = queue.find((entry) => entry.quote === quote);
       if (existing) {
         if (usesBatchPath) {
           existing.usesBatchPath = true;
@@ -206,18 +228,16 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       }
 
       if (!usesBatchPath) {
-        const singleEntries = this.quotes.filter(
-          (entry) => !entry.usesBatchPath
-        );
+        const singleEntries = queue.filter((entry) => !entry.usesBatchPath);
         if (singleEntries.length >= this.maxLength) {
           const oldest = singleEntries.reduce((left, right) =>
             left.addedAt <= right.addedAt ? left : right
           );
-          this.removeInvoiceFromChecker(oldest.quote);
+          this.removeMintQuoteFromChecker(method, oldest.quote);
         }
       }
 
-      this.quotes.push({
+      queue.push({
         quote,
         addedAt: Date.now(),
         lastChecked: 0,
@@ -228,48 +248,94 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
     },
 
     removeInvoiceFromChecker(quote: string) {
-      const index = this.quotes.findIndex((entry) => entry.quote === quote);
-      if (index !== -1) this.quotes.splice(index, 1);
+      this.removeMintQuoteFromChecker(PaymentMethod.Bolt11, quote);
     },
 
     addBolt12OfferToChecker(quote: string, forceStart = false) {
-      this.addReusableQuoteToChecker(this.bolt12Quotes, quote, forceStart);
+      this.addMintQuoteToChecker(
+        PaymentMethod.Bolt12,
+        quote,
+        forceStart,
+        false
+      );
     },
 
     removeBolt12OfferFromChecker(quote: string) {
-      const index = this.bolt12Quotes.findIndex(
-        (entry) => entry.quote === quote
-      );
-      if (index !== -1) this.bolt12Quotes.splice(index, 1);
+      this.removeMintQuoteFromChecker(PaymentMethod.Bolt12, quote);
     },
 
     addOnchainQuoteToChecker(quote: string, forceStart = false) {
-      this.addReusableQuoteToChecker(this.onchainQuotes, quote, forceStart);
+      this.addMintQuoteToChecker(
+        PaymentMethod.Onchain,
+        quote,
+        forceStart,
+        false
+      );
     },
 
     removeOnchainQuoteFromChecker(quote: string) {
-      const index = this.onchainQuotes.findIndex(
-        (entry) => entry.quote === quote
-      );
-      if (index !== -1) this.onchainQuotes.splice(index, 1);
+      this.removeMintQuoteFromChecker(PaymentMethod.Onchain, quote);
     },
 
-    addReusableQuoteToChecker(
-      queue: InvoiceQuote[],
+    mintQuoteQueue(method: IncomingPaymentMethod): InvoiceQuote[] {
+      if (method === PaymentMethod.Bolt12) return this.bolt12Quotes;
+      if (method === PaymentMethod.Onchain) return this.onchainQuotes;
+      return this.quotes;
+    },
+
+    removeMintQuoteFromChecker(method: IncomingPaymentMethod, quote: string) {
+      const queue = this.mintQuoteQueue(method);
+      const index = queue.findIndex((entry) => entry.quote === quote);
+      if (index !== -1) queue.splice(index, 1);
+    },
+
+    addBatchMintQuoteToChecker(
+      method: IncomingPaymentMethod,
       quote: string,
-      forceStart: boolean
+      forceStart = false
     ) {
-      if (!quote) return;
-      if (!queue.some((entry) => entry.quote === quote)) {
-        if (queue.length >= this.maxLength) queue.shift();
-        queue.push({
-          quote,
-          addedAt: Date.now(),
-          lastChecked: 0,
-          checkCount: 0,
-        });
+      this.addMintQuoteToChecker(method, quote, forceStart, true);
+    },
+
+    addSingleMintQuoteToChecker(
+      method: IncomingPaymentMethod,
+      quote: string,
+      forceStart = false
+    ) {
+      this.addMintQuoteToChecker(method, quote, forceStart, false);
+    },
+
+    mintSupportsBatch(
+      mint: Pick<StoredMint, "info"> | undefined,
+      method: IncomingPaymentMethod
+    ) {
+      const nut29 = mint?.info?.nuts?.[29];
+      if (!nut29) return false;
+      // Older NUT-29 advertisements predate the methods field and only cover
+      // Bolt11. Newer methods must be advertised explicitly.
+      if (!nut29.methods) return method === PaymentMethod.Bolt11;
+      return nut29.methods.includes(method);
+    },
+
+    mintSupportsBolt11Batch(mint: Pick<StoredMint, "info"> | undefined) {
+      return this.mintSupportsBatch(mint, PaymentMethod.Bolt11);
+    },
+
+    batchSizeLimit(mint: Pick<StoredMint, "info"> | undefined) {
+      if (!mint?.info) return undefined;
+      try {
+        const limit = new MintInfo(mint.info).isSupported(29).params
+          ?.max_batch_size;
+        return typeof limit === "number" && Number.isFinite(limit) && limit > 0
+          ? Math.floor(limit)
+          : undefined;
+      } catch {
+        return undefined;
       }
-      this.startTransactionWorker(forceStart);
+    },
+
+    bolt11BatchSizeLimit(mint: Pick<StoredMint, "info"> | undefined) {
+      return this.batchSizeLimit(mint);
     },
 
     addOutgoingInvoiceToChecker(quote: string, forceStart = false) {
@@ -335,25 +401,6 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
 
     isDue(entry: { lastChecked: number; checkCount: number }, now: number) {
       return now >= this.dueTime(entry);
-    },
-
-    mintSupportsBolt11Batch(mint: Pick<StoredMint, "info"> | undefined) {
-      const nut29 = mint?.info?.nuts?.[29];
-      if (!nut29) return false;
-      return !nut29.methods || nut29.methods.includes(PaymentMethod.Bolt11);
-    },
-
-    bolt11BatchSizeLimit(mint: Pick<StoredMint, "info"> | undefined) {
-      if (!mint?.info) return undefined;
-      try {
-        const limit = new MintInfo(mint.info).isSupported(29).params
-          ?.max_batch_size;
-        return typeof limit === "number" && Number.isFinite(limit) && limit > 0
-          ? Math.floor(limit)
-          : undefined;
-      } catch {
-        return undefined;
-      }
     },
 
     shouldCheckInvoice(invoice: any) {
@@ -467,18 +514,17 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       return Array.from(mintUrls);
     },
 
-    mintLaneReady(mintUrl: string, now: number) {
+    mintLaneReady(mintUrl: string, now: number, bypassInterval = false) {
       if (this.mintLaneInFlight[mintUrl]) return false;
-      const lastRequestAt = this.mintLastRequestAt[mintUrl] ?? 0;
       const cooldownUntil =
         this.reusableMintCooldowns[mintUrl]?.nextRetryAt ?? 0;
-      return now >= Math.max(lastRequestAt + this.checkInterval, cooldownUntil);
+      if (now < cooldownUntil) return false;
+      if (bypassInterval) return true;
+      const lastRequestAt = this.mintLastRequestAt[mintUrl] ?? 0;
+      return now >= lastRequestAt + this.checkInterval;
     },
 
-    async processTransactions(
-      walletStore?: any,
-      prioritizeBolt11Batch = false
-    ) {
+    async processTransactions(walletStore?: any, prioritizeBatch = false) {
       const activeWalletStore = walletStore ?? useWalletStore();
       const settingsStore = useSettingsStore();
       const checkIncoming = settingsStore.periodicallyCheckIncomingInvoices;
@@ -492,29 +538,56 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       return await this.dispatchMintLanes(
         activeWalletStore,
         scope,
-        prioritizeBolt11Batch
+        prioritizeBatch,
+        false
+      );
+    },
+
+    async processIncomingTransactionsNow(walletStore?: any) {
+      return await this.dispatchMintLanes(
+        walletStore ?? useWalletStore(),
+        "incoming",
+        true,
+        true
       );
     },
 
     // Retained as callable helpers for diagnostics and tests.
     async processIncomingQueues(_now: number, walletStore: any) {
-      return await this.dispatchMintLanes(walletStore, "incoming", false);
+      return await this.dispatchMintLanes(
+        walletStore,
+        "incoming",
+        false,
+        false
+      );
     },
 
     async processOutgoingQueue(_now: number, walletStore: any) {
       if (!useSettingsStore().checkSentTokens) return;
-      return await this.dispatchMintLanes(walletStore, "outgoing", false);
+      return await this.dispatchMintLanes(
+        walletStore,
+        "outgoing",
+        false,
+        false
+      );
     },
 
     async dispatchMintLanes(
       walletStore: any,
       scope: WorkScope,
-      prioritizeBolt11Batch: boolean
+      prioritizeBatch: boolean,
+      drain: boolean
     ) {
       const now = Date.now();
       this.pruneQueues(now, walletStore);
       const lanes = this.mintUrlsWithWork(walletStore, scope).map((mintUrl) =>
-        this.processMintLane(mintUrl, walletStore, scope, prioritizeBolt11Batch)
+        this.processMintLane(
+          mintUrl,
+          walletStore,
+          scope,
+          prioritizeBatch,
+          drain
+        )
       );
       await Promise.allSettled(lanes);
     },
@@ -523,50 +596,83 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       mintUrl: string,
       walletStore: any,
       scope: WorkScope,
-      prioritizeBolt11Batch: boolean
+      prioritizeBatch: boolean,
+      drain: boolean
     ) {
-      const now = Date.now();
-      if (!this.mintLaneReady(mintUrl, now)) return;
-
-      const job = this.nextMintJob(
-        mintUrl,
-        walletStore,
-        now,
-        scope,
-        prioritizeBolt11Batch
-      );
-      if (!job) return;
-
+      if (this.mintLaneInFlight[mintUrl]) {
+        if (drain && scope !== "outgoing") {
+          this.incomingMintLaneDrainRequested[mintUrl] = true;
+        }
+        return;
+      }
+      if (!this.mintLaneReady(mintUrl, Date.now(), drain)) return;
       this.mintLaneInFlight[mintUrl] = true;
-      this.mintLastRequestAt[mintUrl] = now;
+      let shouldDrain = drain;
+      let laneScope = scope;
+      let prioritizeLaneBatch = prioritizeBatch;
       try {
-        await this.runMintJob(job, walletStore, now);
-        this.clearMintCooldown(mintUrl);
-        if (job.kind === "bolt11-batch") {
-          this.clearBatchPathCooldown(job.mintUrl, job.unit);
-        }
-      } catch (error) {
-        this.markJobAttempt(job, now);
-        if (job.kind === "bolt11-batch") {
-          if (this.isNetworkOrRateLimitFailure(error)) {
-            this.recordMintFailure(mintUrl, error, Date.now());
-          } else {
+        do {
+          const now = Date.now();
+          const job = this.nextMintJob(
+            mintUrl,
+            walletStore,
+            now,
+            laneScope,
+            prioritizeLaneBatch
+          );
+          if (!job) return;
+
+          this.mintLastRequestAt[mintUrl] = now;
+          try {
+            await this.runMintJob(job, walletStore, now);
             this.clearMintCooldown(mintUrl);
-            this.recordBatchPathFailure(
-              job.mintUrl,
-              job.unit,
-              error,
-              Date.now()
-            );
+            if (job.kind === "incoming-batch") {
+              this.clearBatchPathCooldown(job.mintUrl, job.unit, job.method);
+            }
+          } catch (error) {
+            this.markJobAttempt(job, now);
+            if (job.kind === "incoming-batch") {
+              if (this.isNetworkOrRateLimitFailure(error)) {
+                this.recordMintFailure(mintUrl, error, Date.now());
+              } else {
+                this.clearMintCooldown(mintUrl);
+                this.recordBatchPathFailure(
+                  job.mintUrl,
+                  job.unit,
+                  job.method,
+                  error,
+                  Date.now()
+                );
+              }
+            } else if (this.isNetworkOrRateLimitFailure(error)) {
+              this.recordMintFailure(mintUrl, error, Date.now());
+            } else {
+              this.clearMintCooldown(mintUrl);
+            }
           }
-        } else if (this.isNetworkOrRateLimitFailure(error)) {
-          this.recordMintFailure(mintUrl, error, Date.now());
-        } else {
-          this.clearMintCooldown(mintUrl);
-        }
+
+          if (this.incomingMintLaneDrainRequested[mintUrl]) {
+            delete this.incomingMintLaneDrainRequested[mintUrl];
+            shouldDrain = true;
+            laneScope = "incoming";
+            prioritizeLaneBatch = true;
+          }
+          if (!shouldDrain || this.reusableMintCooldowns[mintUrl]) return;
+        } while (true);
       } finally {
         delete this.mintLaneInFlight[mintUrl];
       }
+    },
+
+    incomingQueueGroups() {
+      return [
+        { method: PaymentMethod.Bolt11, queue: this.quotes },
+        { method: PaymentMethod.Bolt12, queue: this.bolt12Quotes },
+        { method: PaymentMethod.Onchain, queue: this.onchainQuotes },
+      ] as Array<{
+        method: IncomingPaymentMethod;
+        queue: InvoiceQuote[];
+      }>;
     },
 
     nextMintJob(
@@ -574,88 +680,72 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       walletStore: any,
       now: number,
       scope: WorkScope,
-      prioritizeBolt11Batch: boolean
+      prioritizeBatch: boolean
     ): MintJob | undefined {
       const candidates: Array<{
-        oldest: number;
+        order: number;
         batchPriority: number;
         job: MintJob;
       }> = [];
       const invoices = walletStore.invoiceHistory;
 
       if (scope !== "outgoing") {
-        const bolt11Entries = this.quotes
-          .map((queueEntry) => ({
-            queueEntry,
-            invoice: invoices.find(
-              (invoice: any) => invoice.quote === queueEntry.quote
-            ),
-          }))
-          .filter(
-            (entry) =>
-              entry.invoice?.mint === mintUrl &&
-              this.isDue(entry.queueEntry, now)
-          ) as DueBolt11Quote[];
-
         const mint = useMintsStore().mints.find(
           (storedMint) => storedMint.url === mintUrl
         );
-        const mintCanBatch = this.mintSupportsBolt11Batch(mint);
-        const groups = new Map<string, DueBolt11Quote[]>();
-        for (const entry of bolt11Entries) {
-          const group = groups.get(entry.invoice.unit) ?? [];
-          group.push(entry);
-          groups.set(entry.invoice.unit, group);
-        }
-        for (const [unit, entries] of groups) {
-          const canBatch =
-            mintCanBatch && !this.batchPathInCooldown(mintUrl, unit, now);
-          entries.sort(
-            (left, right) =>
-              queueAge(left.queueEntry) - queueAge(right.queueEntry)
-          );
-          const job: MintJob = canBatch
-            ? {
-                kind: "bolt11-batch",
-                mintUrl,
-                unit,
-                entries: entries.slice(
-                  0,
-                  this.bolt11BatchSizeLimit(mint) ?? entries.length
-                ),
-              }
-            : { kind: "bolt11-single", mintUrl, entry: entries[0] };
-          candidates.push({
-            oldest: queueAge(entries[0].queueEntry),
-            batchPriority:
-              prioritizeBolt11Batch && job.kind === "bolt11-batch" ? 0 : 1,
-            job,
-          });
-        }
 
-        for (const entry of this.bolt12Quotes) {
-          if (!this.isDue(entry, now)) continue;
-          const invoice = invoices.find(
-            (item: any) => item.quote === entry.quote
-          );
-          if (invoice?.mint !== mintUrl) continue;
-          candidates.push({
-            oldest: queueAge(entry),
-            batchPriority: 1,
-            job: { kind: "bolt12", mintUrl, entry, invoice },
-          });
-        }
-        for (const entry of this.onchainQuotes) {
-          if (!this.isDue(entry, now)) continue;
-          const invoice = invoices.find(
-            (item: any) => item.quote === entry.quote
-          );
-          if (invoice?.mint !== mintUrl) continue;
-          candidates.push({
-            oldest: queueAge(entry),
-            batchPriority: 1,
-            job: { kind: "onchain", mintUrl, entry, invoice },
-          });
+        for (const { method, queue } of this.incomingQueueGroups()) {
+          const dueEntries = queue
+            .map((queueEntry) => ({
+              queueEntry,
+              invoice: invoices.find(
+                (invoice: any) => invoice.quote === queueEntry.quote
+              ),
+            }))
+            .filter(
+              (entry) =>
+                entry.invoice?.mint === mintUrl &&
+                this.isDue(entry.queueEntry, now)
+            ) as DueMintQuote[];
+
+          const groups = new Map<string, DueMintQuote[]>();
+          for (const entry of dueEntries) {
+            const group = groups.get(entry.invoice.unit) ?? [];
+            group.push(entry);
+            groups.set(entry.invoice.unit, group);
+          }
+
+          for (const [unit, entries] of groups) {
+            entries.sort((left, right) =>
+              compareQueueEntries(left.queueEntry, right.queueEntry)
+            );
+            const canBatch =
+              this.mintSupportsBatch(mint, method) &&
+              !this.batchPathInCooldown(mintUrl, unit, method, now);
+            const job: MintJob = canBatch
+              ? {
+                  kind: "incoming-batch",
+                  mintUrl,
+                  unit,
+                  method,
+                  entries: entries.slice(
+                    0,
+                    this.batchSizeLimit(mint) ?? entries.length
+                  ),
+                }
+              : {
+                  kind: "incoming-single",
+                  mintUrl,
+                  method,
+                  entry: entries[0],
+                };
+            candidates.push({
+              order: queueOrder(entries[0].queueEntry),
+              batchPriority:
+                prioritizeBatch && job.kind === "incoming-batch" ? 0 : 1,
+              job,
+            });
+          }
         }
       }
 
@@ -669,7 +759,7 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
             );
             if (invoice?.mint !== mintUrl) continue;
             candidates.push({
-              oldest: queueAge(entry),
+              order: queueAge(entry),
               batchPriority: 1,
               job: { kind: "outgoing-invoice", mintUrl, entry, invoice },
             });
@@ -677,7 +767,7 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
             const historyToken = tokens.find((item) => item.token === entry.id);
             if (historyToken?.mint !== mintUrl) continue;
             candidates.push({
-              oldest: queueAge(entry),
+              order: queueAge(entry),
               batchPriority: 1,
               job: { kind: "outgoing-token", mintUrl, entry, historyToken },
             });
@@ -687,26 +777,26 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
 
       candidates.sort(
         (left, right) =>
-          left.batchPriority - right.batchPriority || left.oldest - right.oldest
+          left.batchPriority - right.batchPriority || left.order - right.order
       );
       return candidates[0]?.job;
     },
 
     async runMintJob(job: MintJob, walletStore: any, now: number) {
       switch (job.kind) {
-        case "bolt11-batch":
-          await this.runBolt11Batch(job, walletStore, now);
+        case "incoming-batch":
+          await this.runMintBatch(job, walletStore, now);
           return;
-        case "bolt11-single":
-          await walletStore.checkInvoiceBolt11(
-            job.entry.queueEntry.quote,
-            false
-          );
-          this.removeInvoiceFromChecker(job.entry.queueEntry.quote);
-          return;
-        case "bolt12":
-        case "onchain":
-          await this.runReusableMintJob(job, walletStore, now);
+        case "incoming-single":
+          if (job.method === PaymentMethod.Bolt11) {
+            await walletStore.checkInvoiceBolt11(
+              job.entry.queueEntry.quote,
+              false
+            );
+            this.removeInvoiceFromChecker(job.entry.queueEntry.quote);
+          } else {
+            await this.runReusableMintJob(job, walletStore, now);
+          }
           return;
         case "outgoing-invoice":
           await walletStore.checkOutgoingInvoice(job.entry.id, false);
@@ -727,54 +817,93 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
     },
 
     async runReusableMintJob(
-      job: Extract<MintJob, { kind: "bolt12" | "onchain" }>,
+      job: Extract<MintJob, { kind: "incoming-single" }>,
       walletStore: any,
       now: number
     ) {
       // Probe outside the wallet mutex so an offline reusable mint cannot hold
       // up minting work for another mint.
       const mintWallet = await walletStore.mintWallet(
-        job.invoice.mint,
-        job.invoice.unit
+        job.entry.invoice.mint,
+        job.entry.invoice.unit
       );
       const quote =
-        job.kind === "bolt12"
-          ? await mintWallet.checkMintQuoteBolt12(job.entry.quote)
-          : await mintWallet.checkMintQuoteOnchain(job.entry.quote);
+        job.method === PaymentMethod.Bolt12
+          ? await mintWallet.checkMintQuoteBolt12(job.entry.queueEntry.quote)
+          : await mintWallet.checkMintQuoteOnchain(job.entry.queueEntry.quote);
       const delta =
         amountToNumber(quote.amount_paid) - amountToNumber(quote.amount_issued);
 
       if (delta <= 0) {
-        if (job.kind === "onchain") {
-          const normalizedQuote = normalizeMintQuote(
-            quote,
-            PaymentMethod.Onchain
-          );
-          job.invoice.mintQuote = normalizedQuote;
-          await usePaymentHistoryStore().upsertMintQuote(
-            normalizedQuote,
-            PaymentMethod.Onchain
-          );
-          walletStore.syncPaymentHistoryCache?.();
-          if (walletStore.invoiceData?.quote === job.invoice.quote) {
-            walletStore.invoiceData.mintQuote = normalizedQuote;
-          }
-        }
-        this.markEntryAttempt(job.entry, now);
+        await this.persistCheckedMintQuote(
+          job.entry,
+          quote,
+          job.method,
+          walletStore
+        );
+        walletStore.syncPaymentHistoryCache?.();
+        this.markEntryAttempt(job.entry.queueEntry, now);
         return;
       }
 
-      if (job.kind === "bolt12") {
-        await walletStore.checkOfferAndMintBolt12(job.entry.quote, false);
+      if (job.method === PaymentMethod.Bolt12) {
+        await walletStore.checkOfferAndMintBolt12(
+          job.entry.queueEntry.quote,
+          false
+        );
       } else {
-        await walletStore.checkOnchainAndMint(job.entry.quote, false);
+        await walletStore.checkOnchainAndMint(
+          job.entry.queueEntry.quote,
+          false
+        );
       }
-      job.entry.lastChecked = now;
-      job.entry.checkCount = 0;
+      job.entry.queueEntry.lastChecked = now;
+      job.entry.queueEntry.checkCount = 0;
     },
 
-    async runBolt11Batch(
-      job: Extract<MintJob, { kind: "bolt11-batch" }>,
+    async checkMintQuoteBatch(
+      mintWallet: any,
+      method: IncomingPaymentMethod,
+      quoteIds: string[]
+    ) {
+      if (method === PaymentMethod.Bolt11) {
+        return await mintWallet.checkMintQuoteBatchBolt11(quoteIds);
+      }
+      if (method === PaymentMethod.Bolt12) {
+        return await mintWallet.checkMintQuoteBatchBolt12(quoteIds);
+      }
+      return await mintWallet.checkMintQuoteBatch(method, quoteIds);
+    },
+
+    mintableAmount(method: IncomingPaymentMethod, quote: Record<string, any>) {
+      if (method === PaymentMethod.Bolt11) {
+        return quote.state === MintQuoteState.PAID
+          ? amountToNumber(quote.amount)
+          : 0;
+      }
+      return Math.max(
+        0,
+        amountToNumber(quote.amount_paid) - amountToNumber(quote.amount_issued)
+      );
+    },
+
+    async persistCheckedMintQuote(
+      entry: DueMintQuote,
+      quote: Record<string, any>,
+      method: IncomingPaymentMethod,
+      walletStore: any
+    ) {
+      const normalizedQuote = normalizeMintQuote(quote, method);
+      entry.invoice.mintQuote = normalizedQuote;
+      await usePaymentHistoryStore().upsertMintQuote(normalizedQuote, method);
+      if (walletStore.invoiceData?.quote === entry.invoice.quote) {
+        walletStore.invoiceData.mintQuote = normalizedQuote;
+      }
+      return normalizedQuote;
+    },
+
+    async runMintBatch(
+      job: Extract<MintJob, { kind: "incoming-batch" }>,
       walletStore: any,
       now: number
     ) {
@@ -782,34 +911,39 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       const requestedQuotes = job.entries.map(
         (entry) => entry.queueEntry.quote
       );
-      const responses = await mintWallet.checkMintQuoteBatchBolt11(
+      const responses = await this.checkMintQuoteBatch(
+        mintWallet,
+        job.method,
         requestedQuotes
       );
       this.validateBatchQuoteResponses(requestedQuotes, responses);
 
-      const paymentHistoryStore = usePaymentHistoryStore();
-      const paidEntries: PaidBolt11Quote[] = [];
+      const paidEntries: MintableQuote[] = [];
       for (let index = 0; index < job.entries.length; index++) {
         const entry = job.entries[index];
-        const response = normalizeMintQuote(
+        const response = await this.persistCheckedMintQuote(
+          entry,
           responses[index],
-          PaymentMethod.Bolt11
-        );
-        entry.invoice.mintQuote = response;
-        await paymentHistoryStore.upsertMintQuote(
-          response,
-          PaymentMethod.Bolt11
+          job.method,
+          walletStore
         );
 
-        if (response.state === MintQuoteState.UNPAID) {
-          this.markEntryAttempt(entry.queueEntry, now);
-        } else if (response.state === MintQuoteState.ISSUED) {
+        if (
+          job.method === PaymentMethod.Bolt11 &&
+          response.state === MintQuoteState.ISSUED
+        ) {
           await walletStore.setInvoicePaid(entry.queueEntry.quote, {
             mintQuote: response,
           });
           this.removeInvoiceFromChecker(entry.queueEntry.quote);
-        } else if (response.state === MintQuoteState.PAID) {
-          paidEntries.push({ ...entry, mintQuote: response });
+          continue;
+        }
+
+        const mintAmount = this.mintableAmount(job.method, response);
+        if (mintAmount > 0) {
+          paidEntries.push({ ...entry, mintQuote: response, mintAmount });
+        } else {
+          this.markEntryAttempt(entry.queueEntry, now);
         }
       }
       walletStore.syncPaymentHistoryCache?.();
@@ -822,7 +956,8 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       }
       if (mintable.length === 0) return;
 
-      await this.mintPaidBolt11Batch(
+      await this.mintPaidQuoteBatch(
+        job.method,
         mintable,
         signingKeys,
         mintWallet,
@@ -831,8 +966,9 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       );
     },
 
-    async mintPaidBolt11Batch(
-      paidEntries: PaidBolt11Quote[],
+    async mintPaidQuoteBatch(
+      method: IncomingPaymentMethod,
+      paidEntries: MintableQuote[],
       signingKeys: string[],
       mintWallet: any,
       walletStore: any,
@@ -846,13 +982,9 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       const keysetId = walletStore.getKeyset(mintUrl, unit);
       const uiStore = useUiStore();
       let proofs: any[] = [];
-      const entriesToMint: PaidBolt11Quote[] = [];
-      const issuedEntries: PaidBolt11Quote[] = [];
-      const unpaidEntries: PaidBolt11Quote[] = [];
-      const latestQuotes: Array<{
-        entry: PaidBolt11Quote;
-        quote: Record<string, any>;
-      }> = [];
+      const entriesToMint: MintableQuote[] = [];
+      const issuedEntries: MintableQuote[] = [];
+      const notMintableEntries: MintableQuote[] = [];
 
       const quoteIds = paidEntries.map((entry) => entry.queueEntry.quote);
       await uiStore.lockMutex();
@@ -865,25 +997,31 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       try {
         // The claim makes WebSocket callbacks stand down while this status
         // recheck and mint request run without holding the global wallet mutex.
-        const latestResponses = await mintWallet.checkMintQuoteBatchBolt11(
+        const latestResponses = await this.checkMintQuoteBatch(
+          mintWallet,
+          method,
           quoteIds
         );
         this.validateBatchQuoteResponses(quoteIds, latestResponses);
         for (let index = 0; index < paidEntries.length; index++) {
           const entry = paidEntries[index];
-          const quote = normalizeMintQuote(
+          const quote = await this.persistCheckedMintQuote(
+            entry,
             latestResponses[index],
-            PaymentMethod.Bolt11
+            method,
+            walletStore
           );
-          latestQuotes.push({ entry, quote });
-          entry.invoice.mintQuote = quote;
           entry.mintQuote = quote;
-          if (quote.state === MintQuoteState.PAID) {
-            entriesToMint.push(entry);
-          } else if (quote.state === MintQuoteState.ISSUED) {
+          entry.mintAmount = this.mintableAmount(method, quote);
+          if (
+            method === PaymentMethod.Bolt11 &&
+            quote.state === MintQuoteState.ISSUED
+          ) {
             issuedEntries.push(entry);
+          } else if (entry.mintAmount > 0) {
+            entriesToMint.push(entry);
           } else {
-            unpaidEntries.push(entry);
+            notMintableEntries.push(entry);
           }
         }
 
@@ -895,9 +1033,9 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
               await uiStore.lockMutex();
               try {
                 preview = await mintWallet.prepareBatchMint(
-                  PaymentMethod.Bolt11,
+                  method,
                   entriesToMint.map((entry) => ({
-                    amount: entry.mintQuote.amount,
+                    amount: entry.mintAmount,
                     quote: entry.mintQuote,
                   })),
                   {
@@ -915,13 +1053,6 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
           );
         }
 
-        const paymentHistoryStore = usePaymentHistoryStore();
-        for (const { quote } of latestQuotes) {
-          await paymentHistoryStore.upsertMintQuote(
-            quote,
-            PaymentMethod.Bolt11
-          );
-        }
         walletStore.syncPaymentHistoryCache?.();
 
         for (const entry of issuedEntries) {
@@ -930,21 +1061,105 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
           });
           this.removeInvoiceFromChecker(entry.queueEntry.quote);
         }
-        for (const entry of unpaidEntries) {
+        for (const entry of notMintableEntries) {
           this.markEntryAttempt(entry.queueEntry, now);
         }
         if (proofs.length > 0) {
           await useProofsStore().addProofs(proofs);
         }
-        for (const entry of entriesToMint) {
-          await walletStore.setInvoicePaid(entry.queueEntry.quote, {
-            mintQuote: entry.mintQuote,
-          });
-          this.removeInvoiceFromChecker(entry.queueEntry.quote);
+        if (method === PaymentMethod.Bolt11) {
+          for (const entry of entriesToMint) {
+            await walletStore.setInvoicePaid(entry.queueEntry.quote, {
+              mintQuote: entry.mintQuote,
+            });
+            this.removeInvoiceFromChecker(entry.queueEntry.quote);
+          }
+        } else if (entriesToMint.length > 0) {
+          await this.finalizeReusableBatchMint(
+            method,
+            entriesToMint,
+            mintWallet,
+            walletStore,
+            now
+          );
         }
       } finally {
         this.releaseMintQuotes(mintUrl, quoteIds);
       }
+    },
+
+    async finalizeReusableBatchMint(
+      method: PaymentMethod.Bolt12 | PaymentMethod.Onchain,
+      entries: MintableQuote[],
+      mintWallet: any,
+      walletStore: any,
+      now: number
+    ) {
+      const quoteIds = entries.map((entry) => entry.queueEntry.quote);
+      let finalQuotes = entries.map((entry) => ({
+        ...entry.mintQuote,
+        // The batch minted the entire available delta. This fallback prevents
+        // a failed post-mint status refresh from making that delta look
+        // mintable again locally.
+        amount_issued: entry.mintQuote.amount_paid,
+      }));
+
+      try {
+        const responses = await this.checkMintQuoteBatch(
+          mintWallet,
+          method,
+          quoteIds
+        );
+        this.validateBatchQuoteResponses(quoteIds, responses);
+        finalQuotes = responses;
+      } catch {
+        // Proofs are already safely stored. Persist the conservative local
+        // state above and let the regular worker refresh it on its next check.
+      }
+
+      for (let index = 0; index < entries.length; index++) {
+        const entry = entries[index];
+        const quote = await this.persistCheckedMintQuote(
+          entry,
+          finalQuotes[index],
+          method,
+          walletStore
+        );
+        const paidAt = currentDateStr();
+        const subpaymentType =
+          method === PaymentMethod.Bolt12
+            ? PaymentMethod.Bolt12Subpayment
+            : PaymentMethod.OnchainSubpayment;
+        const label =
+          method === PaymentMethod.Bolt12
+            ? "Bolt12 Subpayment"
+            : "On-chain Subpayment";
+
+        if (entry.invoice.status === "paid") {
+          await walletStore.addPaymentHistory({
+            ...entry.invoice,
+            id: createSubpaymentHistoryQuote(),
+            amount: entry.mintAmount,
+            quote: entry.invoice.quote,
+            parentQuote: entry.invoice.quote,
+            date: paidAt,
+            paidDate: paidAt,
+            status: "paid",
+            mintQuote: quote,
+            label,
+            type: subpaymentType,
+          });
+        } else {
+          await walletStore.setInvoicePaid(entry.invoice.quote, {
+            amount: entry.mintAmount,
+            mintQuote: quote,
+          });
+        }
+
+        entry.queueEntry.lastChecked = now;
+        entry.queueEntry.checkCount = 0;
+      }
+      walletStore.syncPaymentHistoryCache?.();
     },
 
     mintQuoteClaimKey(mintUrl: string, quote: string) {
@@ -1025,7 +1240,7 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       });
     },
 
-    partitionLockedPaidQuotes(paidEntries: PaidBolt11Quote[]) {
+    partitionLockedPaidQuotes(paidEntries: MintableQuote[]) {
       const availableKeys = Array.from(
         new Set(
           paidEntries
@@ -1047,8 +1262,8 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
         }
       });
 
-      const mintable: PaidBolt11Quote[] = [];
-      const missingKey: PaidBolt11Quote[] = [];
+      const mintable: MintableQuote[] = [];
+      const missingKey: MintableQuote[] = [];
       const signingKeys = new Set<string>();
       for (const entry of paidEntries) {
         const quotePubkey = entry.mintQuote.pubkey;
@@ -1079,16 +1294,16 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
     },
 
     markJobAttempt(job: MintJob, now: number) {
-      if (job.kind === "bolt11-batch") {
+      if (job.kind === "incoming-batch") {
         for (const { queueEntry } of job.entries) {
-          if (this.quotes.includes(queueEntry)) {
+          if (this.mintQuoteQueue(job.method).includes(queueEntry)) {
             this.markEntryAttempt(queueEntry, now);
           }
         }
         return;
       }
-      if (job.kind === "bolt11-single") {
-        if (this.quotes.includes(job.entry.queueEntry)) {
+      if (job.kind === "incoming-single") {
+        if (this.mintQuoteQueue(job.method).includes(job.entry.queueEntry)) {
           this.markEntryAttempt(job.entry.queueEntry, now);
         }
         return;
@@ -1102,18 +1317,31 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       }
     },
 
-    batchPathKey(mintUrl: string, unit: string) {
-      return `${mintUrl}|${unit}|${PaymentMethod.Bolt11}`;
+    batchPathKey(
+      mintUrl: string,
+      unit: string,
+      method: IncomingPaymentMethod = PaymentMethod.Bolt11
+    ) {
+      return `${mintUrl}|${unit}|${method}`;
     },
 
-    batchPathInCooldown(mintUrl: string, unit: string, now: number) {
+    batchPathInCooldown(
+      mintUrl: string,
+      unit: string,
+      method: IncomingPaymentMethod,
+      now: number
+    ) {
       const cooldown =
-        this.batchPathCooldowns[this.batchPathKey(mintUrl, unit)];
+        this.batchPathCooldowns[this.batchPathKey(mintUrl, unit, method)];
       return Boolean(cooldown && now < cooldown.nextRetryAt);
     },
 
-    clearBatchPathCooldown(mintUrl: string, unit: string) {
-      const key = this.batchPathKey(mintUrl, unit);
+    clearBatchPathCooldown(
+      mintUrl: string,
+      unit: string,
+      method: IncomingPaymentMethod = PaymentMethod.Bolt11
+    ) {
+      const key = this.batchPathKey(mintUrl, unit, method);
       if (this.batchPathCooldowns[key]) {
         delete this.batchPathCooldowns[key];
       }
@@ -1122,10 +1350,11 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
     recordBatchPathFailure(
       mintUrl: string,
       unit: string,
+      method: IncomingPaymentMethod,
       error: any,
       now: number
     ) {
-      const key = this.batchPathKey(mintUrl, unit);
+      const key = this.batchPathKey(mintUrl, unit, method);
       const previous = this.batchPathCooldowns[key];
       const failureCount = (previous?.failureCount ?? 0) + 1;
       const retryDelay = Math.min(
@@ -1203,20 +1432,58 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
 
       const activeWalletStore = walletStore ?? useWalletStore();
       this.queuePendingIncomingPayments(activeWalletStore);
-      this.queuePendingOutgoingPayments(activeWalletStore);
+      // Every mint gets an immediate incoming lane, and that lane keeps using
+      // native worker batches until all currently due quotes have been checked.
+      await this.dispatchMintLanes(activeWalletStore, "incoming", true, true);
 
-      // Every mint gets an immediate startup lane. A slow lane cannot prevent
-      // the other mint lanes from starting.
-      await this.dispatchMintLanes(
-        activeWalletStore,
-        useSettingsStore().checkSentTokens ? "all" : "incoming",
-        true
+      this.queuePendingOutgoingPayments(activeWalletStore);
+      if (useSettingsStore().checkSentTokens) {
+        await this.dispatchMintLanes(
+          activeWalletStore,
+          "outgoing",
+          false,
+          false
+        );
+      }
+    },
+
+    invoicePaymentMethod(invoice: any): IncomingPaymentMethod {
+      if (invoice.type === PaymentMethod.Bolt12) return PaymentMethod.Bolt12;
+      if (invoice.type === PaymentMethod.Onchain) return PaymentMethod.Onchain;
+      return PaymentMethod.Bolt11;
+    },
+
+    queueIncomingMintQuote(invoice: any, forceStart = false) {
+      const method = this.invoicePaymentMethod(invoice);
+      const mint = useMintsStore().mints.find(
+        (item) => item.url === invoice.mint
       );
+      const supportsBatch = this.mintSupportsBatch(mint, method);
+      if (supportsBatch) {
+        this.clearMintCooldown(invoice.mint);
+        this.addBatchMintQuoteToChecker(method, invoice.quote, forceStart);
+      } else {
+        this.addSingleMintQuoteToChecker(method, invoice.quote, forceStart);
+      }
+      return { method, supportsBatch };
+    },
+
+    startMintQuoteWebsocket(
+      walletStore: any,
+      method: IncomingPaymentMethod,
+      quote: string
+    ) {
+      if (method === PaymentMethod.Bolt12) {
+        return walletStore.mintOnPaidBolt12(quote, false, false);
+      }
+      if (method === PaymentMethod.Onchain) {
+        return walletStore.mintOnPaidOnchain(quote, false, false);
+      }
+      return walletStore.mintOnPaidBolt11(quote, false, false);
     },
 
     queuePendingIncomingPayments(walletStore: any) {
       const settingsStore = useSettingsStore();
-      const mintStore = useMintsStore();
       const periodicChecks = settingsStore.periodicallyCheckIncomingInvoices;
       const pending = walletStore.invoiceHistory.filter((invoice: any) =>
         this.shouldCheckInvoice(invoice)
@@ -1224,48 +1491,33 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       let singleBolt11QuotesQueued = 0;
       for (const invoice of pending) {
         try {
-          if (invoice.type === PaymentMethod.Bolt12) {
-            this.addBolt12OfferToChecker(invoice.quote);
-            void walletStore
-              .mintOnPaidBolt12(invoice.quote, false, false)
-              .catch(() => {});
-            continue;
-          }
-          if (invoice.type === PaymentMethod.Onchain) {
-            this.addOnchainQuoteToChecker(invoice.quote);
-            void walletStore
-              .mintOnPaidOnchain(invoice.quote, false, false)
-              .catch(() => {});
-            continue;
-          }
-
-          const mint = mintStore.mints.find(
+          const method = this.invoicePaymentMethod(invoice);
+          const mint = useMintsStore().mints.find(
             (item) => item.url === invoice.mint
           );
-          if (this.mintSupportsBolt11Batch(mint)) {
-            this.clearMintCooldown(invoice.mint);
-            this.addBatchInvoiceToChecker(invoice.quote);
-            if (!periodicChecks) {
-              void walletStore
-                .mintOnPaidBolt11(invoice.quote, false, false)
-                .catch(() => {});
-            }
-            continue;
-          }
+          const supportsBatch = this.mintSupportsBatch(mint, method);
+
           if (
+            method === PaymentMethod.Bolt11 &&
+            !supportsBatch &&
             singleBolt11QuotesQueued >=
-            this.maxSingleBolt11QuotesToCheckOnStartup
+              this.maxSingleBolt11QuotesToCheckOnStartup
           ) {
             continue;
           }
-
-          singleBolt11QuotesQueued += 1;
-          if (periodicChecks) {
-            this.addInvoiceToChecker(invoice.quote);
+          if (method === PaymentMethod.Bolt11 && !supportsBatch) {
+            singleBolt11QuotesQueued += 1;
           }
-          void walletStore
-            .mintOnPaidBolt11(invoice.quote, false, false)
-            .catch(() => {});
+
+          this.queueIncomingMintQuote(invoice);
+
+          if (!supportsBatch || !periodicChecks) {
+            void this.startMintQuoteWebsocket(
+              walletStore,
+              method,
+              invoice.quote
+            ).catch(() => {});
+          }
         } catch {
           // Startup reconciliation is best-effort and remains silent.
         }

--- a/src/stores/transactionWorker.ts
+++ b/src/stores/transactionWorker.ts
@@ -130,7 +130,6 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
     // Lane state is ephemeral so a restart immediately retries pending work.
     mintLaneInFlight: {} as Record<string, boolean>,
     mintLastRequestAt: {} as Record<string, number>,
-    incomingMintLaneDrainRequested: {} as Record<string, boolean>,
     mintQuoteClaims: {} as Record<string, boolean>,
 
     // These keys intentionally retain their old names so existing queues
@@ -514,12 +513,11 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       return Array.from(mintUrls);
     },
 
-    mintLaneReady(mintUrl: string, now: number, bypassInterval = false) {
+    mintLaneReady(mintUrl: string, now: number) {
       if (this.mintLaneInFlight[mintUrl]) return false;
       const cooldownUntil =
         this.reusableMintCooldowns[mintUrl]?.nextRetryAt ?? 0;
       if (now < cooldownUntil) return false;
-      if (bypassInterval) return true;
       const lastRequestAt = this.mintLastRequestAt[mintUrl] ?? 0;
       return now >= lastRequestAt + this.checkInterval;
     },
@@ -538,8 +536,7 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       return await this.dispatchMintLanes(
         activeWalletStore,
         scope,
-        prioritizeBatch,
-        false
+        prioritizeBatch
       );
     },
 
@@ -547,47 +544,29 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       return await this.dispatchMintLanes(
         walletStore ?? useWalletStore(),
         "incoming",
-        true,
         true
       );
     },
 
     // Retained as callable helpers for diagnostics and tests.
     async processIncomingQueues(_now: number, walletStore: any) {
-      return await this.dispatchMintLanes(
-        walletStore,
-        "incoming",
-        false,
-        false
-      );
+      return await this.dispatchMintLanes(walletStore, "incoming", false);
     },
 
     async processOutgoingQueue(_now: number, walletStore: any) {
       if (!useSettingsStore().checkSentTokens) return;
-      return await this.dispatchMintLanes(
-        walletStore,
-        "outgoing",
-        false,
-        false
-      );
+      return await this.dispatchMintLanes(walletStore, "outgoing", false);
     },
 
     async dispatchMintLanes(
       walletStore: any,
       scope: WorkScope,
-      prioritizeBatch: boolean,
-      drain: boolean
+      prioritizeBatch: boolean
     ) {
       const now = Date.now();
       this.pruneQueues(now, walletStore);
       const lanes = this.mintUrlsWithWork(walletStore, scope).map((mintUrl) =>
-        this.processMintLane(
-          mintUrl,
-          walletStore,
-          scope,
-          prioritizeBatch,
-          drain
-        )
+        this.processMintLane(mintUrl, walletStore, scope, prioritizeBatch)
       );
       await Promise.allSettled(lanes);
     },
@@ -596,69 +575,49 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       mintUrl: string,
       walletStore: any,
       scope: WorkScope,
-      prioritizeBatch: boolean,
-      drain: boolean
+      prioritizeBatch: boolean
     ) {
-      if (this.mintLaneInFlight[mintUrl]) {
-        if (drain && scope !== "outgoing") {
-          this.incomingMintLaneDrainRequested[mintUrl] = true;
-        }
-        return;
-      }
-      if (!this.mintLaneReady(mintUrl, Date.now(), drain)) return;
+      if (!this.mintLaneReady(mintUrl, Date.now())) return;
       this.mintLaneInFlight[mintUrl] = true;
-      let shouldDrain = drain;
-      let laneScope = scope;
-      let prioritizeLaneBatch = prioritizeBatch;
       try {
-        do {
-          const now = Date.now();
-          const job = this.nextMintJob(
-            mintUrl,
-            walletStore,
-            now,
-            laneScope,
-            prioritizeLaneBatch
-          );
-          if (!job) return;
+        const now = Date.now();
+        const job = this.nextMintJob(
+          mintUrl,
+          walletStore,
+          now,
+          scope,
+          prioritizeBatch
+        );
+        if (!job) return;
 
-          this.mintLastRequestAt[mintUrl] = now;
-          try {
-            await this.runMintJob(job, walletStore, now);
-            this.clearMintCooldown(mintUrl);
-            if (job.kind === "incoming-batch") {
-              this.clearBatchPathCooldown(job.mintUrl, job.unit, job.method);
-            }
-          } catch (error) {
-            this.markJobAttempt(job, now);
-            if (job.kind === "incoming-batch") {
-              if (this.isNetworkOrRateLimitFailure(error)) {
-                this.recordMintFailure(mintUrl, error, Date.now());
-              } else {
-                this.clearMintCooldown(mintUrl);
-                this.recordBatchPathFailure(
-                  job.mintUrl,
-                  job.unit,
-                  job.method,
-                  error,
-                  Date.now()
-                );
-              }
-            } else if (this.isNetworkOrRateLimitFailure(error)) {
+        this.mintLastRequestAt[mintUrl] = now;
+        try {
+          await this.runMintJob(job, walletStore, now);
+          this.clearMintCooldown(mintUrl);
+          if (job.kind === "incoming-batch") {
+            this.clearBatchPathCooldown(job.mintUrl, job.unit, job.method);
+          }
+        } catch (error) {
+          this.markJobAttempt(job, now);
+          if (job.kind === "incoming-batch") {
+            if (this.isNetworkOrRateLimitFailure(error)) {
               this.recordMintFailure(mintUrl, error, Date.now());
             } else {
               this.clearMintCooldown(mintUrl);
+              this.recordBatchPathFailure(
+                job.mintUrl,
+                job.unit,
+                job.method,
+                error,
+                Date.now()
+              );
             }
+          } else if (this.isNetworkOrRateLimitFailure(error)) {
+            this.recordMintFailure(mintUrl, error, Date.now());
+          } else {
+            this.clearMintCooldown(mintUrl);
           }
-
-          if (this.incomingMintLaneDrainRequested[mintUrl]) {
-            delete this.incomingMintLaneDrainRequested[mintUrl];
-            shouldDrain = true;
-            laneScope = "incoming";
-            prioritizeLaneBatch = true;
-          }
-          if (!shouldDrain || this.reusableMintCooldowns[mintUrl]) return;
-        } while (true);
+        }
       } finally {
         delete this.mintLaneInFlight[mintUrl];
       }
@@ -1432,18 +1391,13 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
 
       const activeWalletStore = walletStore ?? useWalletStore();
       this.queuePendingIncomingPayments(activeWalletStore);
-      // Every mint gets an immediate incoming lane, and that lane keeps using
-      // native worker batches until all currently due quotes have been checked.
-      await this.dispatchMintLanes(activeWalletStore, "incoming", true, true);
+      // Give every mint one immediate startup job. Remaining work stays queued
+      // and is paced by the regular per-mint worker interval.
+      await this.dispatchMintLanes(activeWalletStore, "incoming", true);
 
       this.queuePendingOutgoingPayments(activeWalletStore);
       if (useSettingsStore().checkSentTokens) {
-        await this.dispatchMintLanes(
-          activeWalletStore,
-          "outgoing",
-          false,
-          false
-        );
+        await this.dispatchMintLanes(activeWalletStore, "outgoing", false);
       }
     },
 

--- a/src/stores/transactionWorker.ts
+++ b/src/stores/transactionWorker.ts
@@ -122,6 +122,7 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
     keepIntervalConstantForNChecks: 5,
     maxLength: 50,
     maxAge: 14 * 24 * 60 * 60 * 1_000,
+    maxBatchQuoteAge: 7 * 24 * 60 * 60 * 1_000,
     oneHour: 60 * 60 * 1_000,
 
     transactionCheckListener: null as NodeJS.Timeout | null,
@@ -417,6 +418,13 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       return invoice.status === "pending" && invoice.amount > 0;
     },
 
+    isMintQuoteBatchEligible(invoice: any, now = Date.now()) {
+      const createdAt = Date.parse(invoice?.date);
+      return (
+        Number.isFinite(createdAt) && now - createdAt < this.maxBatchQuoteAge
+      );
+    },
+
     shouldCheckOutgoingInvoice(invoice: any) {
       if (!invoice) return false;
       return (
@@ -678,32 +686,50 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
             entries.sort((left, right) =>
               compareQueueEntries(left.queueEntry, right.queueEntry)
             );
-            const canBatch =
+            const batchPathAvailable =
               this.mintSupportsBatch(mint, method) &&
               !this.batchPathInCooldown(mintUrl, unit, method, now);
-            const job: MintJob = canBatch
-              ? {
-                  kind: "incoming-batch",
-                  mintUrl,
-                  unit,
-                  method,
-                  entries: entries.slice(
-                    0,
-                    this.batchSizeLimit(mint) ?? entries.length
-                  ),
-                }
-              : {
+            const batchEntries = batchPathAvailable
+              ? entries.filter((entry) =>
+                  this.isMintQuoteBatchEligible(entry.invoice, now)
+                )
+              : [];
+            const singleEntries = batchPathAvailable
+              ? entries.filter(
+                  (entry) => !this.isMintQuoteBatchEligible(entry.invoice, now)
+                )
+              : entries;
+
+            if (batchEntries.length > 0) {
+              const job: MintJob = {
+                kind: "incoming-batch",
+                mintUrl,
+                unit,
+                method,
+                entries: batchEntries.slice(
+                  0,
+                  this.batchSizeLimit(mint) ?? batchEntries.length
+                ),
+              };
+              candidates.push({
+                order: queueOrder(batchEntries[0].queueEntry),
+                batchPriority: prioritizeBatch ? 0 : 1,
+                job,
+              });
+            }
+
+            if (singleEntries.length > 0) {
+              candidates.push({
+                order: queueOrder(singleEntries[0].queueEntry),
+                batchPriority: 1,
+                job: {
                   kind: "incoming-single",
                   mintUrl,
                   method,
-                  entry: entries[0],
-                };
-            candidates.push({
-              order: queueOrder(entries[0].queueEntry),
-              batchPriority:
-                prioritizeBatch && job.kind === "incoming-batch" ? 0 : 1,
-              job,
-            });
+                  entry: singleEntries[0],
+                },
+              });
+            }
           }
         }
       }
@@ -1413,13 +1439,15 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
         (item) => item.url === invoice.mint
       );
       const supportsBatch = this.mintSupportsBatch(mint, method);
-      if (supportsBatch) {
+      const usesBatchPath =
+        supportsBatch && this.isMintQuoteBatchEligible(invoice);
+      if (usesBatchPath) {
         this.clearMintCooldown(invoice.mint);
         this.addBatchMintQuoteToChecker(method, invoice.quote, forceStart);
       } else {
         this.addSingleMintQuoteToChecker(method, invoice.quote, forceStart);
       }
-      return { method, supportsBatch };
+      return { method, supportsBatch, usesBatchPath };
     },
 
     startMintQuoteWebsocket(
@@ -1450,16 +1478,18 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
             (item) => item.url === invoice.mint
           );
           const supportsBatch = this.mintSupportsBatch(mint, method);
+          const usesBatchPath =
+            supportsBatch && this.isMintQuoteBatchEligible(invoice);
 
           if (
             method === PaymentMethod.Bolt11 &&
-            !supportsBatch &&
+            !usesBatchPath &&
             singleBolt11QuotesQueued >=
               this.maxSingleBolt11QuotesToCheckOnStartup
           ) {
             continue;
           }
-          if (method === PaymentMethod.Bolt11 && !supportsBatch) {
+          if (method === PaymentMethod.Bolt11 && !usesBatchPath) {
             singleBolt11QuotesQueued += 1;
           }
 
@@ -1467,7 +1497,7 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
 
           if (
             method !== PaymentMethod.Bolt11 ||
-            !supportsBatch ||
+            !usesBatchPath ||
             !periodicChecks
           ) {
             void this.startMintQuoteWebsocket(

--- a/src/stores/walletBolt12.ts
+++ b/src/stores/walletBolt12.ts
@@ -13,6 +13,7 @@ import { usePriceStore } from "./price";
 import { type AppMeltQuote, normalizeMeltQuote } from "./walletMelt";
 import { createSubpaymentHistoryQuote } from "src/js/invoice-history";
 import { usePaymentHistoryStore } from "./paymentHistory";
+import { useTransactionWorkerStore } from "src/stores/transactionWorker";
 
 // BOLT12: reusable offers
 
@@ -117,7 +118,20 @@ export async function checkOfferAndMintBolt12(
   const mint = mintStore.mints.find((m: any) => m.url === invoice.mint);
   if (!mint) throw new Error("mint not found");
 
-  await uIStore.lockMutex();
+  const transactionWorkerStore = useTransactionWorkerStore();
+  while (true) {
+    await transactionWorkerStore.waitForMintQuoteRelease(
+      invoice.mint,
+      invoice.quote
+    );
+    await uIStore.lockMutex();
+    if (
+      !transactionWorkerStore.mintQuoteIsClaimed(invoice.mint, invoice.quote)
+    ) {
+      break;
+    }
+    uIStore.unlockMutex();
+  }
   try {
     uIStore.triggerActivityOrb();
     const updated = await mintWallet.checkMintQuoteBolt12(quoteId);

--- a/src/stores/walletOnchain.ts
+++ b/src/stores/walletOnchain.ts
@@ -132,7 +132,20 @@ export async function checkOnchainAndMint(
     }
   }
 
-  await uIStore.lockMutex();
+  const transactionWorkerStore = useTransactionWorkerStore();
+  while (true) {
+    await transactionWorkerStore.waitForMintQuoteRelease(
+      invoice.mint,
+      invoice.quote
+    );
+    await uIStore.lockMutex();
+    if (
+      !transactionWorkerStore.mintQuoteIsClaimed(invoice.mint, invoice.quote)
+    ) {
+      break;
+    }
+    uIStore.unlockMutex();
+  }
   try {
     uIStore.triggerActivityOrb();
     const updated = await mintWallet.checkMintQuoteOnchain(quoteId);


### PR DESCRIPTION
## Summary
- preserve the mint quote state returned by npub.cash and immediately route restored zaps through the transaction worker
- generalize native NUT-29 batch checking and minting by mint, unit, and payment method for Bolt11, Bolt12, and on-chain quotes
- drain outstanding incoming batches at startup, prioritize newly queued payments, and hand immediate work to an already-active mint lane
- coordinate reusable-payment WebSocket minting with batch claims to prevent duplicate mint races

## Validation
- npm test -- --run (142 tests passed)
- ESLint on all changed source and test files
- git diff --check