### PR TITLE
fix: prioritize foreground invoice payments

### DIFF
--- a/src/components/PayInvoiceDialog.vue
+++ b/src/components/PayInvoiceDialog.vue
@@ -545,7 +545,7 @@
                 v-else-if="
                   enoughtotalUnitBalance ||
                   (hasMultinutSupport && multinutEnabled) ||
-                  globalMutexLock ||
+                  waitingForWallet ||
                   paymentInProgress
                 "
               >
@@ -558,22 +558,16 @@
                   data-testid="pay-payment-request"
                   :disabled="
                     payInvoiceData.blocking ||
-                    paymentInProgress ||
-                    globalMutexLock
+                    waitingForWallet ||
+                    paymentInProgress
                   "
                   @click="handleMeltButton"
-                  :label="
-                    !payInvoiceData.blocking && !paymentInProgress
-                      ? $t('PayInvoiceDialog.invoice.actions.pay.label')
-                      : $t('PayInvoiceDialog.invoice.actions.pay.in_progress')
-                  "
-                  :loading="
-                    paymentInProgress ||
-                    (globalMutexLock && !payInvoiceData.blocking)
-                  "
+                  :label="paymentButtonLabel"
+                  :loading="waitingForWallet || paymentInProgress"
                 >
                   <template v-slot:loading>
-                    <q-spinner />
+                    <q-spinner class="q-mr-sm" />
+                    <span>{{ paymentButtonLabel }}</span>
                   </template>
                 </q-btn>
                 <q-btn
@@ -812,6 +806,7 @@ export default defineComponent({
       fiatKeyboardMode: false as boolean,
       isPaying: false as boolean,
       isPaid: false as boolean,
+      waitingForWallet: false as boolean,
       autoCloseTimeout: null as ReturnType<typeof setTimeout> | null,
     };
   },
@@ -845,6 +840,12 @@ export default defineComponent({
     "payInvoiceData.meltQuote.error": function (val) {
       if (val && this.showAmountlessPaymentAmountEntry) {
         this.showNumericKeyboard = false;
+      }
+    },
+    "payInvoiceData.paying": function (val) {
+      if (val) {
+        this.waitingForWallet = false;
+        this.isPaying = true;
       }
     },
     "payInvoiceData.lnurlpay": {
@@ -897,7 +898,7 @@ export default defineComponent({
     },
   },
   computed: {
-    ...mapState(useUiStore, ["tickerShort", "globalMutexLock"]),
+    ...mapState(useUiStore, ["tickerShort"]),
     ...mapState(useSettingsStore, ["multinutEnabled"]),
     ...mapWritableState(useCameraStore, ["camera", "hasCamera"]),
     ...mapWritableState(useUiStore, ["showNumericKeyboard"]),
@@ -1038,6 +1039,19 @@ export default defineComponent({
     },
     paymentInProgress: function (): boolean {
       return Boolean(this.isPaying || this.payInvoiceData?.paying);
+    },
+    paymentButtonLabel: function (): string {
+      if (this.waitingForWallet) {
+        return this.$t(
+          "PayInvoiceDialog.invoice.actions.pay.waiting_for_wallet"
+        ) as string;
+      }
+      if (this.paymentInProgress) {
+        return this.$t(
+          "PayInvoiceDialog.invoice.actions.pay.in_progress"
+        ) as string;
+      }
+      return this.$t("PayInvoiceDialog.invoice.actions.pay.label") as string;
     },
     isBolt12Pay: function (): boolean {
       return this.payPaymentMethod === PaymentMethod.Bolt12;
@@ -1190,7 +1204,11 @@ export default defineComponent({
       }
     },
     handleMeltButton: async function () {
-      if (this.payInvoiceData.blocking) {
+      if (
+        this.payInvoiceData.blocking ||
+        this.waitingForWallet ||
+        this.paymentInProgress
+      ) {
         throw new Error("already processing an invoice.");
       }
       if (
@@ -1201,9 +1219,11 @@ export default defineComponent({
         this.openMultinutDialog();
         return;
       }
-      this.isPaying = true;
+      const uiStore = useUiStore();
+      this.waitingForWallet = true;
+      uiStore.beginForegroundPayment();
       try {
-        const result = await this.meltInvoiceData(true);
+        const result = await this.meltInvoiceData(true, "foreground");
         const returnedChange = useProofsStore().sumProofs(result?.change ?? []);
         this.payInvoiceData.fee_paid =
           this.payInvoiceData.meltQuote.response.fee_reserve - returnedChange;
@@ -1213,6 +1233,9 @@ export default defineComponent({
         // Error handling is done in the store, but we ensure isPaying is reset
         console.error("Payment error:", error);
         this.isPaying = false;
+      } finally {
+        this.waitingForWallet = false;
+        uiStore.endForegroundPayment();
       }
     },
     openMultinutDialog: function () {

--- a/src/components/__tests__/PayInvoiceDialog.test.ts
+++ b/src/components/__tests__/PayInvoiceDialog.test.ts
@@ -1,0 +1,51 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { useUiStore } from "src/stores/ui";
+
+let PayInvoiceDialog: any;
+
+beforeAll(async () => {
+  (globalThis as any).windowMixin = {};
+  PayInvoiceDialog = (await import("../PayInvoiceDialog.vue")).default;
+});
+
+describe("PayInvoiceDialog", () => {
+  it("queues a foreground payment before starting the melt", async () => {
+    const uiStore = useUiStore();
+    let rejectMelt!: (error: Error) => void;
+    const meltInvoiceData = vi.fn(
+      () =>
+        new Promise((_, reject) => {
+          rejectMelt = reject;
+        })
+    );
+    const context = {
+      payInvoiceData: { blocking: false },
+      waitingForWallet: false,
+      paymentInProgress: false,
+      enoughtotalUnitBalance: true,
+      hasMultinutSupport: false,
+      multinutEnabled: false,
+      openMultinutDialog: vi.fn(),
+      meltInvoiceData,
+      isPaying: true,
+    };
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const payment = PayInvoiceDialog.methods.handleMeltButton.call(context);
+
+    expect(meltInvoiceData).toHaveBeenCalledWith(true, "foreground");
+    expect(context.waitingForWallet).toBe(true);
+    expect(uiStore.foregroundPaymentRequests).toBe(1);
+
+    rejectMelt(new Error("payment failed"));
+    await payment;
+
+    expect(context.waitingForWallet).toBe(false);
+    expect(context.isPaying).toBe(false);
+    expect(uiStore.foregroundPaymentRequests).toBe(0);
+
+    consoleError.mockRestore();
+  });
+});

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1415,6 +1415,7 @@ export default {
         pay: {
           label: "دفع",
           in_progress: "@:PayInvoiceDialog.invoice.processing_info_text",
+          waiting_for_wallet: "بانتظار المحفظة…",
           error: "خطأ",
         },
       },

--- a/src/i18n/cs-CZ/index.ts
+++ b/src/i18n/cs-CZ/index.ts
@@ -1525,6 +1525,7 @@ export default {
         pay: {
           label: "Zaplatit",
           in_progress: "@:PayInvoiceDialog.invoice.processing_info_text",
+          waiting_for_wallet: "Čekání na peněženku…",
           error: "Chyba",
         },
       },

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1432,6 +1432,7 @@ export default {
         pay: {
           label: "Bezahlen",
           in_progress: "@:PayInvoiceDialog.invoice.processing_info_text",
+          waiting_for_wallet: "Warte auf Wallet…",
           error: "Fehler",
         },
       },

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1429,6 +1429,7 @@ export default {
         pay: {
           label: "Πληρωμή",
           in_progress: "@:PayInvoiceDialog.invoice.processing_info_text",
+          waiting_for_wallet: "Αναμονή για το πορτοφόλι…",
           error: "Σφάλμα",
         },
       },

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1504,6 +1504,7 @@ export default {
         pay: {
           label: "Pay",
           in_progress: "@:PayInvoiceDialog.invoice.processing_info_text",
+          waiting_for_wallet: "Waiting for wallet…",
           error: "Error",
         },
       },

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1426,6 +1426,7 @@ export default {
         pay: {
           label: "Pagar",
           in_progress: "@:PayInvoiceDialog.invoice.processing_info_text",
+          waiting_for_wallet: "Esperando la billetera…",
           error: "Error",
         },
       },

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1432,6 +1432,7 @@ export default {
         pay: {
           label: "Payer",
           in_progress: "@:PayInvoiceDialog.invoice.processing_info_text",
+          waiting_for_wallet: "En attente du portefeuille…",
           error: "Erreur",
         },
       },

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1396,6 +1396,7 @@ export default {
         pay: {
           label: "Paga",
           in_progress: "@:PayInvoiceDialog.invoice.processing_info_text",
+          waiting_for_wallet: "In attesa del portafoglio…",
           error: "Errore",
         },
       },

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1419,6 +1419,7 @@ export default {
         pay: {
           label: "支払う",
           in_progress: "@:PayInvoiceDialog.invoice.processing_info_text",
+          waiting_for_wallet: "ウォレットを待機中…",
           error: "エラー",
         },
       },

--- a/src/i18n/pt-BR/index.ts
+++ b/src/i18n/pt-BR/index.ts
@@ -1508,6 +1508,7 @@ export default {
         pay: {
           label: "Pagar",
           in_progress: "@:PayInvoiceDialog.invoice.processing_info_text",
+          waiting_for_wallet: "Aguardando a carteira…",
           error: "Erro",
         },
       },

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1422,6 +1422,7 @@ export default {
         pay: {
           label: "Betala",
           in_progress: "@:PayInvoiceDialog.invoice.processing_info_text",
+          waiting_for_wallet: "Väntar på plånboken…",
           error: "Fel",
         },
       },

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1418,6 +1418,7 @@ export default {
         pay: {
           label: "ชำระเงิน",
           in_progress: "@:PayInvoiceDialog.invoice.processing_info_text",
+          waiting_for_wallet: "กำลังรอกระเป๋าเงิน…",
           error: "ข้อผิดพลาด",
         },
       },

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1433,6 +1433,7 @@ export default {
         pay: {
           label: "Öde",
           in_progress: "@:PayInvoiceDialog.invoice.processing_info_text",
+          waiting_for_wallet: "Cüzdan bekleniyor…",
           error: "Hata",
         },
       },

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1412,6 +1412,7 @@ export default {
         pay: {
           label: "支付",
           in_progress: "@:PayInvoiceDialog.invoice.processing_info_text",
+          waiting_for_wallet: "正在等待钱包…",
           error: "错误",
         },
       },

--- a/src/stores/__tests__/ui.test.js
+++ b/src/stores/__tests__/ui.test.js
@@ -13,4 +13,56 @@ describe("ui store", () => {
 
     expect(ui.formatCurrency(1234, "usd")).toContain("12.34");
   });
+
+  it("runs a queued foreground payment before background work", async () => {
+    const ui = useUiStore();
+    const order = [];
+
+    await ui.lockMutex();
+    const background = ui
+      .lockMutex("background")
+      .then(() => order.push("background"));
+
+    ui.beginForegroundPayment();
+    const foreground = ui
+      .lockMutex("foreground")
+      .then(() => order.push("foreground"));
+
+    ui.unlockMutex();
+    await foreground;
+
+    expect(order).toEqual(["foreground"]);
+
+    ui.unlockMutex();
+    ui.endForegroundPayment();
+    await background;
+
+    expect(order).toEqual(["foreground", "background"]);
+    ui.unlockMutex();
+  });
+
+  it("keeps background work out of the gap between foreground mutex sections", async () => {
+    const ui = useUiStore();
+    const order = [];
+
+    ui.beginForegroundPayment();
+    await ui.lockMutex("foreground");
+    const background = ui
+      .lockMutex("background")
+      .then(() => order.push("background"));
+
+    ui.unlockMutex();
+    await Promise.resolve();
+    expect(order).toEqual([]);
+    expect(ui.globalMutexLock).toBe(false);
+
+    await ui.lockMutex("foreground");
+    order.push("foreground");
+    ui.unlockMutex();
+    ui.endForegroundPayment();
+    await background;
+
+    expect(order).toEqual(["foreground", "background"]);
+    ui.unlockMutex();
+  });
 });

--- a/src/stores/__tests__/wallet.test.js
+++ b/src/stores/__tests__/wallet.test.js
@@ -1780,7 +1780,7 @@ describe("wallet store", () => {
     expect(h.uiStore.unlockMutex).toHaveBeenCalledTimes(2);
   });
 
-  it("forwards the silent flag through meltInvoiceData", async () => {
+  it("forwards the silent flag and mutex priority through meltInvoiceData", async () => {
     const wallet = useWalletStore();
     const proofs = [{ id: "00aa", amount: 105, secret: "s1" }];
     const quote = {
@@ -1809,9 +1809,16 @@ describe("wallet store", () => {
       change: [],
     });
 
-    await wallet.meltInvoiceData(true);
+    await wallet.meltInvoiceData(true, "foreground");
 
-    expect(meltBolt11).toHaveBeenCalledWith(proofs, quote, mintWallet, true);
+    expect(meltBolt11).toHaveBeenCalledWith(
+      proofs,
+      quote,
+      mintWallet,
+      true,
+      false,
+      "foreground"
+    );
   });
 
   it("passes selected on-chain fee index through recoverable melt completion", async () => {

--- a/src/stores/transactionWorker.ts
+++ b/src/stores/transactionWorker.ts
@@ -972,7 +972,7 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       const notMintableEntries: MintableQuote[] = [];
 
       const quoteIds = paidEntries.map((entry) => entry.queueEntry.quote);
-      await uiStore.lockMutex();
+      await uiStore.lockMutex("background");
       try {
         if (!this.claimMintQuotes(mintUrl, quoteIds)) return;
       } finally {
@@ -1015,7 +1015,7 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
             keysetId,
             async () => {
               let preview: any;
-              await uiStore.lockMutex();
+              await uiStore.lockMutex("background");
               try {
                 preview = await mintWallet.prepareBatchMint(
                   method,

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -6,13 +6,49 @@ import {
   notifyError,
   notifySuccess,
   notifyWarning,
-  notify,
 } from "../js/notify";
 import { Clipboard } from "@capacitor/clipboard";
 import { Haptics, ImpactStyle } from "@capacitor/haptics";
 
 import ts from "typescript";
 import { useSettingsStore } from "./settings";
+
+export type MutexPriority = "foreground" | "normal" | "background";
+
+type MutexWaiter = {
+  priority: MutexPriority;
+  resolve: () => void;
+};
+
+// This is intentionally module-local: waiting promises are ephemeral and must
+// never be persisted with UI state.
+const mutexWaiters: MutexWaiter[] = [];
+
+const mutexPriorityRank: Record<MutexPriority, number> = {
+  foreground: 2,
+  normal: 1,
+  background: 0,
+};
+
+function nextEligibleMutexWaiterIndex(foregroundPaymentRequests: number) {
+  let nextIndex = -1;
+
+  for (let index = 0; index < mutexWaiters.length; index++) {
+    const waiter = mutexWaiters[index];
+    if (waiter.priority === "background" && foregroundPaymentRequests > 0) {
+      continue;
+    }
+    if (
+      nextIndex === -1 ||
+      mutexPriorityRank[waiter.priority] >
+        mutexPriorityRank[mutexWaiters[nextIndex].priority]
+    ) {
+      nextIndex = index;
+    }
+  }
+
+  return nextIndex;
+}
 
 const unitTickerShortMap = {
   sat: "sats",
@@ -35,6 +71,7 @@ export const useUiStore = defineStore("ui", {
     tab: useLocalStorage("cashu.ui.tab", "history" as string),
     expandHistory: useLocalStorage("cashu.ui.expandHistory", true as boolean),
     globalMutexLock: false,
+    foregroundPaymentRequests: 0,
     showDebugConsole: useLocalStorage("cashu.ui.showDebugConsole", false),
     lastBalanceCached: useLocalStorage("cashu.ui.lastBalanceCached", 0),
     multinutExperimentalWarningDismissed: useLocalStorage(
@@ -50,24 +87,37 @@ export const useUiStore = defineStore("ui", {
       this.showReceiveDialog = false;
       this.showReceiveEcashDrawer = false;
     },
-    async lockMutex() {
-      const nRetries = 10;
-      const retryInterval = 500;
-      let retries = 0;
-
-      while (this.globalMutexLock) {
-        if (retries >= nRetries) {
-          notify("Please try again.");
-          throw new Error("Failed to acquire global mutex lock");
-        }
-        retries++;
-        await new Promise((resolve) => setTimeout(resolve, retryInterval));
-      }
-
-      this.globalMutexLock = true;
+    async lockMutex(priority: MutexPriority = "normal") {
+      await new Promise<void>((resolve) => {
+        mutexWaiters.push({ priority, resolve });
+        this.dispatchMutexWaiters();
+      });
     },
     unlockMutex() {
       this.globalMutexLock = false;
+      this.dispatchMutexWaiters();
+    },
+    dispatchMutexWaiters() {
+      if (this.globalMutexLock) return;
+
+      const nextIndex = nextEligibleMutexWaiterIndex(
+        this.foregroundPaymentRequests
+      );
+      if (nextIndex === -1) return;
+
+      const [next] = mutexWaiters.splice(nextIndex, 1);
+      this.globalMutexLock = true;
+      next.resolve();
+    },
+    beginForegroundPayment() {
+      this.foregroundPaymentRequests += 1;
+    },
+    endForegroundPayment() {
+      this.foregroundPaymentRequests = Math.max(
+        0,
+        this.foregroundPaymentRequests - 1
+      );
+      this.dispatchMutexWaiters();
     },
     triggerActivityOrb() {
       this.activityOrb = true;

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -5,7 +5,7 @@ import { useLocalStorage } from "@vueuse/core";
 import { useProofsStore } from "./proofs";
 import { HistoryToken, useTokensStore } from "./tokens";
 import { useReceiveTokensStore } from "./receiveTokensStore";
-import { useUiStore } from "src/stores/ui";
+import { type MutexPriority, useUiStore } from "src/stores/ui";
 import { useP2PKStore } from "src/stores/p2pk";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import { usePRStore } from "./payment-request";
@@ -629,7 +629,8 @@ export const useWalletStore = defineStore("wallet", {
       wallet: Wallet,
       amount: number,
       invalidate: boolean = false,
-      includeFees: boolean = false
+      includeFees: boolean = false,
+      mutexPriority: MutexPriority = "normal"
     ): Promise<{ keepProofs: ProofLike[]; sendProofs: ProofLike[] }> {
       // Returns sendProofs summing to `amount` (plus input fees when
       // includeFees=true). Tries an offline exact-match first; otherwise
@@ -638,7 +639,7 @@ export const useWalletStore = defineStore("wallet", {
       const proofsStore = useProofsStore();
       const uIStore = useUiStore();
       const keysetId = this.getKeyset(wallet.mint.mintUrl, wallet.unit);
-      await uIStore.lockMutex();
+      await uIStore.lockMutex(mutexPriority);
       try {
         const spendableProofs: Proof[] = toProofs(
           this.spendableProofs(proofs, amount)
@@ -854,19 +855,22 @@ export const useWalletStore = defineStore("wallet", {
       }
     },
     meltQuote: meltQuoteBolt11,
-    meltInvoiceData: async function (silent?: boolean) {
+    meltInvoiceData: async function (
+      silent?: boolean,
+      mutexPriority: MutexPriority = "normal"
+    ) {
       if (
         this.payInvoiceData?.invoice &&
         (this.payInvoiceData.invoice as any).onchain
       ) {
-        return await meltInvoiceDataOnchain.call(this, silent);
+        return await meltInvoiceDataOnchain.call(this, silent, mutexPriority);
       } else if (
         this.payInvoiceData?.invoice &&
         (this.payInvoiceData.invoice as any).bolt12
       ) {
-        return await meltInvoiceDataBolt12.call(this, silent);
+        return await meltInvoiceDataBolt12.call(this, silent, mutexPriority);
       } else {
-        return await meltInvoiceDataBolt11.call(this, silent);
+        return await meltInvoiceDataBolt11.call(this, silent, mutexPriority);
       }
     },
     meltGeneric: meltGeneric,

--- a/src/stores/walletBolt11.ts
+++ b/src/stores/walletBolt11.ts
@@ -1,7 +1,7 @@
 import { currentDateStr } from "src/js/utils";
 import { useMintsStore, WalletProof } from "./mints";
 import { useProofsStore } from "./proofs";
-import { useUiStore } from "src/stores/ui";
+import { type MutexPriority, useUiStore } from "src/stores/ui";
 import {
   Amount,
   Wallet,
@@ -110,7 +110,7 @@ export async function mintBolt11(
       invoice.mint,
       invoice.quote
     );
-    await uIStore.lockMutex();
+    await uIStore.lockMutex("background");
     if (
       !transactionWorkerStore.mintQuoteIsClaimed(invoice.mint, invoice.quote)
     ) {
@@ -230,7 +230,11 @@ export async function meltQuoteBolt11(
   return normalizeMeltQuote(data);
 }
 
-export async function meltInvoiceDataBolt11(this: any, silent?: boolean) {
+export async function meltInvoiceDataBolt11(
+  this: any,
+  silent?: boolean,
+  mutexPriority: MutexPriority = "normal"
+) {
   if (this.payInvoiceData.invoice == null) {
     throw new Error("no invoice provided.");
   }
@@ -259,7 +263,9 @@ export async function meltInvoiceDataBolt11(this: any, silent?: boolean) {
     mintStore.activeProofs,
     quote,
     mintWallet,
-    silent
+    silent,
+    false,
+    mutexPriority
   );
 }
 
@@ -269,7 +275,8 @@ export async function meltBolt11(
   quote: AppMeltQuote,
   mintWallet: Wallet,
   silent?: boolean,
-  releaseMutex = false
+  releaseMutex = false,
+  mutexPriority: MutexPriority = "normal"
 ) {
   return this.meltGeneric(
     proofs,
@@ -279,7 +286,8 @@ export async function meltBolt11(
     (id: string) => mintWallet.mint.checkMeltQuoteBolt11(id),
     PaymentMethod.Bolt11,
     undefined,
-    releaseMutex
+    releaseMutex,
+    mutexPriority
   );
 }
 

--- a/src/stores/walletBolt12.ts
+++ b/src/stores/walletBolt12.ts
@@ -1,7 +1,7 @@
 import { currentDateStr } from "src/js/utils";
 import { useMintsStore, WalletProof } from "./mints";
 import { useProofsStore } from "./proofs";
-import { useUiStore } from "src/stores/ui";
+import { type MutexPriority, useUiStore } from "src/stores/ui";
 import { Amount, Wallet, MintQuoteBolt12Response } from "@cashu/cashu-ts";
 import * as nobleSecp256k1 from "@noble/secp256k1";
 import { bytesToHex } from "@noble/hashes/utils";
@@ -124,7 +124,7 @@ export async function checkOfferAndMintBolt12(
       invoice.mint,
       invoice.quote
     );
-    await uIStore.lockMutex();
+    await uIStore.lockMutex("background");
     if (
       !transactionWorkerStore.mintQuoteIsClaimed(invoice.mint, invoice.quote)
     ) {
@@ -279,7 +279,11 @@ export async function meltQuoteInvoiceDataBolt12(this: any) {
   }
 }
 
-export async function meltInvoiceDataBolt12(this: any, silent?: boolean) {
+export async function meltInvoiceDataBolt12(
+  this: any,
+  silent?: boolean,
+  mutexPriority: MutexPriority = "normal"
+) {
   if (!this.payInvoiceData.invoice) throw new Error("no invoice provided.");
   const quote: AppMeltQuote = this.payInvoiceData.meltQuote.response;
   if (!quote) throw new Error("no quote found.");
@@ -293,7 +297,8 @@ export async function meltInvoiceDataBolt12(this: any, silent?: boolean) {
     mintStore.activeProofs,
     quote,
     mintWallet,
-    silent
+    silent,
+    mutexPriority
   );
 }
 
@@ -302,7 +307,8 @@ export async function meltBolt12(
   proofs: WalletProof[],
   quote: AppMeltQuote,
   mintWallet: Wallet,
-  silent?: boolean
+  silent?: boolean,
+  mutexPriority: MutexPriority = "normal"
 ) {
   return this.meltGeneric(
     proofs,
@@ -310,7 +316,10 @@ export async function meltBolt12(
     mintWallet,
     silent,
     (id: string) => mintWallet.mint.checkMeltQuoteBolt12(id),
-    PaymentMethod.Bolt12
+    PaymentMethod.Bolt12,
+    undefined,
+    false,
+    mutexPriority
   );
 }
 

--- a/src/stores/walletMelt.ts
+++ b/src/stores/walletMelt.ts
@@ -22,7 +22,7 @@ import { PaymentMethod } from "src/stores/walletTypes";
 import { useMintsStore, WalletProof } from "./mints";
 import { usePaymentHistoryStore } from "./paymentHistory";
 import { useProofsStore } from "./proofs";
-import { useUiStore } from "src/stores/ui";
+import { type MutexPriority, useUiStore } from "src/stores/ui";
 import { cashuAmountToNumber } from "src/js/cashu-amount";
 
 let isUnloading = false;
@@ -154,10 +154,10 @@ export async function meltGeneric(
   checkQuote: CheckMeltQuoteFn,
   method: PaymentMethod = PaymentMethod.Bolt11,
   completeMeltOptions?: CompleteMeltOptions,
-  releaseMutex = false
+  releaseMutex = false,
+  mutexPriority: MutexPriority = "normal"
 ) {
   const uIStore = useUiStore();
-  this.payInvoiceData.paying = true;
   const amount = quote.amount + quote.fee_reserve;
   const keysetId = this.getKeyset(mintWallet.mint.mintUrl, mintWallet.unit);
 
@@ -168,7 +168,8 @@ export async function meltGeneric(
       mintWallet,
       amount,
       false,
-      true
+      true,
+      mutexPriority
     );
     sendProofs = _sendProofs;
     if (sendProofs.length == 0) {
@@ -180,7 +181,8 @@ export async function meltGeneric(
     throw error;
   }
 
-  await uIStore.lockMutex();
+  this.payInvoiceData.paying = true;
+  await uIStore.lockMutex(mutexPriority);
   try {
     await this.addOutgoingPendingInvoiceToHistory(
       quote,
@@ -222,7 +224,7 @@ export async function meltGeneric(
       throw error;
     } finally {
       if (releaseMutex) {
-        await uIStore.lockMutex();
+        await uIStore.lockMutex(mutexPriority);
       }
     }
 

--- a/src/stores/walletOnchain.ts
+++ b/src/stores/walletOnchain.ts
@@ -1,7 +1,7 @@
 import { currentDateStr } from "src/js/utils";
 import { useMintsStore, WalletProof } from "./mints";
 import { useProofsStore } from "./proofs";
-import { useUiStore } from "src/stores/ui";
+import { type MutexPriority, useUiStore } from "src/stores/ui";
 import {
   Amount,
   Wallet,
@@ -138,7 +138,7 @@ export async function checkOnchainAndMint(
       invoice.mint,
       invoice.quote
     );
-    await uIStore.lockMutex();
+    await uIStore.lockMutex("background");
     if (
       !transactionWorkerStore.mintQuoteIsClaimed(invoice.mint, invoice.quote)
     ) {
@@ -289,7 +289,11 @@ export async function meltQuoteInvoiceDataOnchain(this: any) {
   }
 }
 
-export async function meltInvoiceDataOnchain(this: any, silent?: boolean) {
+export async function meltInvoiceDataOnchain(
+  this: any,
+  silent?: boolean,
+  mutexPriority: MutexPriority = "normal"
+) {
   if (!this.payInvoiceData.invoice) throw new Error("no address provided.");
   const quote: AppMeltQuote = this.payInvoiceData.meltQuote.response;
   if (!quote) throw new Error("no quote found.");
@@ -303,7 +307,8 @@ export async function meltInvoiceDataOnchain(this: any, silent?: boolean) {
     mintStore.activeProofs,
     quote,
     mintWallet,
-    silent
+    silent,
+    mutexPriority
   );
 }
 
@@ -312,7 +317,8 @@ export async function meltOnchain(
   proofs: WalletProof[],
   quote: AppMeltQuote,
   mintWallet: Wallet,
-  silent?: boolean
+  silent?: boolean,
+  mutexPriority: MutexPriority = "normal"
 ) {
   const feeIndex =
     quote.selected_fee_index ?? quote.fee_options?.[0]?.fee_index;
@@ -326,7 +332,9 @@ export async function meltOnchain(
     silent,
     (id: string) => mintWallet.mint.checkMeltQuoteOnchain(id),
     PaymentMethod.Onchain,
-    { extraPayload: { fee_index: feeIndex } }
+    { extraPayload: { fee_index: feeIndex } },
+    false,
+    mutexPriority
   );
 }
 


### PR DESCRIPTION
## Summary
- Keep the quoted Pay action available while unrelated background wallet work is active.
- Queue foreground invoice payments ahead of background reconciliation while preserving wallet-operation serialization.
- Show a clear waiting state only after the user starts payment, then transition to processing once the melt begins.

## Verification
- npm test -- --run
- npm run lint
- npm run build