### PR TITLE
Add live npub.cash zap updates

### DIFF
--- a/src/pages/settings/LightningAddressSettings.vue
+++ b/src/pages/settings/LightningAddressSettings.vue
@@ -81,7 +81,6 @@
 import { defineComponent } from "vue";
 import { mapActions, mapState, mapWritableState } from "pinia";
 import ChooseMint from "src/components/ChooseMint.vue";
-import { useNostrStore } from "src/stores/nostr";
 import { useNpubCashStore } from "src/stores/npubcash";
 import SettingsPageShell from "src/pages/settings/SettingsPageShell.vue";
 import SettingsSection from "src/pages/settings/SettingsSection.vue";
@@ -106,9 +105,9 @@ export default defineComponent({
   watch: {
     enabled: async function () {
       if (this.enabled) {
-        await this.initSigner();
-        await this.refreshNpubCashConnection();
+        await this.initializeNpubCash();
       } else {
+        this.stopQuoteUpdates();
         this.address = "";
       }
     },
@@ -119,10 +118,10 @@ export default defineComponent({
     },
   },
   methods: {
-    ...mapActions(useNostrStore, ["initSigner"]),
     ...mapActions(useNpubCashStore, [
-      "refreshNpubCashConnection",
+      "initializeNpubCash",
       "changeMintUrl",
+      "stopQuoteUpdates",
     ]),
   },
 });

--- a/src/pages/settings/LightningAddressSettings.vue
+++ b/src/pages/settings/LightningAddressSettings.vue
@@ -59,19 +59,42 @@
             />
           </q-item-section>
         </q-item>
-        <q-item tag="label">
-          <q-item-section>
-            <q-item-label>{{
-              $t("Settings.lightning_address.automatic_claim.toggle")
-            }}</q-item-label>
-            <q-item-label caption>{{
-              $t("Settings.lightning_address.automatic_claim.description")
-            }}</q-item-label>
-          </q-item-section>
-          <q-item-section side>
-            <q-toggle v-model="claimAutomatically" color="primary" />
-          </q-item-section>
-        </q-item>
+        <q-expansion-item
+          :label="$t('Settings.menu.advanced.title')"
+          icon="tune"
+          dense
+        >
+          <q-item class="settings-control-item">
+            <q-item-section>
+              <q-input
+                outlined
+                v-model="serverUrlInput"
+                label="npub.cash hostname"
+                hint="Enter a hostname or HTTPS URL"
+                placeholder="https://npub.cash"
+                dense
+                rounded
+                :error="Boolean(serverUrlError)"
+                :error-message="serverUrlError"
+                @blur="applyServerUrl"
+                @keyup.enter="applyServerUrl"
+              />
+            </q-item-section>
+          </q-item>
+          <q-item tag="label">
+            <q-item-section>
+              <q-item-label>{{
+                $t("Settings.lightning_address.automatic_claim.toggle")
+              }}</q-item-label>
+              <q-item-label caption>{{
+                $t("Settings.lightning_address.automatic_claim.description")
+              }}</q-item-label>
+            </q-item-section>
+            <q-item-section side>
+              <q-toggle v-model="claimAutomatically" color="primary" />
+            </q-item-section>
+          </q-item>
+        </q-expansion-item>
       </template>
     </SettingsSection>
   </SettingsPageShell>
@@ -93,8 +116,14 @@ export default defineComponent({
     SettingsSection,
     ChooseMint,
   },
+  data: function () {
+    return {
+      serverUrlInput: "",
+      serverUrlError: "",
+    };
+  },
   computed: {
-    ...mapState(useNpubCashStore, ["loading"]),
+    ...mapState(useNpubCashStore, ["loading", "baseHost"]),
     ...mapWritableState(useNpubCashStore, [
       "enabled",
       "address",
@@ -103,6 +132,12 @@ export default defineComponent({
     ]),
   },
   watch: {
+    baseHost: {
+      immediate: true,
+      handler(baseHost: string) {
+        this.serverUrlInput = `https://${baseHost}`;
+      },
+    },
     enabled: async function () {
       if (this.enabled) {
         await this.initializeNpubCash();
@@ -121,8 +156,20 @@ export default defineComponent({
     ...mapActions(useNpubCashStore, [
       "initializeNpubCash",
       "changeMintUrl",
+      "setBaseHost",
       "stopQuoteUpdates",
     ]),
+    applyServerUrl: async function () {
+      try {
+        this.serverUrlError = "";
+        this.serverUrlInput = await this.setBaseHost(this.serverUrlInput);
+      } catch (error) {
+        this.serverUrlError =
+          error instanceof Error
+            ? error.message
+            : "Enter a valid HTTPS server URL";
+      }
+    },
   },
 });
 </script>

--- a/src/pages/settings/__tests__/LightningAddressSettings.test.ts
+++ b/src/pages/settings/__tests__/LightningAddressSettings.test.ts
@@ -1,0 +1,76 @@
+import { createPinia, setActivePinia } from "pinia";
+import { mount } from "@vue/test-utils";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useNpubCashStore } from "src/stores/npubcash";
+
+let LightningAddressSettings: any;
+
+beforeAll(async () => {
+  (globalThis as any).windowMixin = {};
+  LightningAddressSettings = (await import("../LightningAddressSettings.vue"))
+    .default;
+});
+
+describe("LightningAddressSettings", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setActivePinia(createPinia());
+  });
+
+  it("keeps hostname and automatic claiming in a collapsed advanced section", () => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    useNpubCashStore().enabled = true;
+    const wrapper = mount(LightningAddressSettings, {
+      global: {
+        plugins: [pinia],
+        mocks: { $t: (key: string) => key },
+        config: { warnHandler: () => undefined },
+        stubs: {
+          SettingsPageShell: { template: "<div><slot /></div>" },
+          SettingsSection: { template: "<div><slot /></div>" },
+          ChooseMint: { template: "<div />" },
+          QItem: { template: "<div><slot /></div>" },
+          QItemSection: { template: "<div><slot /></div>" },
+          QItemLabel: { template: "<div><slot /></div>" },
+          QToggle: { template: "<div />" },
+          QSpinner: { template: "<div />" },
+          QIcon: { template: "<div><slot /></div>" },
+          QTooltip: { template: "<div><slot /></div>" },
+          QInput: {
+            props: ["label"],
+            template: '<div class="q-input">{{ label }}</div>',
+          },
+          QExpansionItem: {
+            props: ["label"],
+            template:
+              '<details class="advanced-settings"><summary>{{ label }}</summary><slot /></details>',
+          },
+        },
+      },
+    });
+
+    const advanced = wrapper.get(".advanced-settings");
+    expect(advanced.element).toBeInstanceOf(HTMLDetailsElement);
+    expect((advanced.element as HTMLDetailsElement).open).toBe(false);
+    expect(advanced.text()).toContain("npub.cash hostname");
+    expect(advanced.text()).toContain(
+      "Settings.lightning_address.automatic_claim.toggle"
+    );
+  });
+
+  it("writes the normalized HTTPS URL back into the input", async () => {
+    const setBaseHost = vi.fn().mockResolvedValue("https://custom.example");
+    const context = {
+      serverUrlInput: "custom.example",
+      serverUrlError: "old error",
+      setBaseHost,
+    };
+
+    await LightningAddressSettings.methods.applyServerUrl.call(context);
+
+    expect(setBaseHost).toHaveBeenCalledWith("custom.example");
+    expect(context.serverUrlInput).toBe("https://custom.example");
+    expect(context.serverUrlError).toBe("");
+  });
+});

--- a/src/stores/__tests__/npubcash.test.ts
+++ b/src/stores/__tests__/npubcash.test.ts
@@ -84,7 +84,7 @@ describe("npub.cash store", () => {
     ["npub.cash", "npub.cash"],
     ["  custom.example  ", "custom.example"],
     ["https://custom.example", "custom.example"],
-    ["https://CUSTOM.example:8443/", "custom.example:8443"],
+    ["https://CUSTOM.example/", "custom.example"],
   ])("normalizes the npub.cash server host from %s", (input, expected) => {
     expect(normalizeNpubCashBaseHost(input)).toBe(expected);
   });
@@ -92,6 +92,7 @@ describe("npub.cash store", () => {
   it.each([
     "",
     "http://npub.cash",
+    "https://custom.example:8443",
     "https://npub.cash/path",
     "https://user:secret@npub.cash",
   ])("rejects invalid npub.cash server input %s", (input) => {
@@ -617,6 +618,93 @@ describe("npub.cash store", () => {
 
     expect(requests).toBe(2);
     expect(maxActiveRequests).toBe(1);
+  });
+
+  it("discards an in-flight quote sync when the server host changes", async () => {
+    const oldMintUrl = "https://old-mint.example";
+    const newMintUrl = "https://new-mint.example";
+    const store = useNpubCashStore();
+    store.enabled = true;
+    store.baseHost = "old.example";
+    store.lastCheck = 100;
+    store.claimAutomatically = false;
+    const walletStore = useWalletStore();
+    walletStore.invoiceHistory = [];
+    vi.spyOn(walletStore, "addPaymentHistory").mockImplementation(
+      async (invoice) => {
+        walletStore.invoiceHistory.push(invoice);
+      }
+    );
+
+    let releaseOldRequest: ((response: Response) => void) | undefined;
+    const oldRequest = new Promise<Response>((resolve) => {
+      releaseOldRequest = resolve;
+    });
+    const requestedUrls: string[] = [];
+    vi.spyOn(store, "sendAuthedRequest").mockImplementation(async (url) => {
+      requestedUrls.push(url);
+      if (url.startsWith("https://old.example")) return oldRequest;
+      return new Response(
+        JSON.stringify({
+          error: false,
+          data: {
+            quotes: [
+              {
+                createdAt: 190,
+                paidAt: 200,
+                expiresAt: 1_000,
+                mintUrl: newMintUrl,
+                quoteId: "new-zap",
+                request: "lnbcnew",
+                amount: 20,
+                state: "PAID",
+                locked: false,
+              },
+            ],
+          },
+          metadata: { limit: 50, total: 1 },
+        })
+      );
+    });
+    vi.spyOn(store, "initializeNpubCash").mockImplementation(async () => {
+      await store.synchronizeQuotes();
+    });
+
+    const oldSync = store.synchronizeQuotes();
+    const hostChange = store.setBaseHost("new.example");
+    releaseOldRequest?.(
+      new Response(
+        JSON.stringify({
+          error: false,
+          data: {
+            quotes: [
+              {
+                createdAt: 490,
+                paidAt: 500,
+                expiresAt: 1_000,
+                mintUrl: oldMintUrl,
+                quoteId: "old-zap",
+                request: "lnbcold",
+                amount: 50,
+                state: "PAID",
+                locked: false,
+              },
+            ],
+          },
+          metadata: { limit: 50, total: 1 },
+        })
+      )
+    );
+    await Promise.all([oldSync, hostChange]);
+
+    expect(requestedUrls).toEqual([
+      "https://old.example/api/v2/wallet/quotes?limit=50&offset=0&since=99",
+      "https://new.example/api/v2/wallet/quotes?limit=50&offset=0",
+    ]);
+    expect(walletStore.invoiceHistory.map((invoice) => invoice.quote)).toEqual([
+      "new-zap",
+    ]);
+    expect(store.lastCheck).toBe(200);
   });
 
   it("reconnects realtime quote updates with backoff", async () => {

--- a/src/stores/__tests__/npubcash.test.ts
+++ b/src/stores/__tests__/npubcash.test.ts
@@ -17,10 +17,49 @@ vi.mock("vue-i18n", async (importOriginal) => {
   };
 });
 
+class MockQuoteWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 3;
+  static instances: MockQuoteWebSocket[] = [];
+
+  readyState = MockQuoteWebSocket.CONNECTING;
+  sent: string[] = [];
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  constructor(public url: string) {
+    MockQuoteWebSocket.instances.push(this);
+  }
+
+  open() {
+    this.readyState = MockQuoteWebSocket.OPEN;
+  }
+
+  message(message: unknown) {
+    this.onmessage?.({ data: JSON.stringify(message) });
+  }
+
+  send(message: string) {
+    this.sent.push(message);
+  }
+
+  close() {
+    if (this.readyState === MockQuoteWebSocket.CLOSED) return;
+    this.readyState = MockQuoteWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
 describe("npub.cash store", () => {
   beforeEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
     localStorage.clear();
     vi.restoreAllMocks();
+    MockQuoteWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockQuoteWebSocket);
   });
 
   it("starts a fresh wallet with canonical defaults", () => {
@@ -139,7 +178,7 @@ describe("npub.cash store", () => {
             })
           );
         }
-        if (url === "https://npub.cash/api/v2/wallet/quotes") {
+        if (url.startsWith("https://npub.cash/api/v2/wallet/quotes?")) {
           return new Response(
             JSON.stringify({
               error: false,
@@ -190,7 +229,7 @@ describe("npub.cash store", () => {
             })
           );
         }
-        if (url === "https://npub.cash/api/v2/wallet/quotes") {
+        if (url.startsWith("https://npub.cash/api/v2/wallet/quotes?")) {
           return new Response(
             JSON.stringify({
               error: false,
@@ -209,7 +248,7 @@ describe("npub.cash store", () => {
 
     expect(requestedUrls.sort()).toEqual([
       "https://npub.cash/api/v2/user/info",
-      "https://npub.cash/api/v2/wallet/quotes",
+      "https://npub.cash/api/v2/wallet/quotes?limit=50&offset=0",
     ]);
     expect(store.address).toMatch(/^npub1.+@npub\.cash$/);
     expect(store.mintUrl).toBe(mintUrl);
@@ -369,5 +408,174 @@ describe("npub.cash store", () => {
     ]);
     expect(mintOnPaid).not.toHaveBeenCalled();
     expect(processNow).toHaveBeenCalledOnce();
+  });
+
+  it("authenticates realtime updates and debounces quote synchronization", async () => {
+    vi.useFakeTimers();
+    const store = useNpubCashStore();
+    store.enabled = true;
+    const generateToken = vi
+      .spyOn(store, "generateNip98Event")
+      .mockResolvedValue("signed-event");
+    const synchronize = vi
+      .spyOn(store, "synchronizeQuotes")
+      .mockResolvedValue();
+
+    store.startQuoteUpdates();
+    const socket = MockQuoteWebSocket.instances[0];
+    socket.open();
+    socket.message({
+      type: "challenge",
+      payload: {
+        url: "wss://npub.cash/api/v2/ws/quote",
+        method: "GET",
+      },
+    });
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(1));
+
+    expect(generateToken).toHaveBeenCalledWith(
+      "wss://npub.cash/api/v2/ws/quote",
+      "GET"
+    );
+    expect(JSON.parse(socket.sent[0])).toEqual({
+      type: "challenge-response",
+      payload: "Nostr signed-event",
+    });
+
+    socket.message({ type: "update", payload: { quoteId: "zap-1" } });
+    socket.message({ type: "update", payload: { quoteId: "zap-2" } });
+    await vi.advanceTimersByTimeAsync(249);
+    expect(synchronize).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(synchronize).toHaveBeenCalledOnce();
+  });
+
+  it("supports the documented top-level WebSocket auth protocol", async () => {
+    const store = useNpubCashStore();
+    store.enabled = true;
+    vi.spyOn(store, "generateNip98Event").mockResolvedValue("signed-event");
+
+    store.startQuoteUpdates();
+    const socket = MockQuoteWebSocket.instances[0];
+    socket.open();
+    socket.message({ type: "challenge", challenge: "nonce" });
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(1));
+
+    expect(JSON.parse(socket.sent[0])).toEqual({
+      type: "auth",
+      token: "Nostr signed-event",
+    });
+  });
+
+  it("paginates quotes and advances the paidAt watermark", async () => {
+    const mintUrl = "https://mint.example";
+    const store = useNpubCashStore();
+    store.enabled = true;
+    store.lastCheck = 100;
+    store.claimAutomatically = true;
+    useMintsStore().mints = [
+      { url: mintUrl, keys: [], keysets: [], info: { nuts: { 29: {} } } },
+    ];
+    const walletStore = useWalletStore();
+    walletStore.invoiceHistory = [];
+    vi.spyOn(walletStore, "addPaymentHistory").mockImplementation(
+      async (invoice) => {
+        walletStore.invoiceHistory.push(invoice);
+      }
+    );
+    const worker = useTransactionWorkerStore();
+    vi.spyOn(worker, "startTransactionWorker").mockImplementation(() => {});
+    const processNow = vi
+      .spyOn(worker, "processIncomingTransactionsNow")
+      .mockResolvedValue();
+    const requestedUrls: string[] = [];
+    vi.spyOn(store, "sendAuthedRequest").mockImplementation(async (url) => {
+      requestedUrls.push(url);
+      const offset = Number(new URL(url).searchParams.get("offset"));
+      const index = offset === 0 ? 1 : 2;
+      return new Response(
+        JSON.stringify({
+          error: false,
+          data: {
+            quotes: [
+              {
+                createdAt: 90 + index,
+                paidAt: 100 + index,
+                expiresAt: 1_000,
+                mintUrl,
+                quoteId: `zap-${index}`,
+                request: `lnbc${index}`,
+                amount: index * 10,
+                state: "PAID",
+                locked: false,
+              },
+            ],
+          },
+          metadata: { limit: 50, total: 2 },
+        })
+      );
+    });
+
+    await store.synchronizeQuotes();
+
+    expect(requestedUrls).toEqual([
+      "https://npub.cash/api/v2/wallet/quotes?limit=50&offset=0&since=99",
+      "https://npub.cash/api/v2/wallet/quotes?limit=50&offset=1&since=99",
+    ]);
+    expect(walletStore.invoiceHistory.map((invoice) => invoice.quote)).toEqual([
+      "zap-1",
+      "zap-2",
+    ]);
+    expect(store.lastCheck).toBe(102);
+    expect(processNow).toHaveBeenCalledOnce();
+  });
+
+  it("serializes quote sync bursts and follows up without overlap", async () => {
+    const store = useNpubCashStore();
+    store.enabled = true;
+    let releaseFirstRequest: (() => void) | undefined;
+    const firstRequest = new Promise<void>((resolve) => {
+      releaseFirstRequest = resolve;
+    });
+    let requests = 0;
+    let activeRequests = 0;
+    let maxActiveRequests = 0;
+    vi.spyOn(store, "sendAuthedRequest").mockImplementation(async () => {
+      requests += 1;
+      activeRequests += 1;
+      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+      if (requests === 1) await firstRequest;
+      activeRequests -= 1;
+      return new Response(
+        JSON.stringify({
+          error: false,
+          data: { quotes: [] },
+          metadata: { limit: 50, total: 0 },
+        })
+      );
+    });
+
+    const firstSync = store.synchronizeQuotes();
+    const burstSync = store.synchronizeQuotes();
+    releaseFirstRequest?.();
+    await Promise.all([firstSync, burstSync]);
+
+    expect(requests).toBe(2);
+    expect(maxActiveRequests).toBe(1);
+  });
+
+  it("reconnects realtime quote updates with backoff", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const store = useNpubCashStore();
+    store.enabled = true;
+
+    store.startQuoteUpdates();
+    MockQuoteWebSocket.instances[0].close();
+    expect(MockQuoteWebSocket.instances).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(MockQuoteWebSocket.instances).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(MockQuoteWebSocket.instances).toHaveLength(2);
   });
 });

--- a/src/stores/__tests__/npubcash.test.ts
+++ b/src/stores/__tests__/npubcash.test.ts
@@ -453,7 +453,9 @@ describe("npub.cash store", () => {
   it("supports the documented top-level WebSocket auth protocol", async () => {
     const store = useNpubCashStore();
     store.enabled = true;
-    vi.spyOn(store, "generateNip98Event").mockResolvedValue("signed-event");
+    const generateToken = vi
+      .spyOn(store, "generateNip98Event")
+      .mockResolvedValue("signed-event");
 
     store.startQuoteUpdates();
     const socket = MockQuoteWebSocket.instances[0];
@@ -465,6 +467,10 @@ describe("npub.cash store", () => {
       type: "auth",
       token: "Nostr signed-event",
     });
+    expect(generateToken).toHaveBeenCalledWith(
+      "wss://npub.cash/api/v2/ws/quote",
+      "GET"
+    );
   });
 
   it("paginates quotes and advances the paidAt watermark", async () => {

--- a/src/stores/__tests__/npubcash.test.ts
+++ b/src/stores/__tests__/npubcash.test.ts
@@ -5,7 +5,10 @@ import { nextTick } from "vue";
 import { useTransactionWorkerStore } from "src/stores/transactionWorker";
 import { useMintsStore } from "src/stores/mints";
 import { useNostrStore } from "src/stores/nostr";
-import { useNpubCashStore } from "src/stores/npubcash";
+import {
+  normalizeNpubCashBaseHost,
+  useNpubCashStore,
+} from "src/stores/npubcash";
 import { useSettingsStore } from "src/stores/settings";
 import { useWalletStore } from "src/stores/wallet";
 
@@ -71,9 +74,52 @@ describe("npub.cash store", () => {
       lastCheck: null,
       address: "",
       mintUrl: null,
+      baseHost: "npub.cash",
       loading: false,
     });
     expect(localStorage.getItem("cashu.npubcash.storageVersion")).toBe("1");
+  });
+
+  it.each([
+    ["npub.cash", "npub.cash"],
+    ["  custom.example  ", "custom.example"],
+    ["https://custom.example", "custom.example"],
+    ["https://CUSTOM.example:8443/", "custom.example:8443"],
+  ])("normalizes the npub.cash server host from %s", (input, expected) => {
+    expect(normalizeNpubCashBaseHost(input)).toBe(expected);
+  });
+
+  it.each([
+    "",
+    "http://npub.cash",
+    "https://npub.cash/path",
+    "https://user:secret@npub.cash",
+  ])("rejects invalid npub.cash server input %s", (input) => {
+    expect(() => normalizeNpubCashBaseHost(input)).toThrow(
+      "Enter a valid HTTPS server URL"
+    );
+  });
+
+  it("stores a custom host and reconnects with a fresh quote watermark", async () => {
+    const store = useNpubCashStore();
+    store.enabled = true;
+    store.lastCheck = 123;
+    store.address = "old@npub.cash";
+    const stopUpdates = vi
+      .spyOn(store, "stopQuoteUpdates")
+      .mockImplementation(() => {});
+    const initialize = vi
+      .spyOn(store, "initializeNpubCash")
+      .mockResolvedValue();
+
+    const normalizedUrl = await store.setBaseHost("custom.example");
+
+    expect(normalizedUrl).toBe("https://custom.example");
+    expect(store.baseHost).toBe("custom.example");
+    expect(store.lastCheck).toBeNull();
+    expect(store.address).toBe("");
+    expect(stopUpdates).toHaveBeenCalledOnce();
+    expect(initialize).toHaveBeenCalledOnce();
   });
 
   it("preserves enabled v1 preferences during an in-place upgrade", () => {
@@ -97,6 +143,7 @@ describe("npub.cash store", () => {
     localStorage.setItem("cashu.npc.v2.lastCheck", "1712345678");
     localStorage.setItem("cashu.npc.v2.address", "old@npubx.cash");
     localStorage.setItem("cashu.npc.v2.mint", "https://mint.example");
+    localStorage.setItem("cashu.npc.v2.baseURL", "https://custom.example");
 
     const store = useNpubCashStore();
 
@@ -104,6 +151,7 @@ describe("npub.cash store", () => {
     expect(store.claimAutomatically).toBe(false);
     expect(store.lastCheck).toBe(1712345678);
     expect(store.mintUrl).toBe("https://mint.example");
+    expect(store.baseHost).toBe("custom.example");
     expect(store.address).toBe("");
     expect(localStorage.getItem("cashu.npc.v2.enabled")).toBeNull();
     expect(localStorage.getItem("cashu.npc.v2.mint")).toBeNull();
@@ -477,6 +525,7 @@ describe("npub.cash store", () => {
     const mintUrl = "https://mint.example";
     const store = useNpubCashStore();
     store.enabled = true;
+    store.baseHost = "custom.example";
     store.lastCheck = 100;
     store.claimAutomatically = true;
     useMintsStore().mints = [
@@ -525,8 +574,8 @@ describe("npub.cash store", () => {
     await store.synchronizeQuotes();
 
     expect(requestedUrls).toEqual([
-      "https://npub.cash/api/v2/wallet/quotes?limit=50&offset=0&since=99",
-      "https://npub.cash/api/v2/wallet/quotes?limit=50&offset=1&since=99",
+      "https://custom.example/api/v2/wallet/quotes?limit=50&offset=0&since=99",
+      "https://custom.example/api/v2/wallet/quotes?limit=50&offset=1&since=99",
     ]);
     expect(walletStore.invoiceHistory.map((invoice) => invoice.quote)).toEqual([
       "zap-1",

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -61,16 +61,48 @@ type NpubCashQuoteResponse =
 
 type UsernameQuote = { username: string; creq: string };
 
-const NPUB_CASH_BASE_URL = "npub.cash";
-const NPUB_CASH_HTTP_URL = `https://${NPUB_CASH_BASE_URL}`;
-const NPUB_CASH_QUOTES_URL = `${NPUB_CASH_HTTP_URL}/api/v2/wallet/quotes`;
-const NPUB_CASH_WS_URL = `wss://${NPUB_CASH_BASE_URL}/api/v2/ws/quote`;
+const NPUB_CASH_BASE_HOST = "npub.cash";
 const NPUB_CASH_STORAGE_VERSION = "1";
 const NPUB_CASH_STORAGE_PREFIX = "cashu.npubcash";
 const NIP_98_KIND = 27235;
 const QUOTE_PAGE_SIZE = 50;
 const QUOTE_SYNC_DEBOUNCE_MS = 250;
 const QUOTE_RECONNECT_MAX_MS = 30_000;
+
+export function normalizeNpubCashBaseHost(input: string): string {
+  const trimmed = input.trim();
+  let url: URL;
+  try {
+    url = new URL(
+      /^[a-z][a-z\d+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`
+    );
+  } catch {
+    throw new Error("Enter a valid HTTPS server URL");
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    (url.pathname !== "/" && url.pathname !== "") ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error("Enter a valid HTTPS server URL");
+  }
+  return url.host;
+}
+
+function npubCashHttpUrl(host: string): string {
+  return `https://${host}`;
+}
+
+function npubCashQuotesUrl(host: string): string {
+  return `${npubCashHttpUrl(host)}/api/v2/wallet/quotes`;
+}
+
+function npubCashWebSocketUrl(host: string): string {
+  return `wss://${host}/api/v2/ws/quote`;
+}
 
 const legacyStorageKeys = [
   "cashu.npc.enabled",
@@ -162,6 +194,20 @@ function migrateNpubCashStorage() {
     localStorage.setItem(`${NPUB_CASH_STORAGE_PREFIX}.mintUrl`, mintUrl);
   }
 
+  const legacyBaseUrl =
+    readStoredString("cashu.npc.v2.baseURL") ||
+    readStoredString("cashu.npc.baseURL");
+  if (legacyBaseUrl) {
+    try {
+      localStorage.setItem(
+        `${NPUB_CASH_STORAGE_PREFIX}.baseHost`,
+        normalizeNpubCashBaseHost(legacyBaseUrl)
+      );
+    } catch {
+      localStorage.removeItem(`${NPUB_CASH_STORAGE_PREFIX}.baseHost`);
+    }
+  }
+
   localStorage.setItem(
     `${NPUB_CASH_STORAGE_PREFIX}.storageVersion`,
     NPUB_CASH_STORAGE_VERSION
@@ -172,6 +218,15 @@ function migrateNpubCashStorage() {
 export const useNpubCashStore = defineStore("npubCash", {
   state: () => {
     migrateNpubCashStorage();
+    const baseHost = useLocalStorage<string>(
+      `${NPUB_CASH_STORAGE_PREFIX}.baseHost`,
+      NPUB_CASH_BASE_HOST
+    );
+    try {
+      baseHost.value = normalizeNpubCashBaseHost(baseHost.value);
+    } catch {
+      baseHost.value = NPUB_CASH_BASE_HOST;
+    }
     return {
       enabled: useLocalStorage<boolean>(
         `${NPUB_CASH_STORAGE_PREFIX}.enabled`,
@@ -194,6 +249,7 @@ export const useNpubCashStore = defineStore("npubCash", {
         `${NPUB_CASH_STORAGE_PREFIX}.mintUrl`,
         null
       ),
+      baseHost,
       loading: false,
       quoteSocket: null as WebSocket | null,
       quoteSyncPromise: null as Promise<void> | null,
@@ -216,6 +272,18 @@ export const useNpubCashStore = defineStore("npubCash", {
       await this.synchronizeQuotes();
       this.startQuoteUpdates();
     },
+    setBaseHost: async function (input: string): Promise<string> {
+      const baseHost = normalizeNpubCashBaseHost(input);
+      const normalizedUrl = npubCashHttpUrl(baseHost);
+      if (baseHost === this.baseHost) return normalizedUrl;
+
+      this.stopQuoteUpdates();
+      this.baseHost = baseHost;
+      this.lastCheck = null;
+      this.address = "";
+      if (this.enabled) await this.initializeNpubCash();
+      return normalizedUrl;
+    },
     refreshNpubCashConnection: async function () {
       if (!this.enabled) {
         return;
@@ -226,14 +294,14 @@ export const useNpubCashStore = defineStore("npubCash", {
         return;
       }
       const walletPublicKeyHex = nostrStore.pubkey;
-      this.address =
-        nip19.npubEncode(walletPublicKeyHex) + "@" + NPUB_CASH_BASE_URL;
+      const addressHost = new URL(npubCashHttpUrl(this.baseHost)).hostname;
+      this.address = nip19.npubEncode(walletPublicKeyHex) + "@" + addressHost;
       this.loading = true;
       try {
         const previousAddress = this.address;
         const info = await this.getInfo();
         if (info.name) {
-          const usernameAddress = info.name + "@" + NPUB_CASH_BASE_URL;
+          const usernameAddress = info.name + "@" + addressHost;
           if (previousAddress !== usernameAddress) {
             console.log(`[npub.cash] Logged in as ${info.name}`);
           }
@@ -259,7 +327,7 @@ export const useNpubCashStore = defineStore("npubCash", {
     getInfo: async function (): Promise<NpubCashUser> {
       try {
         const response = await this.sendAuthedRequest(
-          `${NPUB_CASH_HTTP_URL}/api/v2/user/info`
+          `${npubCashHttpUrl(this.baseHost)}/api/v2/user/info`
         );
         const info: NpubCashInfoResponse = await response.json();
         if (info.error) {
@@ -288,7 +356,7 @@ export const useNpubCashStore = defineStore("npubCash", {
       }
       try {
         const response = await this.sendAuthedRequest(
-          `${NPUB_CASH_HTTP_URL}/api/v2/user/mint`,
+          `${npubCashHttpUrl(this.baseHost)}/api/v2/user/mint`,
           {
             headers: {
               "Content-Type": "application/json",
@@ -339,6 +407,7 @@ export const useNpubCashStore = defineStore("npubCash", {
       try {
         const quotes: NpubCashQuote[] = [];
         const seenQuotes = new Set<string>();
+        const quotesUrl = npubCashQuotesUrl(this.baseHost);
         let offset = 0;
         let total = 0;
 
@@ -353,9 +422,9 @@ export const useNpubCashStore = defineStore("npubCash", {
             params.set("since", String(Math.max(0, this.lastCheck - 1)));
           }
           const response = await this.sendAuthedRequest(
-            `${NPUB_CASH_QUOTES_URL}?${params.toString()}`,
+            `${quotesUrl}?${params.toString()}`,
             undefined,
-            NPUB_CASH_QUOTES_URL
+            quotesUrl
           );
           if (!response.ok) {
             throw new Error(`npub.cash quote sync failed (${response.status})`);
@@ -473,7 +542,9 @@ export const useNpubCashStore = defineStore("npubCash", {
       }
 
       try {
-        const socket = markRaw(new WebSocket(NPUB_CASH_WS_URL));
+        const socket = markRaw(
+          new WebSocket(npubCashWebSocketUrl(this.baseHost))
+        );
         this.quoteSocket = socket;
         socket.onmessage = (event) => {
           void this.handleQuoteSocketMessage(socket, event.data);
@@ -503,10 +574,11 @@ export const useNpubCashStore = defineStore("npubCash", {
           const payload = message.payload;
           const usesPayloadProtocol =
             payload !== null && typeof payload === "object";
-          const authUrl = usesPayloadProtocol ? payload.url : NPUB_CASH_WS_URL;
+          const websocketUrl = npubCashWebSocketUrl(this.baseHost);
+          const authUrl = usesPayloadProtocol ? payload.url : websocketUrl;
           const method = usesPayloadProtocol ? payload.method : "GET";
           const parsedAuthUrl = new URL(authUrl);
-          const expectedAuthUrl = new URL(NPUB_CASH_WS_URL);
+          const expectedAuthUrl = new URL(websocketUrl);
           if (
             !["https:", "wss:"].includes(parsedAuthUrl.protocol) ||
             parsedAuthUrl.hostname !== expectedAuthUrl.hostname ||
@@ -598,7 +670,7 @@ export const useNpubCashStore = defineStore("npubCash", {
       username: string
     ): Promise<UsernameQuote> {
       const response = await this.sendAuthedRequest(
-        `${NPUB_CASH_HTTP_URL}/api/v2/user/username`,
+        `${npubCashHttpUrl(this.baseHost)}/api/v2/user/username`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -621,7 +693,7 @@ export const useNpubCashStore = defineStore("npubCash", {
     setUsername: async function (username: string, token: string) {
       try {
         const response = await this.sendAuthedRequest(
-          `${NPUB_CASH_HTTP_URL}/api/v2/user/username`,
+          `${npubCashHttpUrl(this.baseHost)}/api/v2/user/username`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json", "X-Cashu": token },
@@ -632,7 +704,8 @@ export const useNpubCashStore = defineStore("npubCash", {
         if (data.error) {
           throw new Error(data.message);
         }
-        this.address = `${data.data.user.name}@${NPUB_CASH_BASE_URL}`;
+        const addressHost = new URL(npubCashHttpUrl(this.baseHost)).hostname;
+        this.address = `${data.data.user.name}@${addressHost}`;
       } catch (error) {
         console.log(error);
         if (error instanceof Error) {

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -61,11 +61,10 @@ type NpubCashQuoteResponse =
 
 type UsernameQuote = { username: string; creq: string };
 
-const NPUB_CASH_BASE_URL = "https://npub.cash";
-const NPUB_CASH_QUOTES_URL = `${NPUB_CASH_BASE_URL}/api/v2/wallet/quotes`;
-const NPUB_CASH_WS_AUTH_URL = `${NPUB_CASH_BASE_URL}/api/v2/ws/quote`;
-const NPUB_CASH_WS_URL = "wss://npub.cash/api/v2/ws/quote";
-const NPUB_CASH_DOMAIN = "npub.cash";
+const NPUB_CASH_BASE_URL = "npub.cash";
+const NPUB_CASH_HTTP_URL = `https://${NPUB_CASH_BASE_URL}`;
+const NPUB_CASH_QUOTES_URL = `${NPUB_CASH_HTTP_URL}/api/v2/wallet/quotes`;
+const NPUB_CASH_WS_URL = `wss://${NPUB_CASH_BASE_URL}/api/v2/ws/quote`;
 const NPUB_CASH_STORAGE_VERSION = "1";
 const NPUB_CASH_STORAGE_PREFIX = "cashu.npubcash";
 const NIP_98_KIND = 27235;
@@ -228,13 +227,13 @@ export const useNpubCashStore = defineStore("npubCash", {
       }
       const walletPublicKeyHex = nostrStore.pubkey;
       this.address =
-        nip19.npubEncode(walletPublicKeyHex) + "@" + NPUB_CASH_DOMAIN;
+        nip19.npubEncode(walletPublicKeyHex) + "@" + NPUB_CASH_BASE_URL;
       this.loading = true;
       try {
         const previousAddress = this.address;
         const info = await this.getInfo();
         if (info.name) {
-          const usernameAddress = info.name + "@" + NPUB_CASH_DOMAIN;
+          const usernameAddress = info.name + "@" + NPUB_CASH_BASE_URL;
           if (previousAddress !== usernameAddress) {
             console.log(`[npub.cash] Logged in as ${info.name}`);
           }
@@ -260,7 +259,7 @@ export const useNpubCashStore = defineStore("npubCash", {
     getInfo: async function (): Promise<NpubCashUser> {
       try {
         const response = await this.sendAuthedRequest(
-          `${NPUB_CASH_BASE_URL}/api/v2/user/info`
+          `${NPUB_CASH_HTTP_URL}/api/v2/user/info`
         );
         const info: NpubCashInfoResponse = await response.json();
         if (info.error) {
@@ -289,7 +288,7 @@ export const useNpubCashStore = defineStore("npubCash", {
       }
       try {
         const response = await this.sendAuthedRequest(
-          `${NPUB_CASH_BASE_URL}/api/v2/user/mint`,
+          `${NPUB_CASH_HTTP_URL}/api/v2/user/mint`,
           {
             headers: {
               "Content-Type": "application/json",
@@ -504,12 +503,10 @@ export const useNpubCashStore = defineStore("npubCash", {
           const payload = message.payload;
           const usesPayloadProtocol =
             payload !== null && typeof payload === "object";
-          const authUrl = usesPayloadProtocol
-            ? payload.url
-            : NPUB_CASH_WS_AUTH_URL;
+          const authUrl = usesPayloadProtocol ? payload.url : NPUB_CASH_WS_URL;
           const method = usesPayloadProtocol ? payload.method : "GET";
           const parsedAuthUrl = new URL(authUrl);
-          const expectedAuthUrl = new URL(NPUB_CASH_WS_AUTH_URL);
+          const expectedAuthUrl = new URL(NPUB_CASH_WS_URL);
           if (
             !["https:", "wss:"].includes(parsedAuthUrl.protocol) ||
             parsedAuthUrl.hostname !== expectedAuthUrl.hostname ||
@@ -601,7 +598,7 @@ export const useNpubCashStore = defineStore("npubCash", {
       username: string
     ): Promise<UsernameQuote> {
       const response = await this.sendAuthedRequest(
-        `${NPUB_CASH_BASE_URL}/api/v2/user/username`,
+        `${NPUB_CASH_HTTP_URL}/api/v2/user/username`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -624,7 +621,7 @@ export const useNpubCashStore = defineStore("npubCash", {
     setUsername: async function (username: string, token: string) {
       try {
         const response = await this.sendAuthedRequest(
-          `${NPUB_CASH_BASE_URL}/api/v2/user/username`,
+          `${NPUB_CASH_HTTP_URL}/api/v2/user/username`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json", "X-Cashu": token },
@@ -635,7 +632,7 @@ export const useNpubCashStore = defineStore("npubCash", {
         if (data.error) {
           throw new Error(data.message);
         }
-        this.address = `${data.data.user.name}@${NPUB_CASH_DOMAIN}`;
+        this.address = `${data.data.user.name}@${NPUB_CASH_BASE_URL}`;
       } catch (error) {
         console.log(error);
         if (error instanceof Error) {

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -83,6 +83,7 @@ export function normalizeNpubCashBaseHost(input: string): string {
     url.protocol !== "https:" ||
     url.username ||
     url.password ||
+    url.port ||
     (url.pathname !== "/" && url.pathname !== "") ||
     url.search ||
     url.hash
@@ -254,6 +255,7 @@ export const useNpubCashStore = defineStore("npubCash", {
       quoteSocket: null as WebSocket | null,
       quoteSyncPromise: null as Promise<void> | null,
       quoteSyncRequested: false,
+      quoteSyncGeneration: 0,
       quoteSyncTimer: null as ReturnType<typeof setTimeout> | null,
       quoteReconnectTimer: null as ReturnType<typeof setTimeout> | null,
       quoteReconnectAttempt: 0,
@@ -404,10 +406,12 @@ export const useNpubCashStore = defineStore("npubCash", {
       if (!this.enabled) return;
       const transactionWorkerStore = useTransactionWorkerStore();
       const walletStore = useWalletStore();
+      const syncGeneration = this.quoteSyncGeneration;
+      const syncHost = this.baseHost;
       try {
         const quotes: NpubCashQuote[] = [];
         const seenQuotes = new Set<string>();
-        const quotesUrl = npubCashQuotesUrl(this.baseHost);
+        const quotesUrl = npubCashQuotesUrl(syncHost);
         let offset = 0;
         let total = 0;
 
@@ -445,7 +449,13 @@ export const useNpubCashStore = defineStore("npubCash", {
           if (page.length === 0) break;
         } while (offset < total);
 
-        if (!this.enabled) return;
+        if (
+          !this.enabled ||
+          this.quoteSyncGeneration !== syncGeneration ||
+          this.baseHost !== syncHost
+        ) {
+          return;
+        }
         let latestQuoteTime: number | undefined;
         let queuedQuotes = false;
         for (const quote of quotes) {
@@ -651,6 +661,7 @@ export const useNpubCashStore = defineStore("npubCash", {
       this.quoteSyncTimer = null;
       this.quoteReconnectTimer = null;
       this.quoteSyncRequested = false;
+      this.quoteSyncGeneration += 1;
       this.quoteReconnectAttempt = 0;
 
       const socket = this.quoteSocket;

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -4,6 +4,7 @@ import { StorageSerializers, useLocalStorage } from "@vueuse/core";
 import { defineStore } from "pinia";
 import { date } from "quasar";
 import { nip19 } from "nostr-tools";
+import { markRaw } from "vue";
 import { notifyApiError, notifyError } from "src/js/notify";
 import { useTransactionWorkerStore } from "src/stores/transactionWorker";
 import { useMintsStore } from "src/stores/mints";
@@ -61,10 +62,16 @@ type NpubCashQuoteResponse =
 type UsernameQuote = { username: string; creq: string };
 
 const NPUB_CASH_BASE_URL = "https://npub.cash";
+const NPUB_CASH_QUOTES_URL = `${NPUB_CASH_BASE_URL}/api/v2/wallet/quotes`;
+const NPUB_CASH_WS_AUTH_URL = `${NPUB_CASH_BASE_URL}/api/v2/ws/quote`;
+const NPUB_CASH_WS_URL = "wss://npub.cash/api/v2/ws/quote";
 const NPUB_CASH_DOMAIN = "npub.cash";
 const NPUB_CASH_STORAGE_VERSION = "1";
 const NPUB_CASH_STORAGE_PREFIX = "cashu.npubcash";
 const NIP_98_KIND = 27235;
+const QUOTE_PAGE_SIZE = 50;
+const QUOTE_SYNC_DEBOUNCE_MS = 250;
+const QUOTE_RECONNECT_MAX_MS = 30_000;
 
 const legacyStorageKeys = [
   "cashu.npc.enabled",
@@ -189,19 +196,26 @@ export const useNpubCashStore = defineStore("npubCash", {
         null
       ),
       loading: false,
+      quoteSocket: null as WebSocket | null,
+      quoteSyncPromise: null as Promise<void> | null,
+      quoteSyncRequested: false,
+      quoteSyncTimer: null as ReturnType<typeof setTimeout> | null,
+      quoteReconnectTimer: null as ReturnType<typeof setTimeout> | null,
+      quoteReconnectAttempt: 0,
+      quoteResumeHandler: null as (() => void) | null,
     };
   },
   actions: {
     initializeNpubCash: async function () {
       if (!this.enabled) {
+        this.stopQuoteUpdates();
         return;
       }
       const nostrStore = useNostrStore();
       await nostrStore.initSignerIfNotSet();
-      await Promise.all([
-        this.refreshNpubCashConnection(),
-        this.synchronizeQuotes(),
-      ]);
+      await this.refreshNpubCashConnection();
+      await this.synchronizeQuotes();
+      this.startQuoteUpdates();
     },
     refreshNpubCashConnection: async function () {
       if (!this.enabled) {
@@ -298,36 +312,87 @@ export const useNpubCashStore = defineStore("npubCash", {
         }
       }
     },
-    synchronizeQuotes: async function () {
-      if (!this.enabled) {
-        return;
+    synchronizeQuotes: async function (): Promise<void> {
+      if (!this.enabled) return;
+      if (this.quoteSyncPromise) {
+        this.quoteSyncRequested = true;
+        return this.quoteSyncPromise;
       }
+
+      this.quoteSyncRequested = true;
+      const syncPromise = (async () => {
+        do {
+          this.quoteSyncRequested = false;
+          await this.fetchAndQueueQuotes();
+        } while (this.enabled && this.quoteSyncRequested);
+      })().finally(() => {
+        if (this.quoteSyncPromise === syncPromise) {
+          this.quoteSyncPromise = null;
+        }
+      });
+      this.quoteSyncPromise = syncPromise;
+      return syncPromise;
+    },
+    fetchAndQueueQuotes: async function () {
+      if (!this.enabled) return;
       const transactionWorkerStore = useTransactionWorkerStore();
       const walletStore = useWalletStore();
-      const since = this.lastCheck ? `?since=${this.lastCheck}` : "";
-      const quoteUrl = `${NPUB_CASH_BASE_URL}/api/v2/wallet/quotes`;
       try {
-        const response = await this.sendAuthedRequest(
-          quoteUrl + since,
-          undefined,
-          quoteUrl
-        );
-        const responseData: NpubCashQuoteResponse = await response.json();
-        if (responseData.error) {
-          return;
-        }
+        const quotes: NpubCashQuote[] = [];
+        const seenQuotes = new Set<string>();
+        let offset = 0;
+        let total = 0;
+
+        do {
+          const params = new URLSearchParams({
+            limit: String(QUOTE_PAGE_SIZE),
+            offset: String(offset),
+          });
+          // Re-read the previous second so quotes sharing a paidAt timestamp
+          // cannot fall through the strict `since` boundary.
+          if (this.lastCheck !== null) {
+            params.set("since", String(Math.max(0, this.lastCheck - 1)));
+          }
+          const response = await this.sendAuthedRequest(
+            `${NPUB_CASH_QUOTES_URL}?${params.toString()}`,
+            undefined,
+            NPUB_CASH_QUOTES_URL
+          );
+          if (!response.ok) {
+            throw new Error(`npub.cash quote sync failed (${response.status})`);
+          }
+          const responseData: NpubCashQuoteResponse = await response.json();
+          if (responseData.error) throw new Error(responseData.message);
+
+          const page = responseData.data.quotes;
+          total = responseData.metadata.total;
+          for (const quote of page) {
+            const key = `${quote.mintUrl}|${quote.quoteId}`;
+            if (!seenQuotes.has(key)) {
+              seenQuotes.add(key);
+              quotes.push(quote);
+            }
+          }
+          offset += page.length;
+          if (page.length === 0) break;
+        } while (offset < total);
+
+        if (!this.enabled) return;
         let latestQuoteTime: number | undefined;
         let queuedQuotes = false;
-        for (const quote of responseData.data.quotes) {
+        for (const quote of quotes) {
+          const paidAt = quote.paidAt || quote.createdAt;
+          if (!latestQuoteTime || latestQuoteTime < paidAt) {
+            latestQuoteTime = paidAt;
+          }
           if (
             walletStore.invoiceHistory.find(
-              (invoice) => invoice.quote === quote.quoteId
+              (invoice) =>
+                invoice.quote === quote.quoteId &&
+                invoice.mint === quote.mintUrl
             )
           ) {
             continue;
-          }
-          if (!latestQuoteTime || latestQuoteTime < quote.createdAt) {
-            latestQuoteTime = quote.createdAt;
           }
           const invoice = {
             label: "Zap",
@@ -367,6 +432,169 @@ export const useNpubCashStore = defineStore("npubCash", {
         }
       } catch (error) {
         console.error(error);
+      }
+    },
+    scheduleQuoteSync: function (delay = QUOTE_SYNC_DEBOUNCE_MS) {
+      if (!this.enabled) return;
+      if (this.quoteSyncTimer) clearTimeout(this.quoteSyncTimer);
+      this.quoteSyncTimer = setTimeout(() => {
+        this.quoteSyncTimer = null;
+        void this.synchronizeQuotes();
+      }, delay);
+    },
+    startQuoteUpdates: function () {
+      if (!this.enabled || typeof WebSocket === "undefined") return;
+      if (!this.quoteResumeHandler) {
+        this.quoteResumeHandler = () => {
+          if (!this.enabled || document.visibilityState === "hidden") return;
+          // Browsers may keep a stale OPEN socket after a device resumes.
+          const socket = this.quoteSocket;
+          this.quoteSocket = null;
+          if (socket) socket.close(1000);
+          this.connectQuoteUpdates();
+          this.scheduleQuoteSync(0);
+        };
+        window.addEventListener("online", this.quoteResumeHandler);
+        document.addEventListener("visibilitychange", this.quoteResumeHandler);
+      }
+      this.connectQuoteUpdates();
+    },
+    connectQuoteUpdates: function () {
+      if (!this.enabled || typeof WebSocket === "undefined") return;
+      if (
+        this.quoteSocket &&
+        (this.quoteSocket.readyState === WebSocket.CONNECTING ||
+          this.quoteSocket.readyState === WebSocket.OPEN)
+      ) {
+        return;
+      }
+      if (this.quoteReconnectTimer) {
+        clearTimeout(this.quoteReconnectTimer);
+        this.quoteReconnectTimer = null;
+      }
+
+      try {
+        const socket = markRaw(new WebSocket(NPUB_CASH_WS_URL));
+        this.quoteSocket = socket;
+        socket.onmessage = (event) => {
+          void this.handleQuoteSocketMessage(socket, event.data);
+        };
+        socket.onerror = () => {
+          socket.close();
+        };
+        socket.onclose = () => {
+          if (this.quoteSocket !== socket) return;
+          this.quoteSocket = null;
+          this.scheduleQuoteReconnect();
+        };
+      } catch (error) {
+        console.error("Could not connect to npub.cash quote updates", error);
+        this.quoteSocket = null;
+        this.scheduleQuoteReconnect();
+      }
+    },
+    handleQuoteSocketMessage: async function (
+      socket: WebSocket,
+      rawMessage: unknown
+    ) {
+      if (typeof rawMessage !== "string") return;
+      try {
+        const message = JSON.parse(rawMessage);
+        if (message.type === "challenge") {
+          const payload = message.payload;
+          const usesPayloadProtocol =
+            payload !== null && typeof payload === "object";
+          const authUrl = usesPayloadProtocol
+            ? payload.url
+            : NPUB_CASH_WS_AUTH_URL;
+          const method = usesPayloadProtocol ? payload.method : "GET";
+          const parsedAuthUrl = new URL(authUrl);
+          const expectedAuthUrl = new URL(NPUB_CASH_WS_AUTH_URL);
+          if (
+            !["https:", "wss:"].includes(parsedAuthUrl.protocol) ||
+            parsedAuthUrl.hostname !== expectedAuthUrl.hostname ||
+            parsedAuthUrl.port !== expectedAuthUrl.port ||
+            parsedAuthUrl.pathname !== expectedAuthUrl.pathname
+          ) {
+            throw new Error("Refusing an unexpected npub.cash auth URL");
+          }
+          const token = await this.generateNip98Event(authUrl, method || "GET");
+          if (
+            this.quoteSocket !== socket ||
+            socket.readyState !== WebSocket.OPEN
+          ) {
+            return;
+          }
+          socket.send(
+            JSON.stringify(
+              usesPayloadProtocol
+                ? {
+                    type: "challenge-response",
+                    payload: `Nostr ${token}`,
+                  }
+                : { type: "auth", token: `Nostr ${token}` }
+            )
+          );
+          return;
+        }
+        if (message.type === "ok" || message.type === "challenge-success") {
+          this.quoteReconnectAttempt = 0;
+          // This second catch-up closes the gap between the startup REST fetch
+          // and successful WebSocket authentication.
+          this.scheduleQuoteSync(0);
+          return;
+        }
+        if (message.type === "update") {
+          const quoteId = message.quoteId || message.payload?.quoteId;
+          if (quoteId) this.scheduleQuoteSync();
+          return;
+        }
+        if (message.type === "error") {
+          socket.close();
+        }
+      } catch (error) {
+        const errorDetails =
+          error instanceof Error
+            ? `${error.name}: ${error.message}`
+            : String(error);
+        console.error(
+          `Could not handle npub.cash quote update: ${errorDetails}`
+        );
+        socket.close();
+      }
+    },
+    scheduleQuoteReconnect: function () {
+      if (!this.enabled || this.quoteReconnectTimer) return;
+      const baseDelay = Math.min(
+        1_000 * 2 ** this.quoteReconnectAttempt,
+        QUOTE_RECONNECT_MAX_MS
+      );
+      const delay = Math.round(baseDelay * (0.75 + Math.random() * 0.5));
+      this.quoteReconnectAttempt += 1;
+      this.quoteReconnectTimer = setTimeout(() => {
+        this.quoteReconnectTimer = null;
+        this.connectQuoteUpdates();
+      }, delay);
+    },
+    stopQuoteUpdates: function () {
+      if (this.quoteSyncTimer) clearTimeout(this.quoteSyncTimer);
+      if (this.quoteReconnectTimer) clearTimeout(this.quoteReconnectTimer);
+      this.quoteSyncTimer = null;
+      this.quoteReconnectTimer = null;
+      this.quoteSyncRequested = false;
+      this.quoteReconnectAttempt = 0;
+
+      const socket = this.quoteSocket;
+      this.quoteSocket = null;
+      if (socket) socket.close(1000);
+
+      if (this.quoteResumeHandler) {
+        window.removeEventListener("online", this.quoteResumeHandler);
+        document.removeEventListener(
+          "visibilitychange",
+          this.quoteResumeHandler
+        );
+        this.quoteResumeHandler = null;
       }
     },
     getUsernameQuote: async function (


### PR DESCRIPTION
## Summary
- subscribe to authenticated npub.cash quote updates while the wallet is open
- debounce and serialize paginated quote synchronization before queueing new zaps in the transaction worker
- reconnect with backoff and recover on browser resume or network return
- support both deployed WebSocket challenge formats and validate the authentication endpoint
- add collapsed advanced Lightning Address settings for automatic claiming and a configurable npub.cash hostname
- normalize hostname-only input to HTTPS and derive REST and WebSocket endpoints from the persisted host

## Validation
- npx vitest run src/stores/__tests__/npubcash.test.ts src/stores/__tests__/transactionWorker.test.js src/pages/settings/__tests__/LightningAddressSettings.test.ts
- npm run lint
- npm run build