### PR TITLE
fix: prioritize foreground ecash sends

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -240,6 +240,7 @@
                 unelevated
                 size="lg"
                 :disable="
+                  sendingEcash ||
                   sendData.amount == null ||
                   sendData.amount <= 0 ||
                   insufficientFunds ||
@@ -251,11 +252,14 @@
                 color="primary"
                 rounded
                 type="submit"
-                :loading="globalMutexLock"
+                :loading="sendingEcash"
               >
                 {{ $t("SendTokenDialog.actions.send.label") }}
                 <template v-slot:loading>
-                  <q-spinner />
+                  <q-spinner class="q-mr-sm" />
+                  <span>{{
+                    $t("SendTokenDialog.actions.send.in_progress")
+                  }}</span>
                 </template>
               </q-btn>
             </div>
@@ -274,7 +278,7 @@
 import { defineComponent } from "vue";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import { useWalletStore } from "src/stores/wallet";
-import { useUiStore } from "src/stores/ui";
+import { type MutexPriority, useUiStore } from "src/stores/ui";
 import { useProofsStore } from "src/stores/proofs";
 import { useMintsStore } from "src/stores/mints";
 import { useTokensStore } from "src/stores/tokens";
@@ -316,6 +320,7 @@ export default defineComponent({
   data: function () {
     return {
       fiatKeyboardMode: false as boolean,
+      sendingEcash: false as boolean,
     };
   },
   computed: {
@@ -610,7 +615,7 @@ export default defineComponent({
       this.sendData.historyToken = historyToken as any;
       return serialized;
     },
-    lockTokens: async function () {
+    lockTokens: async function (mutexPriority: MutexPriority = "normal") {
       if (!this.sendData.amount) {
         throw new Error("Amount is required");
       }
@@ -628,7 +633,8 @@ export default defineComponent({
           this.activeProofs,
           mintWallet,
           sendAmount,
-          this.sendData.p2pkPubkey
+          this.sendData.p2pkPubkey,
+          mutexPriority
         );
         // update UI
         this.sendData.tokens = sendProofs;
@@ -655,18 +661,24 @@ export default defineComponent({
       /*
       calls send, displays token and kicks off the spendableWorker
       */
-      this.sendData.p2pkPubkey = this.maybeConvertNpub(
-        this.sendData.p2pkPubkey
-      );
-      if (
-        this.sendData.p2pkPubkey &&
-        this.isValidPubkey(this.sendData.p2pkPubkey)
-      ) {
-        await this.lockTokens();
-        return;
-      }
+      if (this.sendingEcash) return;
+
+      const uiStore = useUiStore();
+      this.sendingEcash = true;
+      uiStore.beginForegroundPayment();
 
       try {
+        this.sendData.p2pkPubkey = this.maybeConvertNpub(
+          this.sendData.p2pkPubkey
+        );
+        if (
+          this.sendData.p2pkPubkey &&
+          this.isValidPubkey(this.sendData.p2pkPubkey)
+        ) {
+          await this.lockTokens("foreground");
+          return;
+        }
+
         const sendAmount = Math.floor(
           this.sendData.amount * this.activeUnitCurrencyMultiplyer
         );
@@ -681,7 +693,8 @@ export default defineComponent({
           mintWallet,
           sendAmount,
           true,
-          this.includeFeesInSendAmount
+          this.includeFeesInSendAmount,
+          "foreground"
         );
 
         // update UI
@@ -707,6 +720,9 @@ export default defineComponent({
         }
       } catch (error: any) {
         console.error(error);
+      } finally {
+        this.sendingEcash = false;
+        uiStore.endForegroundPayment();
       }
     },
     pasteToP2PKField: async function () {

--- a/src/components/__tests__/SendTokenDialog.test.ts
+++ b/src/components/__tests__/SendTokenDialog.test.ts
@@ -1,0 +1,98 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { useUiStore } from "src/stores/ui";
+
+vi.mock("components/DisplayTokenComponent.vue", () => ({
+  default: {},
+}));
+
+let SendTokenDialog: any;
+
+beforeAll(async () => {
+  (globalThis as any).windowMixin = {};
+  SendTokenDialog = (await import("../SendTokenDialog.vue")).default;
+});
+
+describe("SendTokenDialog", () => {
+  it("queues an ecash send as foreground work after the user taps Send", async () => {
+    const uiStore = useUiStore();
+    let rejectSend!: (error: Error) => void;
+    const send = vi.fn(
+      () =>
+        new Promise((_, reject) => {
+          rejectSend = reject;
+        })
+    );
+    const context = {
+      sendingEcash: false,
+      sendData: { amount: 21, p2pkPubkey: "" },
+      maybeConvertNpub: vi.fn(() => ""),
+      isValidPubkey: vi.fn(() => false),
+      activeUnitCurrencyMultiplyer: 1,
+      activeMintUrl: "https://mint.example",
+      activeUnit: "sat",
+      activeProofs: [],
+      includeFeesInSendAmount: false,
+      mintWallet: vi.fn(async () => ({ id: "wallet" })),
+      send,
+      serializeProofs: vi.fn(),
+      addPendingToken: vi.fn(),
+      g: { offline: true },
+    };
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const sending = SendTokenDialog.methods.sendTokens.call(context);
+
+    await vi.waitFor(() => {
+      expect(send).toHaveBeenCalledWith(
+        [],
+        { id: "wallet" },
+        21,
+        true,
+        false,
+        "foreground"
+      );
+    });
+    expect(context.sendingEcash).toBe(true);
+    expect(uiStore.foregroundPaymentRequests).toBe(1);
+
+    rejectSend(new Error("send failed"));
+    await sending;
+
+    expect(context.sendingEcash).toBe(false);
+    expect(uiStore.foregroundPaymentRequests).toBe(0);
+
+    consoleError.mockRestore();
+  });
+
+  it("uses foreground priority for a locked ecash send", async () => {
+    const uiStore = useUiStore();
+    let finishLock!: () => void;
+    const lockTokens = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishLock = resolve;
+        })
+    );
+    const context = {
+      sendingEcash: false,
+      sendData: { amount: 21, p2pkPubkey: "pubkey" },
+      maybeConvertNpub: vi.fn(() => "pubkey"),
+      isValidPubkey: vi.fn(() => true),
+      lockTokens,
+    };
+
+    const sending = SendTokenDialog.methods.sendTokens.call(context);
+
+    expect(lockTokens).toHaveBeenCalledWith("foreground");
+    expect(context.sendingEcash).toBe(true);
+    expect(uiStore.foregroundPaymentRequests).toBe(1);
+
+    finishLock();
+    await sending;
+
+    expect(context.sendingEcash).toBe(false);
+    expect(uiStore.foregroundPaymentRequests).toBe(0);
+  });
+});

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1041,6 +1041,7 @@ export default {
       },
       send: {
         label: "@:global.actions.send.label",
+        in_progress: "جارٍ الإرسال…",
       },
       delete: {
         tooltip_text: "حذف من السجل",

--- a/src/i18n/cs-CZ/index.ts
+++ b/src/i18n/cs-CZ/index.ts
@@ -1090,6 +1090,7 @@ export default {
       },
       send: {
         label: "@:global.actions.send.label",
+        in_progress: "Odesílání…",
       },
       delete: {
         tooltip_text: "Smazat z historie",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1056,6 +1056,7 @@ export default {
       },
       send: {
         label: "@:global.actions.send.label",
+        in_progress: "Wird gesendet…",
       },
       delete: {
         tooltip_text: "Aus Verlauf löschen",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1053,6 +1053,7 @@ export default {
       },
       send: {
         label: "@:global.actions.send.label",
+        in_progress: "Αποστολή…",
       },
       delete: {
         tooltip_text: "Διαγραφή από το ιστορικό",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1082,6 +1082,7 @@ export default {
       },
       send: {
         label: "@:global.actions.send.label",
+        in_progress: "Sending…",
       },
       delete: {
         tooltip_text: "Delete from history",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1050,6 +1050,7 @@ export default {
       },
       send: {
         label: "@:global.actions.send.label",
+        in_progress: "Enviando…",
       },
       delete: {
         tooltip_text: "Eliminar del historial",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1056,6 +1056,7 @@ export default {
       },
       send: {
         label: "@:global.actions.send.label",
+        in_progress: "Envoi…",
       },
       delete: {
         tooltip_text: "Supprimer de l'historique",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1021,6 +1021,7 @@ export default {
       },
       send: {
         label: "@:global.actions.send.label",
+        in_progress: "Invio…",
       },
       delete: {
         tooltip_text: "Elimina dalla cronologia",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1042,6 +1042,7 @@ export default {
       },
       send: {
         label: "@:global.actions.send.label",
+        in_progress: "送信中…",
       },
       delete: {
         tooltip_text: "履歴から削除",

--- a/src/i18n/pt-BR/index.ts
+++ b/src/i18n/pt-BR/index.ts
@@ -1087,6 +1087,7 @@ export default {
       },
       send: {
         label: "@:global.actions.send.label",
+        in_progress: "Enviando…",
       },
       delete: {
         tooltip_text: "Excluir do histórico",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1046,6 +1046,7 @@ export default {
       },
       send: {
         label: "@:global.actions.send.label",
+        in_progress: "Skickar…",
       },
       delete: {
         tooltip_text: "Ta bort från historik",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1043,6 +1043,7 @@ export default {
       },
       send: {
         label: "@:global.actions.send.label",
+        in_progress: "กำลังส่ง…",
       },
       delete: {
         tooltip_text: "ลบออกจากประวัติ",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1057,6 +1057,7 @@ export default {
       },
       send: {
         label: "@:global.actions.send.label",
+        in_progress: "Gönderiliyor…",
       },
       delete: {
         tooltip_text: "Geçmişten sil",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1039,6 +1039,7 @@ export default {
       },
       send: {
         label: "@:global.actions.send.label",
+        in_progress: "正在发送…",
       },
       delete: {
         tooltip_text: "从历史记录中删除",

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -594,35 +594,42 @@ export const useWalletStore = defineStore("wallet", {
       proofs: WalletProof[],
       wallet: Wallet,
       amount: number,
-      receiverPubkey: string | P2PKOptions
+      receiverPubkey: string | P2PKOptions,
+      mutexPriority: MutexPriority = "normal"
     ) {
       // Accept a bare pubkey (manual lock flow) or a full P2PKOptions so a
       // NUT-18 payment request can reproduce its requested NUT-10 condition
       // (P2PK or HTLC). Going through the `.asP2PK()` builder keeps the
       // blinding keyset-aware (for upcoming cashu-ts v5).
-      const p2pkOptions: P2PKOptions =
-        typeof receiverPubkey === "string"
-          ? { pubkey: receiverPubkey }
-          : receiverPubkey;
-      const spendableProofs = this.spendableProofs(proofs, amount);
-      const proofsToSend = this.coinSelect(
-        spendableProofs,
-        wallet,
-        amount,
-        true
-      );
-      const keysetId = this.getKeyset(wallet.mint.mintUrl, wallet.unit);
-      const { keep: keepProofs, send: sendProofs } = await wallet.ops
-        .send(amount, toProofs(proofsToSend))
-        .keyset(keysetId)
-        .asP2PK(p2pkOptions)
-        .run();
-      const proofsStore = useProofsStore();
-      await proofsStore.removeProofs(proofsToSend);
-      // note: we do not store sendProofs in the proofs store but
-      // expect from the caller to store it in the history
-      await proofsStore.addProofs(keepProofs);
-      return { keepProofs, sendProofs };
+      const uiStore = useUiStore();
+      await uiStore.lockMutex(mutexPriority);
+      try {
+        const p2pkOptions: P2PKOptions =
+          typeof receiverPubkey === "string"
+            ? { pubkey: receiverPubkey }
+            : receiverPubkey;
+        const spendableProofs = this.spendableProofs(proofs, amount);
+        const proofsToSend = this.coinSelect(
+          spendableProofs,
+          wallet,
+          amount,
+          true
+        );
+        const keysetId = this.getKeyset(wallet.mint.mintUrl, wallet.unit);
+        const { keep: keepProofs, send: sendProofs } = await wallet.ops
+          .send(amount, toProofs(proofsToSend))
+          .keyset(keysetId)
+          .asP2PK(p2pkOptions)
+          .run();
+        const proofsStore = useProofsStore();
+        await proofsStore.removeProofs(proofsToSend);
+        // note: we do not store sendProofs in the proofs store but
+        // expect from the caller to store it in the history
+        await proofsStore.addProofs(keepProofs);
+        return { keepProofs, sendProofs };
+      } finally {
+        uiStore.unlockMutex();
+      }
     },
     send: async function (
       proofs: WalletProof[],


### PR DESCRIPTION
## Summary

- Keep the ecash Send button available while unrelated background wallet checks hold the mutex.
- Reserve foreground priority only after the user taps Send, prevent duplicate submissions, and show a localized Sending state.
- Route both ordinary and P2PK-locked ecash sends through the priority mutex and release it safely.
- Add regression coverage for ordinary and locked foreground sends.

## Verification

- Full Vitest suite: 167 tests passed
- ESLint passed
- Targeted Prettier check passed
- Production SPA build passed
- New progress copy is present in all 14 supported locales

The repository-wide i18n checker still reports the existing missing-key baseline; it does not report the new Send progress key.