### PR TITLE
fix: overhaul npub.cash lightning address QR view

### DIFF
--- a/src/components/CreateInvoiceDialog.vue
+++ b/src/components/CreateInvoiceDialog.vue
@@ -79,55 +79,13 @@
         <div class="col column items-center q-px-lg amount-area">
           <transition name="receive-content" mode="out-in">
             <div
-              v-if="showNpubCashPreview"
-              key="npub-cash-address"
+              v-if="qrPreview"
+              :key="qrPreview.key"
               class="row justify-center full-width q-mt-lg q-mb-auto"
             >
               <div class="col-12" style="max-width: 400px">
                 <div
-                  class="qr-container cursor-pointer"
-                  @click="copyNpubCashAddress"
-                >
-                  <q-responsive :ratio="1" class="q-mx-none">
-                    <vue-qrcode
-                      :value="npubCashLnurl"
-                      :options="{ width: 400 }"
-                      class="rounded-borders"
-                      style="width: 100%"
-                    >
-                    </vue-qrcode>
-                  </q-responsive>
-                </div>
-                <div
-                  class="q-mt-sm text-center text-grey-7 npub-cash-address cursor-pointer"
-                  data-testid="npub-cash-lightning-address"
-                  @click="copyNpubCashAddress"
-                >
-                  <q-icon
-                    :name="npubCashAddressCopied ? 'check' : 'content_copy'"
-                    size="xs"
-                    class="q-mr-xs"
-                  />
-                  {{ npubCashAddress }}
-                </div>
-              </div>
-            </div>
-            <div
-              v-else-if="isOnchain && checkingReusableOnchainQuote"
-              key="checking-onchain"
-              class="column items-center justify-center q-pa-xl q-my-auto"
-            >
-              <q-spinner size="48px" color="primary" />
-              <div class="text-grey-6 q-mt-md">Checking address...</div>
-            </div>
-            <div
-              v-else-if="!checkingReusableOnchainQuote && showReusableQuote"
-              key="reusable-quote"
-              class="row justify-center full-width q-my-auto"
-            >
-              <div class="col-12" style="max-width: 400px">
-                <div
-                  v-if="activeMintErrored"
+                  v-if="qrPreview.kind === 'reusable' && activeMintErrored"
                   class="mint-error-warning column items-center text-center q-pa-lg"
                 >
                   <q-icon name="warning" size="42px" color="warning" />
@@ -147,40 +105,47 @@
                     @click="refreshActiveMint"
                   />
                 </div>
-                <div
-                  v-else-if="reusableReceiveQuote"
-                  @click="onCopyReusableOffer"
-                  class="cursor-pointer"
-                >
-                  <q-responsive :ratio="1" class="q-mx-none">
-                    <vue-qrcode
-                      :value="reusableQrValue"
-                      :options="{ width: 400 }"
-                      class="rounded-borders"
-                      style="width: 100%"
-                    >
-                    </vue-qrcode>
-                  </q-responsive>
-                </div>
-                <div
-                  v-if="reusableReceiveQuote && !activeMintErrored"
-                  class="q-mt-sm text-center text-grey-7"
-                  @click="onCopyReusableOffer"
-                >
-                  <q-icon
-                    :name="copyButtonCopied ? 'check' : 'content_copy'"
-                    size="xs"
-                    class="q-mr-xs"
-                  />
-                  {{
-                    copyButtonCopied
-                      ? $t("global.copy_to_clipboard.success")
-                      : isOnchain
-                      ? "Copy Address"
-                      : "Copy Offer"
-                  }}
-                </div>
+                <template v-else>
+                  <div
+                    class="qr-container cursor-pointer"
+                    @click="copyQrPreview"
+                  >
+                    <q-responsive :ratio="1" class="q-mx-none">
+                      <vue-qrcode
+                        :value="qrPreview.value"
+                        :options="{ width: 400 }"
+                        class="rounded-borders"
+                        style="width: 100%"
+                      >
+                      </vue-qrcode>
+                    </q-responsive>
+                  </div>
+                  <div
+                    class="q-mt-sm text-center text-grey-7 qr-copy-text cursor-pointer"
+                    :data-testid="
+                      qrPreview.kind === 'npubcash'
+                        ? 'npub-cash-lightning-address'
+                        : null
+                    "
+                    @click="copyQrPreview"
+                  >
+                    <q-icon
+                      :name="qrPreview.copied ? 'check' : 'content_copy'"
+                      size="xs"
+                      class="q-mr-xs"
+                    />
+                    {{ qrPreview.text }}
+                  </div>
+                </template>
               </div>
+            </div>
+            <div
+              v-else-if="isOnchain && checkingReusableOnchainQuote"
+              key="checking-onchain"
+              class="column items-center justify-center q-pa-xl q-my-auto"
+            >
+              <q-spinner size="48px" color="primary" />
+              <div class="text-grey-6 q-mt-md">Checking address...</div>
             </div>
 
             <AmountInputComponent
@@ -439,6 +404,33 @@ export default defineComponent({
     npubCashLnurl(): string {
       return lightningAddressToLnurl(this.npubCashAddress || "");
     },
+    qrPreview(): {
+      key: string;
+      kind: string;
+      value: string;
+      text: string;
+      copied: boolean;
+    } | null {
+      if (this.showNpubCashPreview) {
+        return {
+          key: "npub-cash-address",
+          kind: "npubcash",
+          value: this.npubCashLnurl,
+          text: this.npubCashAddress,
+          copied: this.npubCashAddressCopied,
+        };
+      }
+      if (!this.checkingReusableOnchainQuote && this.showReusableQuote) {
+        return {
+          key: "reusable-quote",
+          kind: "reusable",
+          value: this.reusableQrValue,
+          text: this.reusableReceiveQuote?.request || "",
+          copied: this.copyButtonCopied,
+        };
+      }
+      return null;
+    },
     canCreate(): boolean {
       if (this.activeMintErrored) return false;
       // Bolt11 requires amount > 0
@@ -557,6 +549,14 @@ export default defineComponent({
       this.$nextTick(() => {
         this.showNumericKeyboard = true;
       });
+    },
+    copyQrPreview() {
+      if (!this.qrPreview) return;
+      if (this.qrPreview.kind === "npubcash") {
+        this.copyNpubCashAddress();
+      } else {
+        this.onCopyReusableOffer();
+      }
     },
     async copyNpubCashAddress() {
       if (!this.npubCashAddress) return;
@@ -743,7 +743,7 @@ export default defineComponent({
   border-radius: 8px;
   overflow: hidden;
 }
-.npub-cash-address {
+.qr-copy-text {
   overflow-wrap: anywhere;
   word-break: break-all;
   -webkit-hyphens: none;

--- a/src/components/CreateInvoiceDialog.vue
+++ b/src/components/CreateInvoiceDialog.vue
@@ -231,7 +231,7 @@
                 type="submit"
                 :loading="globalMutexLock || createInvoiceButtonBlocked"
               >
-              {{ createButtonLabel }}
+                {{ createButtonLabel }}
                 <template v-slot:loading>
                   <q-spinner />
                 </template>
@@ -439,9 +439,7 @@ export default defineComponent({
         return this.showReusableQuote ? "New Offer" : "Create Offer";
       }
       if (this.isOnchain) {
-        return this.showReusableQuote
-          ? "Create New Address"
-          : "Create Address";
+        return this.showReusableQuote ? "Create New Address" : "Create Address";
       }
       return this.$t("InvoiceDetailDialog.actions.create.label") as string;
     },

--- a/src/components/CreateInvoiceDialog.vue
+++ b/src/components/CreateInvoiceDialog.vue
@@ -231,13 +231,7 @@
                 type="submit"
                 :loading="globalMutexLock || createInvoiceButtonBlocked"
               >
-                {{
-                  isBolt12
-                    ? "Create Offer"
-                    : isOnchain
-                    ? "Create Address"
-                    : $t("InvoiceDetailDialog.actions.create.label")
-                }}
+              {{ createButtonLabel }}
                 <template v-slot:loading>
                   <q-spinner />
                 </template>
@@ -439,6 +433,17 @@ export default defineComponent({
       return (
         this.invoiceData.amount != null && Number(this.invoiceData.amount) > 0
       );
+    },
+    createButtonLabel(): string {
+      if (this.isBolt12) {
+        return this.showReusableQuote ? "New Offer" : "Create Offer";
+      }
+      if (this.isOnchain) {
+        return this.showReusableQuote
+          ? "Create New Address"
+          : "Create Address";
+      }
+      return this.$t("InvoiceDetailDialog.actions.create.label") as string;
     },
     /**
      * Find a reusable Bolt12 offer from invoice history.

--- a/src/components/CreateInvoiceDialog.vue
+++ b/src/components/CreateInvoiceDialog.vue
@@ -32,7 +32,7 @@
               {{
                 isOnchain
                   ? "Receive On-chain"
-                  : isBolt12
+                  : isBolt12 && !showNpubCashPreview
                   ? "Receive Bolt12"
                   : $t("InvoiceDetailDialog.title")
               }}
@@ -76,86 +76,123 @@
         </div>
 
         <!-- Amount display -->
-        <div class="col column items-center justify-center q-px-lg amount-area">
-          <transition name="fade" mode="out-in">
+        <div class="col column items-center q-px-lg amount-area">
+          <transition name="receive-content" mode="out-in">
             <div
-              v-if="isOnchain && checkingReusableOnchainQuote"
+              v-if="showNpubCashPreview"
+              key="npub-cash-address"
+              class="row justify-center full-width q-mt-lg q-mb-auto"
+            >
+              <div class="col-12" style="max-width: 400px">
+                <div
+                  class="qr-container cursor-pointer"
+                  @click="copyNpubCashAddress"
+                >
+                  <q-responsive :ratio="1" class="q-mx-none">
+                    <vue-qrcode
+                      :value="npubCashLnurl"
+                      :options="{ width: 400 }"
+                      class="rounded-borders"
+                      style="width: 100%"
+                    >
+                    </vue-qrcode>
+                  </q-responsive>
+                </div>
+                <div
+                  class="q-mt-sm text-center text-grey-7 npub-cash-address cursor-pointer"
+                  data-testid="npub-cash-lightning-address"
+                  @click="copyNpubCashAddress"
+                >
+                  <q-icon
+                    :name="npubCashAddressCopied ? 'check' : 'content_copy'"
+                    size="xs"
+                    class="q-mr-xs"
+                  />
+                  {{ npubCashAddress }}
+                </div>
+              </div>
+            </div>
+            <div
+              v-else-if="isOnchain && checkingReusableOnchainQuote"
               key="checking-onchain"
-              class="column items-center justify-center q-pa-xl"
+              class="column items-center justify-center q-pa-xl q-my-auto"
             >
               <q-spinner size="48px" color="primary" />
               <div class="text-grey-6 q-mt-md">Checking address...</div>
             </div>
-          </transition>
-          <div
-            v-if="!checkingReusableOnchainQuote && showReusableQuote"
-            class="row justify-center full-width"
-          >
-            <div class="col-12" style="max-width: 400px">
-              <div
-                v-if="activeMintErrored"
-                class="mint-error-warning column items-center text-center q-pa-lg"
-              >
-                <q-icon name="warning" size="42px" color="warning" />
-                <div class="mint-error-title q-mt-md">Mint unreachable</div>
-                <div class="mint-error-text q-mt-sm">
-                  Reconnect to the mint to receive payments.
+            <div
+              v-else-if="!checkingReusableOnchainQuote && showReusableQuote"
+              key="reusable-quote"
+              class="row justify-center full-width q-my-auto"
+            >
+              <div class="col-12" style="max-width: 400px">
+                <div
+                  v-if="activeMintErrored"
+                  class="mint-error-warning column items-center text-center q-pa-lg"
+                >
+                  <q-icon name="warning" size="42px" color="warning" />
+                  <div class="mint-error-title q-mt-md">Mint unreachable</div>
+                  <div class="mint-error-text q-mt-sm">
+                    Reconnect to the mint to receive payments.
+                  </div>
+                  <q-btn
+                    flat
+                    dense
+                    no-caps
+                    color="primary"
+                    icon="refresh"
+                    class="q-mt-md"
+                    label="Reconnect mint"
+                    :loading="refreshingMint"
+                    @click="refreshActiveMint"
+                  />
                 </div>
-                <q-btn
-                  flat
-                  dense
-                  no-caps
-                  color="primary"
-                  icon="refresh"
-                  class="q-mt-md"
-                  label="Reconnect mint"
-                  :loading="refreshingMint"
-                  @click="refreshActiveMint"
-                />
-              </div>
-              <div
-                v-else-if="reusableReceiveQuote"
-                @click="onCopyReusableOffer"
-                class="cursor-pointer"
-              >
-                <q-responsive :ratio="1" class="q-mx-none">
-                  <vue-qrcode
-                    :value="reusableQrValue"
-                    :options="{ width: 400 }"
-                    class="rounded-borders"
-                    style="width: 100%"
-                  >
-                  </vue-qrcode>
-                </q-responsive>
-              </div>
-              <div
-                v-if="reusableReceiveQuote && !activeMintErrored"
-                class="q-mt-sm text-center text-grey-7"
-                @click="onCopyReusableOffer"
-              >
-                <q-icon
-                  :name="copyButtonCopied ? 'check' : 'content_copy'"
-                  size="xs"
-                  class="q-mr-xs"
-                />
-                {{
-                  copyButtonCopied
-                    ? $t("global.copy_to_clipboard.success")
-                    : isOnchain
-                    ? "Copy Address"
-                    : "Copy Offer"
-                }}
+                <div
+                  v-else-if="reusableReceiveQuote"
+                  @click="onCopyReusableOffer"
+                  class="cursor-pointer"
+                >
+                  <q-responsive :ratio="1" class="q-mx-none">
+                    <vue-qrcode
+                      :value="reusableQrValue"
+                      :options="{ width: 400 }"
+                      class="rounded-borders"
+                      style="width: 100%"
+                    >
+                    </vue-qrcode>
+                  </q-responsive>
+                </div>
+                <div
+                  v-if="reusableReceiveQuote && !activeMintErrored"
+                  class="q-mt-sm text-center text-grey-7"
+                  @click="onCopyReusableOffer"
+                >
+                  <q-icon
+                    :name="copyButtonCopied ? 'check' : 'content_copy'"
+                    size="xs"
+                    class="q-mr-xs"
+                  />
+                  {{
+                    copyButtonCopied
+                      ? $t("global.copy_to_clipboard.success")
+                      : isOnchain
+                      ? "Copy Address"
+                      : "Copy Offer"
+                  }}
+                </div>
               </div>
             </div>
-          </div>
 
-          <AmountInputComponent
-            v-if="showAmountInput"
-            v-model="invoiceData.amount"
-            :enabled="true"
-            @enter="requestMintButton"
-            @fiat-mode-changed="fiatKeyboardMode = $event"
-          />
+            <AmountInputComponent
+              v-else-if="showAmountInput"
+              key="amount-input"
+              class="q-my-auto"
+              v-model="invoiceData.amount"
+              :enabled="true"
+              @enter="requestMintButton"
+              @fiat-mode-changed="fiatKeyboardMode = $event"
+            />
+          </transition>
         </div>
 
         <!-- Numeric keypad -->
@@ -179,7 +216,10 @@
           </div>
 
           <!-- Secondary Actions Container (Add Amount) -->
-          <div class="row justify-center" v-if="isBolt12 && !showAmountInput">
+          <div
+            class="row justify-center"
+            v-if="isBolt12 && !showAmountInput && !showNpubCashPreview"
+          >
             <div
               class="col-12 col-sm-11 col-md-8 q-px-md"
               style="max-width: 600px"
@@ -196,13 +236,25 @@
             </div>
           </div>
 
-          <!-- Create action (Fixed position relative to bottom) -->
+          <!-- Primary action (Add amount / Create) -->
           <div class="row justify-center q-pb-lg q-pt-sm">
             <div
               class="col-12 col-sm-11 col-md-8 q-px-md"
               style="max-width: 600px"
             >
               <q-btn
+                v-if="showNpubCashPreview"
+                class="full-width"
+                unelevated
+                rounded
+                color="primary"
+                size="lg"
+                data-testid="npub-cash-add-amount"
+                :label="$t('PaymentRequestDialog.actions.add_amount.label')"
+                @click="enterNpubCashAmountMode"
+              />
+              <q-btn
+                v-else
                 class="full-width"
                 unelevated
                 data-testid="create-payment-request"
@@ -248,6 +300,8 @@ import { usePriceStore } from "src/stores/price";
 import type { InvoiceHistory } from "src/stores/wallet";
 import { PaymentMethod } from "src/stores/walletTypes";
 import { mintSupportsPaymentMethod } from "src/js/mint-payment-methods";
+import { useNpubCashStore } from "src/stores/npubcash";
+import { lightningAddressToLnurl } from "src/js/lnurl";
 
 declare const windowMixin: any;
 
@@ -266,6 +320,9 @@ export default defineComponent({
       createInvoiceButtonBlocked: false,
       fiatKeyboardMode: false as boolean,
       bolt12AddAmount: false as boolean,
+      npubCashAddAmount: false as boolean,
+      npubCashAddressCopied: false,
+      npubCashCopyTimeout: null as ReturnType<typeof setTimeout> | null,
       copyButtonCopied: false,
       copyButtonTimeout: null as any,
       refreshingMint: false,
@@ -293,6 +350,11 @@ export default defineComponent({
       "useNumericKeyboard",
     ]),
     ...mapState(usePriceStore, ["bitcoinPrice", "currentCurrencyPrice"]),
+    ...mapState(useNpubCashStore, {
+      npubCashEnabled: "enabled",
+      npubCashAddress: "address",
+      npubCashMintUrl: "mintUrl",
+    }),
     isBolt12(): boolean {
       return this.invoiceData.type === PaymentMethod.Bolt12;
     },
@@ -300,6 +362,7 @@ export default defineComponent({
       return this.invoiceData.type === PaymentMethod.Onchain;
     },
     showAmountInput(): boolean {
+      if (this.showNpubCashPreview) return false;
       if (this.isOnchain) return false;
       if (!this.isBolt12) return true;
       return this.bolt12AddAmount;
@@ -353,6 +416,28 @@ export default defineComponent({
     },
     activeMintErrored(): boolean {
       return Boolean(this.activeMint?.errored);
+    },
+    hasConfiguredNpubCashAddress(): boolean {
+      return Boolean(
+        this.npubCashEnabled &&
+          this.npubCashAddress &&
+          this.npubCashMintUrl &&
+          this.mints.some((mint: any) => mint.url === this.npubCashMintUrl)
+      );
+    },
+    showNpubCashPreview(): boolean {
+      return Boolean(
+        this.showCreateInvoiceDialog &&
+          !this.isOnchain &&
+          !this.isBolt12 &&
+          this.activeUnit === "sat" &&
+          !this.npubCashAddAmount &&
+          this.hasConfiguredNpubCashAddress &&
+          this.activeMintUrl === this.npubCashMintUrl
+      );
+    },
+    npubCashLnurl(): string {
+      return lightningAddressToLnurl(this.npubCashAddress || "");
     },
     canCreate(): boolean {
       if (this.activeMintErrored) return false;
@@ -426,10 +511,10 @@ export default defineComponent({
   watch: {
     showCreateInvoiceDialog: function (val) {
       if (val) {
+        this.npubCashAddAmount = false;
+        this.npubCashAddressCopied = false;
         this.$nextTick(() => {
-          // If editing a BOLT12 offer with existing amount, don't auto-show keyboard if amount exists?
-          // Actually user likely wants to edit.
-          this.showNumericKeyboard = true;
+          this.showNumericKeyboard = !this.showNpubCashPreview;
         });
         this.refreshReusableOnchainQuote();
       } else {
@@ -437,7 +522,15 @@ export default defineComponent({
       }
     },
     activeMintUrl: {
-      handler: function () {
+      handler: function (newMintUrl, oldMintUrl) {
+        if (
+          this.showCreateInvoiceDialog &&
+          !this.npubCashAddAmount &&
+          oldMintUrl === this.npubCashMintUrl &&
+          newMintUrl !== this.npubCashMintUrl
+        ) {
+          this.enterNpubCashAmountMode();
+        }
         this.syncInvoiceTypeWithActiveMint();
       },
       immediate: true,
@@ -458,6 +551,28 @@ export default defineComponent({
       "mintOnPaidOnchain",
     ]),
     ...mapActions(useMintsStore, ["activateMintUrl", "toggleUnit"]),
+    enterNpubCashAmountMode() {
+      this.npubCashAddAmount = true;
+      this.invoiceData.amount = "";
+      this.$nextTick(() => {
+        this.showNumericKeyboard = true;
+      });
+    },
+    async copyNpubCashAddress() {
+      if (!this.npubCashAddress) return;
+      try {
+        await copyToClipboard(this.npubCashAddress);
+        this.npubCashAddressCopied = true;
+        if (this.npubCashCopyTimeout) {
+          clearTimeout(this.npubCashCopyTimeout);
+        }
+        this.npubCashCopyTimeout = setTimeout(() => {
+          this.npubCashAddressCopied = false;
+        }, 3000);
+      } catch (error) {
+        console.error("Failed to copy lightning address:", error);
+      }
+    },
     toggleInvoiceType() {
       if (this.isBolt12) {
         this.invoiceData.type = PaymentMethod.Bolt11;
@@ -593,6 +708,9 @@ export default defineComponent({
     if (this.copyButtonTimeout) {
       clearTimeout(this.copyButtonTimeout);
     }
+    if (this.npubCashCopyTimeout) {
+      clearTimeout(this.npubCashCopyTimeout);
+    }
   },
 });
 </script>
@@ -618,6 +736,37 @@ export default defineComponent({
 }
 .amount-area {
   flex: 1;
+  min-height: 0;
+}
+.qr-container {
+  position: relative;
+  border-radius: 8px;
+  overflow: hidden;
+}
+.npub-cash-address {
+  overflow-wrap: anywhere;
+  word-break: break-all;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  hyphens: none;
+  font-size: 0.9em;
+  font-family: monospace;
+}
+.receive-content-enter-active,
+.receive-content-leave-active {
+  transition: opacity 180ms ease;
+}
+.receive-content-enter-from {
+  opacity: 0;
+}
+.receive-content-leave-to {
+  opacity: 0;
+}
+@media (prefers-reduced-motion: reduce) {
+  .receive-content-enter-active,
+  .receive-content-leave-active {
+    transition: none;
+  }
 }
 .amount-container {
   position: relative;

--- a/src/components/NumericKeyboard.vue
+++ b/src/components/NumericKeyboard.vue
@@ -176,7 +176,7 @@ export default defineComponent({
 .slide-up-fade-leave-active {
   transition: transform 0.3s ease, opacity 0.3s ease;
 }
-.slide-up-fade-enter,
+.slide-up-fade-enter-from,
 .slide-up-fade-leave-to {
   transform: translateY(100%);
   opacity: 0;

--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -118,6 +118,7 @@ import {
   Bitcoin as BitcoinIcon,
 } from "lucide-vue-next";
 import { PaymentMethod } from "src/stores/walletTypes";
+import { useNpubCashStore } from "src/stores/npubcash";
 import {
   ensurePaymentMintActive,
   firstMintSupportingPaymentMethods,
@@ -155,6 +156,19 @@ export default defineComponent({
     ]),
     ...mapWritableState(useWalletStore, ["invoiceData"]),
     ...mapState(useMintsStore, ["mints", "activeMintUrl", "activeUnit"]),
+    ...mapState(useNpubCashStore, {
+      npubCashEnabled: "enabled",
+      npubCashAddress: "address",
+      npubCashMintUrl: "mintUrl",
+    }),
+    hasConfiguredNpubCashAddress: function (): boolean {
+      return Boolean(
+        this.npubCashEnabled &&
+          this.npubCashAddress &&
+          this.npubCashMintUrl &&
+          this.mints.some((mint: any) => mint.url === this.npubCashMintUrl)
+      );
+    },
     canReceivePayments: function () {
       if (!this.mints.length) {
         return false;
@@ -198,6 +212,9 @@ export default defineComponent({
       this.showReceiveDialog = false;
     },
     showInvoiceCreateDialog: async function () {
+      if (this.hasConfiguredNpubCashAddress && this.npubCashMintUrl) {
+        this.selectMintUrl(this.npubCashMintUrl);
+      }
       const mintResult = await ensurePaymentMintActive(
         this.mints as any,
         this.activeMintUrl as string,

--- a/src/js/__tests__/lnurl.test.ts
+++ b/src/js/__tests__/lnurl.test.ts
@@ -1,0 +1,37 @@
+import { bech32 } from "bech32";
+import { describe, expect, it } from "vitest";
+import { lightningAddressToLnurl } from "src/js/lnurl";
+
+function decodeLnurl(lnurl: string): string {
+  const decoded = bech32.decode(lnurl, 2000);
+  return new TextDecoder().decode(
+    new Uint8Array(bech32.fromWords(decoded.words))
+  );
+}
+
+describe("lightningAddressToLnurl", () => {
+  it("encodes the Lightning Address well-known endpoint", () => {
+    const lnurl = lightningAddressToLnurl("alice@npub.cash");
+
+    expect(lnurl).toMatch(/^LNURL1/);
+    expect(decodeLnurl(lnurl)).toBe(
+      "https://npub.cash/.well-known/lnurlp/alice"
+    );
+  });
+
+  it("encodes npub usernames without truncating them", () => {
+    const username = "npub1example";
+    const lnurl = lightningAddressToLnurl(`${username}@npub.cash`);
+
+    expect(decodeLnurl(lnurl)).toBe(
+      `https://npub.cash/.well-known/lnurlp/${username}`
+    );
+  });
+
+  it.each(["", "alice", "@npub.cash", "alice@"])(
+    "rejects an incomplete Lightning Address: %s",
+    (address) => {
+      expect(lightningAddressToLnurl(address)).toBe("");
+    }
+  );
+});

--- a/src/js/lnurl.ts
+++ b/src/js/lnurl.ts
@@ -1,0 +1,18 @@
+import { bech32 } from "bech32";
+
+export function lightningAddressToLnurl(address: string): string {
+  const separator = address.lastIndexOf("@");
+  if (separator <= 0 || separator === address.length - 1) {
+    return "";
+  }
+
+  const username = address.slice(0, separator);
+  const hostname = address.slice(separator + 1);
+  const endpoint = `https://${hostname}/.well-known/lnurlp/${encodeURIComponent(
+    username
+  )}`;
+
+  return bech32
+    .encode("lnurl", bech32.toWords(new TextEncoder().encode(endpoint)), 2000)
+    .toUpperCase();
+}


### PR DESCRIPTION
## Summary

Overhauls the lightning address QR receive view in the create invoice dialog:

- **QR rendering**: uses the same `q-responsive` square pattern as the invoice detail page, so the QR always fills its square without being cropped on the right
- **Address styling**: lightning address is now grey monospace (matching the rest of the wallet) and wraps when too long
- **Top bar**: B11/B12 method toggle and unit toggle stay visible while the QR is shown; the QR is only shown when bolt11 and sats are selected
- **Button alignment**: "Add amount" and "Create invoice" now share one slot, so the button stays pixel-aligned when the keyboard appears
- **Smooth transition fix**: the QR no longer gets pushed up while fading out

## Root cause of the QR jump

When the keypad mounts, the content area shrinks below the QR's height. With negative free space in a flex column, `margin-bottom: auto` collapses to 0 (auto margins only absorb *positive* free space), so `justify-center` re-centered the QR and split the overflow both ways — shoving it up ~115px mid-fade. Verified with a headless-Chrome layout reproduction.

Fix: removed `justify-center` from the content area; children center via auto margins, which collapse to top-alignment on overflow so content can never be pushed up. Leave transition is now a pure opacity fade.

Also fixes the numeric keyboard's slide-up transition, which used the Vue 2 class `.slide-up-fade-enter` (never applied in Vue 3) and popped in instantly instead of animating.

## Test plan

- [ ] Open receive view with a configured npub.cash address: QR fills its square, address is grey monospace and wraps
- [ ] Tap "Add amount": QR fades in place, keyboard slides up, button doesn't move
- [ ] Toggle B11/B12 and units while QR is shown: falls back to amount/offer flow
- [ ] `npm run lint` and `npx vitest run` pass (171 tests)