### PR TITLE
Fix npub.cash mint update feedback

### DIFF
--- a/src/pages/settings/LightningAddressSettings.vue
+++ b/src/pages/settings/LightningAddressSettings.vue
@@ -148,7 +148,7 @@ export default defineComponent({
     },
     mintUrl: async function (newMintUrl, oldMintUrl) {
       if (this.enabled && newMintUrl && newMintUrl !== oldMintUrl) {
-        await this.changeMintUrl(newMintUrl);
+        await this.changeMintUrl(newMintUrl, oldMintUrl);
       }
     },
   },

--- a/src/stores/__tests__/npubcash.test.ts
+++ b/src/stores/__tests__/npubcash.test.ts
@@ -20,6 +20,11 @@ vi.mock("vue-i18n", async (importOriginal) => {
   };
 });
 
+vi.mock("src/js/notify", () => ({
+  notifyApiError: vi.fn(),
+  notifyError: vi.fn(),
+}));
+
 class MockQuoteWebSocket {
   static CONNECTING = 0;
   static OPEN = 1;
@@ -190,6 +195,60 @@ describe("npub.cash store", () => {
     await store.initializeNpubCash();
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("shows loading while changing the npub.cash mint", async () => {
+    const previousMintUrl = "https://mint.previous";
+    const mintUrl = "https://mint.next";
+    const store = useNpubCashStore();
+    store.mintUrl = mintUrl;
+    useMintsStore().mints = [
+      { url: previousMintUrl, keys: [], keysets: [] },
+      { url: mintUrl, keys: [], keysets: [] },
+    ];
+
+    let resolveRequest: (response: Response) => void;
+    vi.spyOn(store, "sendAuthedRequest").mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveRequest = resolve;
+      })
+    );
+
+    const changeMint = store.changeMintUrl(mintUrl, previousMintUrl);
+
+    expect(store.loading).toBe(true);
+
+    resolveRequest!(
+      new Response(
+        JSON.stringify({
+          error: false,
+          data: { user: { mintUrl } },
+        })
+      )
+    );
+    await changeMint;
+
+    expect(store.loading).toBe(false);
+    expect(store.mintUrl).toBe(mintUrl);
+  });
+
+  it("restores the previous mint when changing the npub.cash mint fails", async () => {
+    const previousMintUrl = "https://mint.previous";
+    const mintUrl = "https://mint.next";
+    const store = useNpubCashStore();
+    store.mintUrl = mintUrl;
+    useMintsStore().mints = [
+      { url: previousMintUrl, keys: [], keysets: [] },
+      { url: mintUrl, keys: [], keysets: [] },
+    ];
+    vi.spyOn(store, "sendAuthedRequest").mockResolvedValue(
+      new Response(JSON.stringify({ error: true, message: "Mint unavailable" }))
+    );
+
+    await store.changeMintUrl(mintUrl, previousMintUrl);
+
+    expect(store.mintUrl).toBe(previousMintUrl);
+    expect(store.loading).toBe(false);
   });
 
   it("initializes the signer before assigning an address", async () => {

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -347,7 +347,10 @@ export const useNpubCashStore = defineStore("npubCash", {
         };
       }
     },
-    changeMintUrl: async function (mintUrl: string) {
+    changeMintUrl: async function (
+      mintUrl: string,
+      previousMintUrl: string | null = this.mintUrl
+    ) {
       const mintsStore = useMintsStore();
       if (!mintsStore.mints.find((mint) => mint.url === mintUrl)) {
         notifyError(
@@ -356,6 +359,7 @@ export const useNpubCashStore = defineStore("npubCash", {
         );
         return;
       }
+      this.loading = true;
       try {
         const response = await this.sendAuthedRequest(
           `${npubCashHttpUrl(this.baseHost)}/api/v2/user/mint`,
@@ -373,12 +377,17 @@ export const useNpubCashStore = defineStore("npubCash", {
         }
         this.mintUrl = data.data.user.mintUrl;
       } catch (error) {
+        if (this.mintUrl === mintUrl) {
+          this.mintUrl = previousMintUrl;
+        }
         console.log(error);
         if (error instanceof Error) {
           notifyError(error.message);
         } else {
           notifyError("Something went wrong!");
         }
+      } finally {
+        this.loading = false;
       }
     },
     synchronizeQuotes: async function (): Promise<void> {


### PR DESCRIPTION
## Summary
- show the existing npub.cash loading indicator while the selected mint is being updated
- restore the prior mint selection when the mint PATCH request fails
- cover the loading and rollback behavior with store tests

## Testing
- npx vitest run src/stores/__tests__/npubcash.test.ts src/pages/settings/__tests__/LightningAddressSettings.test.ts
- npm run lint