### PR TITLE
feat: show copiable onchain address below invoice QR

### DIFF
--- a/src/components/InvoiceDetailDialog.vue
+++ b/src/components/InvoiceDetailDialog.vue
@@ -85,6 +85,18 @@
                     color="primary"
                   />
                 </div>
+                <div
+                  v-if="isOnchain"
+                  class="q-mt-sm text-center text-grey-7 qr-copy-text cursor-pointer"
+                  @click="onCopyBolt11"
+                >
+                  <q-icon
+                    :name="copyButtonCopied ? 'check' : 'content_copy'"
+                    size="xs"
+                    class="q-mr-xs"
+                  />
+                  {{ invoiceData.request }}
+                </div>
               </div>
             </div>
 
@@ -320,6 +332,16 @@ export default defineComponent({
   position: relative;
   border-radius: 8px;
   overflow: hidden;
+}
+
+.qr-copy-text {
+  overflow-wrap: anywhere;
+  word-break: break-all;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  hyphens: none;
+  font-size: 0.9em;
+  font-family: monospace;
 }
 
 .checkmark-overlay {


### PR DESCRIPTION
## Summary

In the invoice detail view for incoming onchain transactions, the onchain address is now shown below the QR code as a copiable bottom text — same style and behavior as the address display in the receive screen:

- Grey monospace text that wraps when long
- Copy icon that turns into a check on copy
- Clicking it copies the address (reuses `onCopyBolt11`, so the feedback stays in sync with the bottom copy button)

Only shown for onchain invoices (`v-if="isOnchain"`).

## Test plan

- [ ] Open details of an incoming onchain transaction: address appears below the QR in grey monospace, wraps on narrow screens
- [ ] Click the address: copied to clipboard, icon turns into a check for 3s
- [ ] Bolt11/Bolt12 invoice details unchanged
- [ ] `npm run lint` and `npx vitest run` pass (173 tests)