### PR TITLE
feat: add Lightning address receive preview toggle

### DIFF
--- a/src/components/CreateInvoiceDialog.vue
+++ b/src/components/CreateInvoiceDialog.vue
@@ -313,6 +313,7 @@ export default defineComponent({
       npubCashEnabled: "enabled",
       npubCashAddress: "address",
       npubCashMintUrl: "mintUrl",
+      showAddressOnReceive: "showAddressOnReceive",
     }),
     isBolt12(): boolean {
       return this.invoiceData.type === PaymentMethod.Bolt12;
@@ -392,6 +393,7 @@ export default defineComponent({
           this.activeUnit === "sat" &&
           !this.npubCashAddAmount &&
           this.hasConfiguredNpubCashAddress &&
+          this.showAddressOnReceive &&
           this.activeMintUrl === this.npubCashMintUrl
       );
     },

--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -160,6 +160,7 @@ export default defineComponent({
       npubCashEnabled: "enabled",
       npubCashAddress: "address",
       npubCashMintUrl: "mintUrl",
+      showAddressOnReceive: "showAddressOnReceive",
     }),
     hasConfiguredNpubCashAddress: function (): boolean {
       return Boolean(
@@ -212,7 +213,11 @@ export default defineComponent({
       this.showReceiveDialog = false;
     },
     showInvoiceCreateDialog: async function () {
-      if (this.hasConfiguredNpubCashAddress && this.npubCashMintUrl) {
+      if (
+        this.showAddressOnReceive &&
+        this.hasConfiguredNpubCashAddress &&
+        this.npubCashMintUrl
+      ) {
         this.selectMintUrl(this.npubCashMintUrl);
       }
       const mintResult = await ensurePaymentMintActive(

--- a/src/components/__tests__/CreateInvoiceDialog.test.ts
+++ b/src/components/__tests__/CreateInvoiceDialog.test.ts
@@ -1,0 +1,48 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+let CreateInvoiceDialog: any;
+
+beforeAll(async () => {
+  (globalThis as any).windowMixin = {};
+  CreateInvoiceDialog = (await import("../CreateInvoiceDialog.vue")).default;
+});
+
+describe("CreateInvoiceDialog", () => {
+  it("uses the amount-first flow when showing the Lightning address is disabled", () => {
+    const showNpubCashPreview =
+      CreateInvoiceDialog.computed.showNpubCashPreview;
+
+    expect(
+      showNpubCashPreview.call({
+        showCreateInvoiceDialog: true,
+        isOnchain: false,
+        isBolt12: false,
+        activeUnit: "sat",
+        npubCashAddAmount: false,
+        hasConfiguredNpubCashAddress: true,
+        showAddressOnReceive: false,
+        activeMintUrl: "https://mint.example",
+        npubCashMintUrl: "https://mint.example",
+      }),
+    ).toBe(false);
+  });
+
+  it("shows the Lightning address preview by default when it is enabled", () => {
+    const showNpubCashPreview =
+      CreateInvoiceDialog.computed.showNpubCashPreview;
+
+    expect(
+      showNpubCashPreview.call({
+        showCreateInvoiceDialog: true,
+        isOnchain: false,
+        isBolt12: false,
+        activeUnit: "sat",
+        npubCashAddAmount: false,
+        hasConfiguredNpubCashAddress: true,
+        showAddressOnReceive: true,
+        activeMintUrl: "https://mint.example",
+        npubCashMintUrl: "https://mint.example",
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/components/__tests__/CreateInvoiceDialog.test.ts
+++ b/src/components/__tests__/CreateInvoiceDialog.test.ts
@@ -23,7 +23,7 @@ describe("CreateInvoiceDialog", () => {
         showAddressOnReceive: false,
         activeMintUrl: "https://mint.example",
         npubCashMintUrl: "https://mint.example",
-      }),
+      })
     ).toBe(false);
   });
 
@@ -42,7 +42,7 @@ describe("CreateInvoiceDialog", () => {
         showAddressOnReceive: true,
         activeMintUrl: "https://mint.example",
         npubCashMintUrl: "https://mint.example",
-      }),
+      })
     ).toBe(true);
   });
 });

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -275,6 +275,10 @@ export default {
       address: {
         copy_tooltip: "نسخ عنوان Lightning",
       },
+      show_on_receive: {
+        toggle: "إظهار عند الاستلام",
+        description: "اعرض عنوان Lightning ورمز QR قبل إدخال المبلغ.",
+      },
       automatic_claim: {
         toggle: "المطالبة تلقائيًا",
         description: "استلام المدفوعات الواردة تلقائيًا.",

--- a/src/i18n/cs-CZ/index.ts
+++ b/src/i18n/cs-CZ/index.ts
@@ -281,6 +281,10 @@ export default {
       address: {
         copy_tooltip: "Kopírovat Lightning adresu",
       },
+      show_on_receive: {
+        toggle: "Zobrazit při přijímání",
+        description: "Před zadáním částky zobrazí Lightning adresu a QR kód.",
+      },
       automatic_claim: {
         toggle: "Přijímat automaticky",
         description: "Automaticky přijímat příchozí platby.",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -279,6 +279,11 @@ export default {
       address: {
         copy_tooltip: "Lightning Adresse kopieren",
       },
+      show_on_receive: {
+        toggle: "Beim Empfangen anzeigen",
+        description:
+          "Zeige deine Lightning-Adresse und den QR-Code, bevor du einen Betrag eingibst.",
+      },
       automatic_claim: {
         toggle: "Automatisch beanspruchen",
         description: "Eingehende Zahlungen automatisch empfangen.",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -278,6 +278,11 @@ export default {
       address: {
         copy_tooltip: "Αντιγραφή διεύθυνσης Lightning",
       },
+      show_on_receive: {
+        toggle: "Εμφάνιση κατά τη λήψη",
+        description:
+          "Εμφάνιση της διεύθυνσης Lightning και του κωδικού QR πριν την εισαγωγή ποσού.",
+      },
       automatic_claim: {
         toggle: "Αυτόματη διεκδίκηση",
         description: "Λήψη εισερχόμενων πληρωμών αυτόματα.",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -285,6 +285,11 @@ export default {
       address: {
         copy_tooltip: "Copy Lightning address",
       },
+      show_on_receive: {
+        toggle: "Show when receiving",
+        description:
+          "Show your Lightning address and QR code before entering an amount.",
+      },
       automatic_claim: {
         toggle: "Claim automatically",
         description: "Receive incoming payments automatically.",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -277,6 +277,11 @@ export default {
       address: {
         copy_tooltip: "Copiar dirección Lightning",
       },
+      show_on_receive: {
+        toggle: "Mostrar al recibir",
+        description:
+          "Muestra tu dirección Lightning y el código QR antes de introducir un importe.",
+      },
       automatic_claim: {
         toggle: "Reclamar automáticamente",
         description: "Recibir pagos entrantes automáticamente.",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -278,6 +278,11 @@ export default {
       address: {
         copy_tooltip: "Copier l'adresse Lightning",
       },
+      show_on_receive: {
+        toggle: "Afficher à la réception",
+        description:
+          "Affiche votre adresse Lightning et le code QR avant de saisir un montant.",
+      },
       automatic_claim: {
         toggle: "Réclamer automatiquement",
         description: "Recevez les paiements entrants automatiquement.",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -250,6 +250,11 @@ export default {
       address: {
         copy_tooltip: "Copia indirizzo Lightning",
       },
+      show_on_receive: {
+        toggle: "Mostra durante la ricezione",
+        description:
+          "Mostra il tuo indirizzo Lightning e il codice QR prima di inserire un importo.",
+      },
       automatic_claim: {
         toggle: "Richiedi automaticamente",
         description: "Ricevi pagamenti in entrata automaticamente.",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -275,6 +275,11 @@ export default {
       address: {
         copy_tooltip: "Lightningアドレスをコピー",
       },
+      show_on_receive: {
+        toggle: "受け取り時に表示",
+        description:
+          "金額を入力する前にLightningアドレスとQRコードを表示します。",
+      },
       automatic_claim: {
         toggle: "自動的に請求",
         description: "着信支払いを自動的に受け取ります。",

--- a/src/i18n/pt-BR/index.ts
+++ b/src/i18n/pt-BR/index.ts
@@ -285,6 +285,11 @@ export default {
       address: {
         copy_tooltip: "Copiar endereço Lightning",
       },
+      show_on_receive: {
+        toggle: "Mostrar ao receber",
+        description:
+          "Mostra seu endereço Lightning e o código QR antes de informar um valor.",
+      },
       automatic_claim: {
         toggle: "Reivindicar automaticamente",
         description: "Receba pagamentos recebidos automaticamente.",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -291,6 +291,11 @@ export default {
       address: {
         copy_tooltip: "Kopiera Lightning-adress",
       },
+      show_on_receive: {
+        toggle: "Visa vid mottagning",
+        description:
+          "Visa din Lightning-adress och QR-kod innan du anger ett belopp.",
+      },
       automatic_claim: {
         toggle: "Hämta automatiskt",
         description: "Ta emot inkommande betalningar automatiskt.",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -292,6 +292,10 @@ export default {
       address: {
         copy_tooltip: "คัดลอกที่อยู่ Lightning",
       },
+      show_on_receive: {
+        toggle: "แสดงเมื่อรับเงิน",
+        description: "แสดงที่อยู่ Lightning และรหัส QR ก่อนกรอกจำนวนเงิน",
+      },
       automatic_claim: {
         toggle: "รับอัตโนมัติ",
         description: "รับการชำระเงินขาเข้าโดยอัตโนมัติ",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -282,6 +282,11 @@ export default {
       address: {
         copy_tooltip: "Lightning adresini kopyala",
       },
+      show_on_receive: {
+        toggle: "Alırken göster",
+        description:
+          "Tutar girmeden önce Lightning adresinizi ve QR kodunu gösterir.",
+      },
       automatic_claim: {
         toggle: "Otomatik olarak talep et",
         description: "Gelen ödemeleri otomatik olarak alın.",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -293,6 +293,10 @@ export default {
       address: {
         copy_tooltip: "复制 Lightning 地址",
       },
+      show_on_receive: {
+        toggle: "收款时显示",
+        description: "输入金额前显示您的 Lightning 地址和二维码。",
+      },
       automatic_claim: {
         toggle: "自动认领",
         description: "自动接收收到的支付。",

--- a/src/pages/settings/LightningAddressSettings.vue
+++ b/src/pages/settings/LightningAddressSettings.vue
@@ -41,6 +41,19 @@
             </q-input>
           </q-item-section>
         </q-item>
+        <q-item tag="label">
+          <q-item-section>
+            <q-item-label>{{
+              $t("Settings.lightning_address.show_on_receive.toggle")
+            }}</q-item-label>
+            <q-item-label caption>{{
+              $t("Settings.lightning_address.show_on_receive.description")
+            }}</q-item-label>
+          </q-item-section>
+          <q-item-section side>
+            <q-toggle v-model="showAddressOnReceive" color="primary" />
+          </q-item-section>
+        </q-item>
         <q-item class="settings-control-item">
           <q-item-section>
             <q-item-label caption class="q-mb-sm">{{
@@ -129,6 +142,7 @@ export default defineComponent({
       "address",
       "mintUrl",
       "claimAutomatically",
+      "showAddressOnReceive",
     ]),
   },
   watch: {

--- a/src/pages/settings/__tests__/LightningAddressSettings.test.ts
+++ b/src/pages/settings/__tests__/LightningAddressSettings.test.ts
@@ -57,6 +57,9 @@ describe("LightningAddressSettings", () => {
     expect(advanced.text()).toContain(
       "Settings.lightning_address.automatic_claim.toggle"
     );
+    expect(wrapper.text()).toContain(
+      "Settings.lightning_address.show_on_receive.toggle"
+    );
   });
 
   it("writes the normalized HTTPS URL back into the input", async () => {

--- a/src/stores/__tests__/npubcash.test.ts
+++ b/src/stores/__tests__/npubcash.test.ts
@@ -76,6 +76,7 @@ describe("npub.cash store", () => {
     expect(store.$state).toMatchObject({
       enabled: false,
       claimAutomatically: true,
+      showAddressOnReceive: true,
       lastCheck: null,
       address: "",
       mintUrl: null,

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -237,6 +237,10 @@ export const useNpubCashStore = defineStore("npubCash", {
         `${NPUB_CASH_STORAGE_PREFIX}.claimAutomatically`,
         true
       ),
+      showAddressOnReceive: useLocalStorage<boolean>(
+        `${NPUB_CASH_STORAGE_PREFIX}.showAddressOnReceive`,
+        true
+      ),
       lastCheck: useLocalStorage<number | null>(
         `${NPUB_CASH_STORAGE_PREFIX}.lastCheck`,
         null,


### PR DESCRIPTION
## Summary
- add a persisted Lightning Address setting to control the immediate address and QR preview
- restore the amount-and-keyboard receive flow, without switching mints, when it is disabled
- add translations and focused coverage for the default and opt-out behaviors

## Verification
- npm run lint
- npm run build
- vitest run src/stores/__tests__/npubcash.test.ts src/pages/settings/__tests__/LightningAddressSettings.test.ts src/components/__tests__/CreateInvoiceDialog.test.ts