### PR TITLE
Avoid reusing paid on-chain receive addresses

### DIFF
--- a/src/components/CreateInvoiceDialog.vue
+++ b/src/components/CreateInvoiceDialog.vue
@@ -689,8 +689,8 @@ export default defineComponent({
         .filter((invoice: InvoiceHistory) => {
           if (invoice.type !== PaymentMethod.Onchain) return false;
           if (invoice.amount < 0) return false;
-          if (invoice.status !== "pending" && invoice.status !== "paid")
-            return false;
+          // A paid address must never be offered again, to avoid address reuse.
+          if (invoice.status !== "pending") return false;
           const quote = invoice.mintQuote as any;
           if (quote?.expiry && quote.expiry > 0 && quote.expiry * 1000 < now) {
             return false;

--- a/src/components/__tests__/CreateInvoiceDialog.test.ts
+++ b/src/components/__tests__/CreateInvoiceDialog.test.ts
@@ -1,4 +1,22 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { PaymentMethod } from "src/stores/walletTypes";
+
+const stores = vi.hoisted(() => ({
+  wallet: { invoiceHistory: [] as any[] },
+  mints: {
+    activeMintUrl: "https://mint.example",
+    activeUnit: "sat",
+    mints: [] as any[],
+  },
+}));
+
+vi.mock("src/stores/wallet", () => ({
+  useWalletStore: () => stores.wallet,
+}));
+
+vi.mock("src/stores/mints", () => ({
+  useMintsStore: () => stores.mints,
+}));
 
 let CreateInvoiceDialog: any;
 
@@ -44,5 +62,24 @@ describe("CreateInvoiceDialog", () => {
         npubCashMintUrl: "https://mint.example",
       })
     ).toBe(true);
+  });
+
+  it("does not reuse an on-chain address after it has been paid", () => {
+    stores.wallet.invoiceHistory = [
+      {
+        amount: 100,
+        date: "2026-08-18T00:00:00.000Z",
+        mint: "https://mint.example",
+        request: "bc1qalreadyusedaddress",
+        status: "paid",
+        type: PaymentMethod.Onchain,
+        unit: "sat",
+      },
+    ] as any;
+
+    const reusableQuotes =
+      CreateInvoiceDialog.methods.findReusableOnchainQuotes.call({});
+
+    expect(reusableQuotes).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- only reuse pending on-chain receive addresses in the initial QR preview
- show the create-address flow when a prior address has already been paid
- add regression coverage for paid address history

## Verification
- ./node_modules/.bin/vitest run src/components/__tests__/CreateInvoiceDialog.test.ts
- ./node_modules/.bin/eslint src/components/CreateInvoiceDialog.vue src/components/__tests__/CreateInvoiceDialog.test.ts
- ./node_modules/.bin/prettier --check src/components/CreateInvoiceDialog.vue src/components/__tests__/CreateInvoiceDialog.test.ts