### PR TITLE
refactor: move Lightning receive preview option to advanced

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -277,7 +277,7 @@ export default {
       },
       show_on_receive: {
         toggle: "إظهار عند الاستلام",
-        description: "اعرض عنوان Lightning ورمز QR قبل إدخال المبلغ.",
+        description: "إظهار العنوان ورمز QR.",
       },
       automatic_claim: {
         toggle: "المطالبة تلقائيًا",

--- a/src/i18n/cs-CZ/index.ts
+++ b/src/i18n/cs-CZ/index.ts
@@ -283,7 +283,7 @@ export default {
       },
       show_on_receive: {
         toggle: "Zobrazit při přijímání",
-        description: "Před zadáním částky zobrazí Lightning adresu a QR kód.",
+        description: "Zobrazit adresu a QR kód.",
       },
       automatic_claim: {
         toggle: "Přijímat automaticky",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -281,8 +281,7 @@ export default {
       },
       show_on_receive: {
         toggle: "Beim Empfangen anzeigen",
-        description:
-          "Zeige deine Lightning-Adresse und den QR-Code, bevor du einen Betrag eingibst.",
+        description: "Adresse und QR-Code anzeigen.",
       },
       automatic_claim: {
         toggle: "Automatisch beanspruchen",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -280,8 +280,7 @@ export default {
       },
       show_on_receive: {
         toggle: "Εμφάνιση κατά τη λήψη",
-        description:
-          "Εμφάνιση της διεύθυνσης Lightning και του κωδικού QR πριν την εισαγωγή ποσού.",
+        description: "Εμφάνιση διεύθυνσης και κωδικού QR.",
       },
       automatic_claim: {
         toggle: "Αυτόματη διεκδίκηση",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -287,8 +287,7 @@ export default {
       },
       show_on_receive: {
         toggle: "Show when receiving",
-        description:
-          "Show your Lightning address and QR code before entering an amount.",
+        description: "Show address and QR code.",
       },
       automatic_claim: {
         toggle: "Claim automatically",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -279,8 +279,7 @@ export default {
       },
       show_on_receive: {
         toggle: "Mostrar al recibir",
-        description:
-          "Muestra tu dirección Lightning y el código QR antes de introducir un importe.",
+        description: "Mostrar dirección y código QR.",
       },
       automatic_claim: {
         toggle: "Reclamar automáticamente",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -280,8 +280,7 @@ export default {
       },
       show_on_receive: {
         toggle: "Afficher à la réception",
-        description:
-          "Affiche votre adresse Lightning et le code QR avant de saisir un montant.",
+        description: "Afficher l'adresse et le code QR.",
       },
       automatic_claim: {
         toggle: "Réclamer automatiquement",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -252,8 +252,7 @@ export default {
       },
       show_on_receive: {
         toggle: "Mostra durante la ricezione",
-        description:
-          "Mostra il tuo indirizzo Lightning e il codice QR prima di inserire un importo.",
+        description: "Mostra indirizzo e codice QR.",
       },
       automatic_claim: {
         toggle: "Richiedi automaticamente",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -277,8 +277,7 @@ export default {
       },
       show_on_receive: {
         toggle: "受け取り時に表示",
-        description:
-          "金額を入力する前にLightningアドレスとQRコードを表示します。",
+        description: "アドレスとQRコードを表示",
       },
       automatic_claim: {
         toggle: "自動的に請求",

--- a/src/i18n/pt-BR/index.ts
+++ b/src/i18n/pt-BR/index.ts
@@ -287,8 +287,7 @@ export default {
       },
       show_on_receive: {
         toggle: "Mostrar ao receber",
-        description:
-          "Mostra seu endereço Lightning e o código QR antes de informar um valor.",
+        description: "Mostrar endereço e código QR.",
       },
       automatic_claim: {
         toggle: "Reivindicar automaticamente",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -293,8 +293,7 @@ export default {
       },
       show_on_receive: {
         toggle: "Visa vid mottagning",
-        description:
-          "Visa din Lightning-adress och QR-kod innan du anger ett belopp.",
+        description: "Visa adress och QR-kod.",
       },
       automatic_claim: {
         toggle: "Hämta automatiskt",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -294,7 +294,7 @@ export default {
       },
       show_on_receive: {
         toggle: "แสดงเมื่อรับเงิน",
-        description: "แสดงที่อยู่ Lightning และรหัส QR ก่อนกรอกจำนวนเงิน",
+        description: "แสดงที่อยู่และรหัส QR",
       },
       automatic_claim: {
         toggle: "รับอัตโนมัติ",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -284,8 +284,7 @@ export default {
       },
       show_on_receive: {
         toggle: "Alırken göster",
-        description:
-          "Tutar girmeden önce Lightning adresinizi ve QR kodunu gösterir.",
+        description: "Adres ve QR kodunu göster.",
       },
       automatic_claim: {
         toggle: "Otomatik olarak talep et",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -295,7 +295,7 @@ export default {
       },
       show_on_receive: {
         toggle: "收款时显示",
-        description: "输入金额前显示您的 Lightning 地址和二维码。",
+        description: "显示地址和二维码。",
       },
       automatic_claim: {
         toggle: "自动认领",

--- a/src/pages/settings/LightningAddressSettings.vue
+++ b/src/pages/settings/LightningAddressSettings.vue
@@ -41,19 +41,6 @@
             </q-input>
           </q-item-section>
         </q-item>
-        <q-item tag="label">
-          <q-item-section>
-            <q-item-label>{{
-              $t("Settings.lightning_address.show_on_receive.toggle")
-            }}</q-item-label>
-            <q-item-label caption>{{
-              $t("Settings.lightning_address.show_on_receive.description")
-            }}</q-item-label>
-          </q-item-section>
-          <q-item-section side>
-            <q-toggle v-model="showAddressOnReceive" color="primary" />
-          </q-item-section>
-        </q-item>
         <q-item class="settings-control-item">
           <q-item-section>
             <q-item-label caption class="q-mb-sm">{{
@@ -105,6 +92,19 @@
             </q-item-section>
             <q-item-section side>
               <q-toggle v-model="claimAutomatically" color="primary" />
+            </q-item-section>
+          </q-item>
+          <q-item tag="label">
+            <q-item-section>
+              <q-item-label>{{
+                $t("Settings.lightning_address.show_on_receive.toggle")
+              }}</q-item-label>
+              <q-item-label caption>{{
+                $t("Settings.lightning_address.show_on_receive.description")
+              }}</q-item-label>
+            </q-item-section>
+            <q-item-section side>
+              <q-toggle v-model="showAddressOnReceive" color="primary" />
             </q-item-section>
           </q-item>
         </q-expansion-item>

--- a/src/pages/settings/__tests__/LightningAddressSettings.test.ts
+++ b/src/pages/settings/__tests__/LightningAddressSettings.test.ts
@@ -17,7 +17,7 @@ describe("LightningAddressSettings", () => {
     setActivePinia(createPinia());
   });
 
-  it("keeps hostname and automatic claiming in a collapsed advanced section", () => {
+  it("keeps Lightning address options in a collapsed advanced section", () => {
     const pinia = createPinia();
     setActivePinia(pinia);
     useNpubCashStore().enabled = true;
@@ -57,7 +57,7 @@ describe("LightningAddressSettings", () => {
     expect(advanced.text()).toContain(
       "Settings.lightning_address.automatic_claim.toggle"
     );
-    expect(wrapper.text()).toContain(
+    expect(advanced.text()).toContain(
       "Settings.lightning_address.show_on_receive.toggle"
     );
   });


### PR DESCRIPTION
## Summary
- move the “Show when receiving” toggle into Lightning Address advanced settings, directly below automatic claim
- shorten its supporting text across all supported locales
- update the settings test to verify the option remains inside the collapsed advanced section

## Verification
- npm run format
- npm run lint
- vitest run src/pages/settings/__tests__/LightningAddressSettings.test.ts