### PR TITLE
style: reduce spacing between balance carousel dots

### DIFF
--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -405,7 +405,7 @@ export default defineComponent({
   opacity: 0.28;
   padding: 0;
   transition: opacity 0.2s ease, transform 0.2s ease;
-  width: 22px;
+  width: 14px;
 }
 .balance-unit-dot::after {
   background: currentColor;


### PR DESCRIPTION
Reduces the width of each dot button in the main balance carousel from 22px to 14px, tightening the spacing between the unit indicator dots below the big balance display.