### PR TITLE
Add incoming on-chain explorer fallback

### DIFF
--- a/src/components/MintQuoteInformation.vue
+++ b/src/components/MintQuoteInformation.vue
@@ -46,13 +46,19 @@
       <div class="detail-value">{{ networkDisplay }}</div>
     </div>
 
-    <div v-if="isOnchain && onchainMetadata" class="detail-item q-mb-md">
+    <div v-if="isOnchain && onchainExplorerUrl" class="detail-item q-mb-md">
       <div class="detail-label">
         <HashIcon :size="20" :color="iconColor" class="detail-icon" />
-        <div class="detail-name">Transaction ID</div>
+        <div class="detail-name">
+          {{ onchainMetadata ? "Transaction ID" : "Address" }}
+        </div>
       </div>
-      <a class="detail-value" :href="onchainMetadata.url" target="_blank">
-        {{ shortTxid(onchainMetadata.txid) }}
+      <a class="detail-value" :href="onchainExplorerUrl" target="_blank">
+        {{
+          onchainMetadata
+            ? shortTxid(onchainMetadata.txid)
+            : shortAddress(invoice.request)
+        }}
       </a>
     </div>
 
@@ -119,6 +125,7 @@ import {
 import { PaymentMethod } from "src/stores/walletTypes";
 import {
   fetchAddressTxMetadata,
+  onchainAddressExplorerUrl,
   onchainNetwork,
   onchainNetworkDisplay,
   type MempoolTxMetadata,
@@ -248,6 +255,13 @@ export default defineComponent({
         this.invoice.network || onchainNetwork(this.invoice.request);
       return network === "mutinynet" ? onchainNetworkDisplay(network) : "";
     },
+    onchainExplorerUrl(): string | null {
+      if (!this.isOnchain || !this.invoice?.request) return null;
+      return (
+        this.onchainMetadata?.url ||
+        onchainAddressExplorerUrl(this.invoice.request)
+      );
+    },
     onchainStatusDisplay(): string {
       if (!this.onchainMetadata) return "";
       const status = this.onchainMetadata.confirmed ? "Confirmed" : "Pending";
@@ -274,6 +288,9 @@ export default defineComponent({
   methods: {
     shortTxid(txid: string): string {
       return `${txid.slice(0, 8)}...${txid.slice(-8)}`;
+    },
+    shortAddress(address: string): string {
+      return `${address.slice(0, 8)}...${address.slice(-8)}`;
     },
     mintConfirmations(): number {
       const mintStore = useMintsStore();
@@ -327,6 +344,9 @@ export default defineComponent({
   watch: {
     "invoice.request": function () {
       this.loadOnchainMetadata();
+    },
+    "invoice.status": function (status: string) {
+      if (status === "paid") this.loadOnchainMetadata();
     },
     method: function () {
       this.loadOnchainMetadata();

--- a/src/components/__tests__/MintQuoteInformation.test.ts
+++ b/src/components/__tests__/MintQuoteInformation.test.ts
@@ -1,0 +1,64 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { PaymentMethod } from "src/stores/walletTypes";
+
+vi.mock("src/stores/mints", () => ({
+  useMintsStore: () => ({ activeMintUrl: "", activeUnit: "sat", mints: [] }),
+}));
+
+let MintQuoteInformation: any;
+
+beforeAll(async () => {
+  (globalThis as any).windowMixin = {};
+  MintQuoteInformation = (await import("../MintQuoteInformation.vue")).default;
+});
+
+describe("MintQuoteInformation", () => {
+  it("uses the address explorer page until a transaction is available", () => {
+    const onchainExplorerUrl = MintQuoteInformation.computed.onchainExplorerUrl;
+    const context: any = {
+      isOnchain: true,
+      invoice: { request: "bc1qexampleaddress" },
+      onchainMetadata: null,
+    };
+
+    expect(onchainExplorerUrl.call(context)).toBe(
+      "https://mempool.space/address/bc1qexampleaddress"
+    );
+
+    context.onchainMetadata = {
+      url: "https://mempool.space/tx/transaction-id",
+    };
+
+    expect(onchainExplorerUrl.call(context)).toBe(
+      "https://mempool.space/tx/transaction-id"
+    );
+  });
+
+  it("refreshes on-chain metadata when an incoming payment becomes paid", () => {
+    const loadOnchainMetadata = vi.fn();
+
+    MintQuoteInformation.watch["invoice.status"].call(
+      { loadOnchainMetadata },
+      "paid"
+    );
+    MintQuoteInformation.watch["invoice.status"].call(
+      { loadOnchainMetadata },
+      "pending"
+    );
+
+    expect(loadOnchainMetadata).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not create an explorer URL for non-on-chain payments", () => {
+    const onchainExplorerUrl = MintQuoteInformation.computed.onchainExplorerUrl;
+
+    expect(
+      onchainExplorerUrl.call({
+        isOnchain: false,
+        method: PaymentMethod.Bolt11,
+        invoice: { request: "lnbc1example" },
+        onchainMetadata: null,
+      })
+    ).toBeNull();
+  });
+});

--- a/src/js/__tests__/onchain.test.ts
+++ b/src/js/__tests__/onchain.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { onchainAddressExplorerUrl } from "src/js/onchain";
+
+describe("onchainAddressExplorerUrl", () => {
+  it("returns the mainnet Mempool address page", () => {
+    expect(onchainAddressExplorerUrl("bc1qexampleaddress")).toBe(
+      "https://mempool.space/address/bc1qexampleaddress"
+    );
+  });
+
+  it("normalizes bitcoin URIs and selects the Mutinynet explorer", () => {
+    expect(
+      onchainAddressExplorerUrl("bitcoin:tb1qexampleaddress?amount=1")
+    ).toBe("https://mutinynet.com/address/tb1qexampleaddress");
+  });
+
+  it("does not return an explorer URL for an unrecognized address", () => {
+    expect(onchainAddressExplorerUrl("invalid-address")).toBeNull();
+  });
+});

--- a/src/js/onchain.ts
+++ b/src/js/onchain.ts
@@ -47,6 +47,15 @@ function mempoolWebBase(apiBase: string): string {
   return apiBase.replace(/\/api$/, "");
 }
 
+export function onchainAddressExplorerUrl(address: string): string | null {
+  const normalizedAddress = normalizeBitcoinAddress(address);
+  const apiBase = mempoolBaseForAddress(normalizedAddress);
+  if (!apiBase) return null;
+  return `${mempoolWebBase(apiBase)}/address/${encodeURIComponent(
+    normalizedAddress
+  )}`;
+}
+
 async function fetchTipHeight(apiBase: string): Promise<number> {
   const response = await fetch(`${apiBase}/blocks/tip/height`, {
     cache: "no-store",


### PR DESCRIPTION
## Summary
- show a Mempool address link for incoming on-chain receives before their transaction is available
- refresh explorer metadata when the receive is marked paid, replacing the address with the transaction link
- add focused explorer URL and detail-refresh tests

## Testing
- npm run test:ci -- src/js/__tests__/onchain.test.ts src/components/__tests__/MintQuoteInformation.test.ts
- npx eslint src/components/MintQuoteInformation.vue src/components/__tests__/MintQuoteInformation.test.ts src/js/onchain.ts src/js/__tests__/onchain.test.ts
- npx prettier --check src/components/MintQuoteInformation.vue src/components/__tests__/MintQuoteInformation.test.ts src/js/onchain.ts src/js/__tests__/onchain.test.ts