### PR TITLE
fix(wallet): recover from rotated keysets via Cashu TS

### DIFF
--- a/src/stores/__tests__/transactionWorker.test.js
+++ b/src/stores/__tests__/transactionWorker.test.js
@@ -595,6 +595,7 @@ describe("transaction worker", () => {
         pendingInvoice("fast-q", { mint: fastMint }),
       ],
       mintWallet: vi.fn(async (mintUrl) => ({
+        keysetId: "00aa",
         checkMintQuoteBatchBolt11: vi.fn(async (quotes) =>
           quotes.map((quote) => ({
             ...unpaidResponse(quote),
@@ -604,8 +605,7 @@ describe("transaction worker", () => {
         prepareBatchMint: vi.fn(async () => ({ preview: true })),
         completeBatchMint: completeBatchMintByMint[mintUrl],
       })),
-      getKeyset: vi.fn(() => "00aa"),
-      retryOnceOnSignedOutputs: vi.fn(
+      retryOnceOnRecoverableError: vi.fn(
         async (_keysetId, operation) => await operation()
       ),
       setInvoicePaid: vi.fn(),
@@ -641,6 +641,7 @@ describe("transaction worker", () => {
     vi.spyOn(useUiStore(), "lockMutex").mockResolvedValue();
     vi.spyOn(useUiStore(), "unlockMutex").mockImplementation(() => {});
     const mintWallet = {
+      keysetId: "00aa",
       checkMintQuoteBatchBolt11: vi.fn(async (quotes) =>
         quotes.map((quote) =>
           quote === "paid-q"
@@ -654,8 +655,7 @@ describe("transaction worker", () => {
     const walletStore = {
       invoiceHistory: [pendingInvoice("paid-q"), pendingInvoice("unpaid-q")],
       mintWallet: vi.fn(async () => mintWallet),
-      getKeyset: vi.fn(() => "00aa"),
-      retryOnceOnSignedOutputs: vi.fn(
+      retryOnceOnRecoverableError: vi.fn(
         async (_keysetId, operation) => await operation()
       ),
       setInvoicePaid: vi.fn(),
@@ -715,6 +715,7 @@ describe("transaction worker", () => {
         }));
       });
       const mintWallet = {
+        keysetId: "00aa",
         ...(method === PaymentMethod.Bolt12
           ? { checkMintQuoteBatchBolt12: checkBatch }
           : { checkMintQuoteBatch: checkBatch }),
@@ -731,8 +732,7 @@ describe("transaction worker", () => {
         ],
         invoiceData: {},
         mintWallet: vi.fn(async () => mintWallet),
-        getKeyset: vi.fn(() => "00aa"),
-        retryOnceOnSignedOutputs: vi.fn(
+        retryOnceOnRecoverableError: vi.fn(
           async (_keysetId, operation) => await operation()
         ),
         setInvoicePaid: vi.fn(),
@@ -783,11 +783,11 @@ describe("transaction worker", () => {
     const walletStore = {
       invoiceHistory: [pendingInvoice("race-q")],
       mintWallet: vi.fn(async () => ({
+        keysetId: "00aa",
         checkMintQuoteBatchBolt11,
         prepareBatchMint,
       })),
-      getKeyset: vi.fn(() => "00aa"),
-      retryOnceOnSignedOutputs: vi.fn(),
+      retryOnceOnRecoverableError: vi.fn(),
       setInvoicePaid: vi.fn(),
       syncPaymentHistoryCache: vi.fn(),
     };

--- a/src/stores/__tests__/wallet.test.js
+++ b/src/stores/__tests__/wallet.test.js
@@ -812,7 +812,7 @@ describe("wallet store", () => {
       .mockResolvedValueOnce("minted");
 
     await expect(
-      wallet.retryOnceOnSignedOutputs("00aa", operation)
+      wallet.retryOnceOnRecoverableError("00aa", operation)
     ).resolves.toBe("minted");
 
     expect(operation).toHaveBeenCalledTimes(2);

--- a/src/stores/__tests__/wallet.test.js
+++ b/src/stores/__tests__/wallet.test.js
@@ -92,6 +92,14 @@ const h = vi.hoisted(() => {
   const walletLoadMintFromCache = vi.fn();
   const walletGetFeesForProofs = vi.fn(() => 7);
   const keychainMintToCacheDTO = vi.fn(() => ({ cache: "dto" }));
+  const keychainCacheToMintDTO = vi.fn(() => ({ keysets: [], keys: [] }));
+  const walletKeychainUpdated = vi.fn(() => () => {});
+  class StaleKeysetErrorMock extends Error {
+    constructor(repaired) {
+      super("stale keyset");
+      this.repaired = repaired;
+    }
+  }
   const outputDataSerialize = vi.fn((output) => ({ serialized: output.id }));
   const outputDataDeserialize = vi.fn((output) => ({ deserialized: output }));
   const tokenModule = {
@@ -110,6 +118,7 @@ const h = vi.hoisted(() => {
       this.getFeesForProofs = walletGetFeesForProofs;
       this.on = {
         countersReserved: vi.fn(() => () => {}),
+        keychainUpdated: walletKeychainUpdated,
       };
     }
 
@@ -150,6 +159,9 @@ const h = vi.hoisted(() => {
     walletLoadMintFromCache,
     walletGetFeesForProofs,
     keychainMintToCacheDTO,
+    keychainCacheToMintDTO,
+    walletKeychainUpdated,
+    StaleKeysetErrorMock,
     outputDataSerialize,
     outputDataDeserialize,
     bolt12Decode,
@@ -208,7 +220,9 @@ vi.mock("@cashu/cashu-ts", () => ({
   },
   KeyChain: {
     mintToCacheDTO: (...args) => h.keychainMintToCacheDTO(...args),
+    cacheToMintDTO: (...args) => h.keychainCacheToMintDTO(...args),
   },
+  StaleKeysetError: h.StaleKeysetErrorMock,
   CheckStateEnum: { SPENT: "SPENT" },
   MeltQuoteState: { PAID: "PAID", PENDING: "PENDING", UNPAID: "UNPAID" },
   MintQuoteState: { PAID: "PAID", ISSUED: "ISSUED", PENDING: "PENDING" },
@@ -597,6 +611,29 @@ describe("wallet store", () => {
     );
   });
 
+  it("persists Cashu TS keychain repairs in the mint cache", () => {
+    const wallet = useWalletStore();
+    const mint = h.mintsStore.mints[0];
+    h.keychainCacheToMintDTO.mockReturnValue({
+      keysets: [
+        { id: "00aa", unit: "sat", active: false },
+        { id: "00bb", unit: "sat", active: true },
+      ],
+      keys: [{ id: "00bb" }],
+    });
+
+    wallet.createWalletInstance(mint, mint.url, "sat");
+    const onKeychainUpdated = h.walletKeychainUpdated.mock.calls[0][0];
+    onKeychainUpdated({ cache: {} });
+
+    expect(mint.keysets).toEqual([
+      { id: "base64-a", unit: "sat", active: true },
+      { id: "00aa", unit: "sat", active: false },
+      { id: "00bb", unit: "sat", active: true },
+    ]);
+    expect(mint.keys).toEqual([{ id: "00aa" }, { id: "00bb" }]);
+  });
+
   it("gets fees using the provided mint context instead of the active mint", () => {
     const wallet = useWalletStore();
     h.mintsStore.mints.push({
@@ -764,6 +801,21 @@ describe("wallet store", () => {
 
     expect(handled).toBe(true);
     expect(wallet.keysetCounter("00aa")).toBe(11);
+    expect(h.notify).toHaveBeenCalledWith("wallet.notifications.trying_again");
+  });
+
+  it("retries once after Cashu TS repairs a stale keyset", async () => {
+    const wallet = useWalletStore();
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(new h.StaleKeysetErrorMock(true))
+      .mockResolvedValueOnce("minted");
+
+    await expect(
+      wallet.retryOnceOnSignedOutputs("00aa", operation)
+    ).resolves.toBe("minted");
+
+    expect(operation).toHaveBeenCalledTimes(2);
     expect(h.notify).toHaveBeenCalledWith("wallet.notifications.trying_again");
   });
 
@@ -1663,6 +1715,7 @@ describe("wallet store", () => {
     const mintWallet = {
       mint: { mintUrl: "https://mint-a.example" },
       unit: "sat",
+      keysetId: "00aa",
       prepareMelt,
       completeMelt,
     };
@@ -1734,6 +1787,7 @@ describe("wallet store", () => {
     const mintWallet = {
       mint: { mintUrl: "https://mint-a.example" },
       unit: "sat",
+      keysetId: "00aa",
       prepareMelt,
       completeMelt,
     };
@@ -1855,6 +1909,7 @@ describe("wallet store", () => {
     const mintWallet = {
       mint: { mintUrl: "https://mint-a.example" },
       unit: "sat",
+      keysetId: "00aa",
       prepareMelt,
       completeMelt,
     };

--- a/src/stores/transactionWorker.ts
+++ b/src/stores/transactionWorker.ts
@@ -964,7 +964,6 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
       const mint = mintStore.mints.find((item) => item.url === mintUrl);
       if (!mint) throw new Error("mint not found");
 
-      const keysetId = walletStore.getKeyset(mintUrl, unit);
       const uiStore = useUiStore();
       let proofs: any[] = [];
       const entriesToMint: MintableQuote[] = [];
@@ -1011,8 +1010,8 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
         }
 
         if (entriesToMint.length > 0) {
-          proofs = await walletStore.retryOnceOnSignedOutputs(
-            keysetId,
+          proofs = await walletStore.retryOnceOnRecoverableError(
+            mintWallet.keysetId,
             async () => {
               let preview: any;
               await uiStore.lockMutex("background");
@@ -1024,7 +1023,7 @@ export const useTransactionWorkerStore = defineStore("transactionWorker", {
                     quote: entry.mintQuote,
                   })),
                   {
-                    keysetId,
+                    keysetId: mintWallet.keysetId,
                     proofsWeHave: mintStore.mintUnitProofs(mint, unit),
                     ...(signingKeys.length > 0 ? { privkey: signingKeys } : {}),
                   }

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -446,7 +446,7 @@ export const useWalletStore = defineStore("wallet", {
       this.sharedCounterSource = null; // force re-creation on next wallet init
       this.mnemonic = generateMnemonic(wordlist);
     },
-    retryOnceOnSignedOutputs: async function <T>(
+    retryOnceOnRecoverableError: async function <T>(
       keysetId: string,
       operation: () => Promise<T>,
       notifyUser = true
@@ -646,7 +646,7 @@ export const useWalletStore = defineStore("wallet", {
           true
         );
         const { keep: keepProofs, send: sendProofs } =
-          await this.retryOnceOnSignedOutputs(wallet.keysetId, async () =>
+          await this.retryOnceOnRecoverableError(wallet.keysetId, async () =>
             wallet.ops
               .send(amount, toProofs(proofsToSend))
               .keyset(wallet.keysetId)
@@ -712,7 +712,7 @@ export const useWalletStore = defineStore("wallet", {
           );
           // includeFees=true inflates send outputs so sendProofs sum to
           // amount + fees(sendProofs): required for melt and includeFees sends.
-          const swapResult = await this.retryOnceOnSignedOutputs(
+          const swapResult = await this.retryOnceOnRecoverableError(
             swapWallet.keysetId,
             async () =>
               swapWallet.ops
@@ -806,7 +806,7 @@ export const useWalletStore = defineStore("wallet", {
         const privkey = receiveStore.receiveData.p2pkPrivateKey;
         let proofs: Proof[];
         try {
-          proofs = await this.retryOnceOnSignedOutputs(
+          proofs = await this.retryOnceOnRecoverableError(
             mintWallet.keysetId,
             async () =>
               mintWallet.ops

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -82,6 +82,7 @@ import {
   type P2PKOptions,
   type CounterSource,
   createEphemeralCounterSource,
+  StaleKeysetError,
   // ConsoleLogger,
 } from "@cashu/cashu-ts";
 // @ts-ignore
@@ -388,6 +389,7 @@ export const useWalletStore = defineStore("wallet", {
       url: string,
       unit: string
     ): Wallet {
+      const mints = useMintsStore();
       if (this.mnemonic == "") {
         this.mnemonic = generateMnemonic(wordlist);
       }
@@ -400,6 +402,26 @@ export const useWalletStore = defineStore("wallet", {
       });
       wallet.on.countersReserved(({ keysetId, next }) => {
         this.syncCounterToStorage(keysetId, next);
+      });
+      wallet.on.keychainUpdated(({ cache }) => {
+        const mint = mints.mints.find((m) => m.url === url);
+        if (!mint) return;
+
+        // Cashu TS repairs its short-lived wallet snapshot after a keyset
+        // rejection. Keep that repair for subsequent wallet instances too.
+        const { keysets, keys } = KeyChain.cacheToMintDTO(cache);
+        mint.keysets = [
+          ...mint.keysets.filter((existing) =>
+            keysets.every((updated) => updated.id !== existing.id)
+          ),
+          ...keysets,
+        ];
+        mint.keys = [
+          ...mint.keys.filter((existing) =>
+            keys.every((updated) => updated.id !== existing.id)
+          ),
+          ...keys,
+        ];
       });
       // Load the caches
       const keychainCache = KeyChain.mintToCacheDTO(
@@ -432,6 +454,14 @@ export const useWalletStore = defineStore("wallet", {
       try {
         return await operation();
       } catch (error: any) {
+        // Cashu TS v4.9.0+ refreshes the wallet snapshot when a mint rejects
+        // outputs on a retired keyset, then asks the caller to retry.
+        if (error instanceof StaleKeysetError && error.repaired) {
+          if (notifyUser) {
+            notify(this.t("wallet.notifications.trying_again"));
+          }
+          return await operation();
+        }
         const handled = await this.handleOutputsHaveAlreadyBeenSignedError(
           keysetId,
           error,
@@ -615,12 +645,14 @@ export const useWalletStore = defineStore("wallet", {
           amount,
           true
         );
-        const keysetId = this.getKeyset(wallet.mint.mintUrl, wallet.unit);
-        const { keep: keepProofs, send: sendProofs } = await wallet.ops
-          .send(amount, toProofs(proofsToSend))
-          .keyset(keysetId)
-          .asP2PK(p2pkOptions)
-          .run();
+        const { keep: keepProofs, send: sendProofs } =
+          await this.retryOnceOnSignedOutputs(wallet.keysetId, async () =>
+            wallet.ops
+              .send(amount, toProofs(proofsToSend))
+              .keyset(wallet.keysetId)
+              .asP2PK(p2pkOptions)
+              .run()
+          );
         const proofsStore = useProofsStore();
         await proofsStore.removeProofs(proofsToSend);
         // note: we do not store sendProofs in the proofs store but
@@ -645,7 +677,6 @@ export const useWalletStore = defineStore("wallet", {
       // or removes them if `invalidate` is true (caller takes ownership).
       const proofsStore = useProofsStore();
       const uIStore = useUiStore();
-      const keysetId = this.getKeyset(wallet.mint.mintUrl, wallet.unit);
       await uIStore.lockMutex(mutexPriority);
       try {
         const spendableProofs: Proof[] = toProofs(
@@ -682,12 +713,12 @@ export const useWalletStore = defineStore("wallet", {
           // includeFees=true inflates send outputs so sendProofs sum to
           // amount + fees(sendProofs): required for melt and includeFees sends.
           const swapResult = await this.retryOnceOnSignedOutputs(
-            keysetId,
+            swapWallet.keysetId,
             async () =>
               swapWallet.ops
                 .send(amount, spendableProofs)
                 .asDeterministic()
-                .keyset(keysetId)
+                .keyset(swapWallet.keysetId)
                 .proofsWeHave(spendableProofs)
                 .includeFees(includeFees)
                 .run()
@@ -772,17 +803,18 @@ export const useWalletStore = defineStore("wallet", {
       await uIStore.lockMutex();
       try {
         // redeem
-        const keysetId = this.getKeyset(historyToken.mint, historyToken.unit);
         const privkey = receiveStore.receiveData.p2pkPrivateKey;
         let proofs: Proof[];
         try {
-          proofs = await this.retryOnceOnSignedOutputs(keysetId, async () =>
-            mintWallet.ops
-              .receive(receiveStore.receiveData.tokensBase64)
-              .asDeterministic()
-              .privkey(privkey)
-              .proofsWeHave(mintStore.mintUnitProofs(mint, historyToken.unit))
-              .run()
+          proofs = await this.retryOnceOnSignedOutputs(
+            mintWallet.keysetId,
+            async () =>
+              mintWallet.ops
+                .receive(receiveStore.receiveData.tokensBase64)
+                .asDeterministic()
+                .privkey(privkey)
+                .proofsWeHave(mintStore.mintUnitProofs(mint, historyToken.unit))
+                .run()
           );
           await proofsStore.addProofs(proofs);
         } catch (error: any) {

--- a/src/stores/walletBolt11.ts
+++ b/src/stores/walletBolt11.ts
@@ -146,7 +146,7 @@ export async function mintBolt11(
         throw new Error("unknown state.");
     }
     // MintQuoteState must be PAID
-    const proofs = await this.retryOnceOnSignedOutputs(
+    const proofs = await this.retryOnceOnRecoverableError(
       mintWallet.keysetId,
       async () =>
         mintWallet.ops

--- a/src/stores/walletBolt11.ts
+++ b/src/stores/walletBolt11.ts
@@ -97,7 +97,6 @@ export async function mintBolt11(
   const proofsStore = useProofsStore();
   const mintStore = useMintsStore();
   const uIStore = useUiStore();
-  const keysetId = this.getKeyset(invoice.mint, invoice.unit);
   const mintWallet = await this.mintWallet(invoice.mint, invoice.unit, true);
   const mint = mintStore.mints.find((m: any) => m.url === invoice.mint);
   if (!mint) {
@@ -147,14 +146,16 @@ export async function mintBolt11(
         throw new Error("unknown state.");
     }
     // MintQuoteState must be PAID
-    const proofs = await this.retryOnceOnSignedOutputs(keysetId, async () =>
-      mintWallet.ops
-        .mintBolt11(invoice.amount, invoice.quote)
-        .keyset(keysetId)
-        .asDeterministic()
-        .proofsWeHave(mintStore.mintUnitProofs(mint, invoice.unit))
-        .privkey(invoice.privKey as string)
-        .run()
+    const proofs = await this.retryOnceOnSignedOutputs(
+      mintWallet.keysetId,
+      async () =>
+        mintWallet.ops
+          .mintBolt11(invoice.amount, invoice.quote)
+          .keyset(mintWallet.keysetId)
+          .asDeterministic()
+          .proofsWeHave(mintStore.mintUnitProofs(mint, invoice.unit))
+          .privkey(invoice.privKey as string)
+          .run()
     );
     await proofsStore.addProofs(proofs);
 

--- a/src/stores/walletBolt12.ts
+++ b/src/stores/walletBolt12.ts
@@ -114,7 +114,6 @@ export async function checkOfferAndMintBolt12(
   if (!invoice) throw new Error("offer not found");
 
   const mintWallet = await this.mintWallet(invoice.mint, invoice.unit);
-  const keysetId = this.getKeyset(invoice.mint, invoice.unit);
   const mint = mintStore.mints.find((m: any) => m.url === invoice.mint);
   if (!mint) throw new Error("mint not found");
 
@@ -145,11 +144,11 @@ export async function checkOfferAndMintBolt12(
     }
 
     const proofs = await this.retryOnceOnSignedOutputs(
-      keysetId,
+      mintWallet.keysetId,
       async () =>
         mintWallet.ops
           .mintBolt12(delta, updated)
-          .keyset(keysetId)
+          .keyset(mintWallet.keysetId)
           .asDeterministic()
           .proofsWeHave(mintStore.mintUnitProofs(mint, invoice.unit))
           .privkey(invoice.privKey)
@@ -214,7 +213,6 @@ export async function checkOfferAndMintBolt12(
       console.error(error);
     }
     if (verbose) notifyApiError(error);
-    this.handleOutputsHaveAlreadyBeenSignedError(keysetId, error, verbose);
     throw error;
   } finally {
     uIStore.unlockMutex();

--- a/src/stores/walletBolt12.ts
+++ b/src/stores/walletBolt12.ts
@@ -143,7 +143,7 @@ export async function checkOfferAndMintBolt12(
       throw new Error("no new funds to mint");
     }
 
-    const proofs = await this.retryOnceOnSignedOutputs(
+    const proofs = await this.retryOnceOnRecoverableError(
       mintWallet.keysetId,
       async () =>
         mintWallet.ops

--- a/src/stores/walletMelt.ts
+++ b/src/stores/walletMelt.ts
@@ -159,7 +159,6 @@ export async function meltGeneric(
 ) {
   const uIStore = useUiStore();
   const amount = quote.amount + quote.fee_reserve;
-  const keysetId = this.getKeyset(mintWallet.mint.mintUrl, mintWallet.unit);
 
   let sendProofs: ProofLike[] = [];
   try {
@@ -198,21 +197,24 @@ export async function meltGeneric(
     let data;
     let paidMeltQuote: AppMeltQuote | null = null;
     try {
-      data = await this.retryOnceOnSignedOutputs(keysetId, async () => {
-        const preparedQuote = toMeltQuote(quote);
-        const preview = await mintWallet.prepareMelt(
-          method,
-          preparedQuote,
-          sendProofs,
-          { keysetId }
-        );
-        await this.setMeltChangeOutputData(quote.quote, preview.outputData);
-        return await mintWallet.completeMelt(
-          preview,
-          undefined,
-          completeMeltOptions
-        );
-      });
+      data = await this.retryOnceOnSignedOutputs(
+        mintWallet.keysetId,
+        async () => {
+          const preparedQuote = toMeltQuote(quote);
+          const preview = await mintWallet.prepareMelt(
+            method,
+            preparedQuote,
+            sendProofs,
+            { keysetId: mintWallet.keysetId }
+          );
+          await this.setMeltChangeOutputData(quote.quote, preview.outputData);
+          return await mintWallet.completeMelt(
+            preview,
+            undefined,
+            completeMeltOptions
+          );
+        }
+      );
       paidMeltQuote = normalizeMeltQuote(data.quote);
       await this.updateOutgoingInvoiceInHistory(paidMeltQuote);
       if (data.outputData?.length) {

--- a/src/stores/walletMelt.ts
+++ b/src/stores/walletMelt.ts
@@ -197,7 +197,7 @@ export async function meltGeneric(
     let data;
     let paidMeltQuote: AppMeltQuote | null = null;
     try {
-      data = await this.retryOnceOnSignedOutputs(
+      data = await this.retryOnceOnRecoverableError(
         mintWallet.keysetId,
         async () => {
           const preparedQuote = toMeltQuote(quote);

--- a/src/stores/walletOnchain.ts
+++ b/src/stores/walletOnchain.ts
@@ -170,7 +170,7 @@ export async function checkOnchainAndMint(
       throw new Error("Address not paid");
     }
 
-    const proofs = await this.retryOnceOnSignedOutputs(
+    const proofs = await this.retryOnceOnRecoverableError(
       mintWallet.keysetId,
       async () =>
         mintWallet.ops

--- a/src/stores/walletOnchain.ts
+++ b/src/stores/walletOnchain.ts
@@ -116,7 +116,6 @@ export async function checkOnchainAndMint(
   if (!invoice) throw new Error("on-chain quote not found");
 
   const mintWallet = await this.mintWallet(invoice.mint, invoice.unit);
-  const keysetId = this.getKeyset(invoice.mint, invoice.unit);
   const mint = mintStore.mints.find((m: any) => m.url === invoice.mint);
   if (!mint) throw new Error("mint not found");
   if (!invoice.network) {
@@ -172,11 +171,11 @@ export async function checkOnchainAndMint(
     }
 
     const proofs = await this.retryOnceOnSignedOutputs(
-      keysetId,
+      mintWallet.keysetId,
       async () =>
         mintWallet.ops
           .mintOnchain(delta, updated)
-          .keyset(keysetId)
+          .keyset(mintWallet.keysetId)
           .asDeterministic()
           .proofsWeHave(mintStore.mintUnitProofs(mint, invoice.unit))
           .privkey(invoice.privKey)
@@ -243,7 +242,6 @@ export async function checkOnchainAndMint(
         notifyApiError(error);
       }
     }
-    this.handleOutputsHaveAlreadyBeenSignedError(keysetId, error, verbose);
     throw error;
   } finally {
     uIStore.unlockMutex();

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -10,8 +10,12 @@ services:
       - --enable-logging
     environment:
       CDK_MINTD_MNEMONIC: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+      CDK_MINTD_MANAGEMENT_ENABLED: "true"
+      CDK_MINTD_MANAGEMENT_ADDRESS: "0.0.0.0"
+      CDK_MINTD_MANAGEMENT_PORT: "10000"
     ports:
       - "127.0.0.1:8085:8085"
+      - "127.0.0.1:10000:10000"
     volumes:
       - ./mints/mint-a.toml:/config/config.toml:ro
     tmpfs:

--- a/test/e2e/fixtures/mint.ts
+++ b/test/e2e/fixtures/mint.ts
@@ -1,12 +1,75 @@
 import { expect, type APIRequestContext } from "@playwright/test";
+import { connect } from "node:http2";
 
 export const MINT_A_URL = process.env.E2E_MINT_A_URL ?? "http://127.0.0.1:8085";
 export const MINT_B_URL = process.env.E2E_MINT_B_URL ?? "http://127.0.0.1:8086";
+const MINT_A_MANAGEMENT_URL =
+  process.env.E2E_MINT_A_MANAGEMENT_URL ?? "http://127.0.0.1:10000";
 
 const TEST_PUBKEY =
   "03d56ce4e446a85bbdaa547b4ec2b073d40ff802831352b8272b7dd7a4de5a7cac";
 
 export type PaymentMethod = "bolt11" | "bolt12" | "onchain";
+
+const ROTATE_KEYSET_PATH = "/cdk_mint_management_v1.CdkMint/RotateNextKeyset";
+const GRPC_PROTOCOL_VERSION = "1.0.0";
+
+/** Rotate the E2E mint's active sat keyset through its local management RPC. */
+export async function rotateMintAKeyset() {
+  const client = connect(MINT_A_MANAGEMENT_URL);
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let grpcStatus: string | undefined;
+    let responseStatus: number | undefined;
+
+    const complete = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      client.close();
+      if (error) reject(error);
+      else resolve();
+    };
+
+    const request = client.request({
+      ":method": "POST",
+      ":path": ROTATE_KEYSET_PATH,
+      "content-type": "application/grpc",
+      te: "trailers",
+      "x-cdk-protocol-version": GRPC_PROTOCOL_VERSION,
+    });
+
+    request.on("response", (headers) => {
+      responseStatus = Number(headers[":status"]);
+    });
+    request.on("trailers", (headers) => {
+      grpcStatus = String(headers["grpc-status"]);
+    });
+    request.on("data", () => {});
+    request.once("error", complete);
+    request.once("end", () => {
+      if (responseStatus !== 200) {
+        complete(new Error(`Keyset rotation returned HTTP ${responseStatus}`));
+      } else if (grpcStatus !== "0") {
+        complete(
+          new Error(`Keyset rotation failed with gRPC status ${grpcStatus}`)
+        );
+      } else {
+        complete();
+      }
+    });
+    client.once("error", complete);
+
+    // RotateNextKeysetRequest { unit: "sat", use_keyset_v2: false }. Keeping
+    // the keyset ID format consistent with the seed keyset makes the scenario
+    // independent of the CDK mint image's default format.
+    const message = Buffer.from([0x0a, 0x03, 0x73, 0x61, 0x74, 0x20, 0x00]);
+    const frame = Buffer.alloc(message.length + 5);
+    frame.writeUInt32BE(message.length, 1);
+    message.copy(frame, 5);
+    request.end(frame);
+  });
+}
 
 async function postJson(
   request: APIRequestContext,

--- a/test/e2e/run.mjs
+++ b/test/e2e/run.mjs
@@ -58,6 +58,7 @@ try {
       ...process.env,
       E2E_MINT_A_URL: "http://127.0.0.1:8085",
       E2E_MINT_B_URL: "http://127.0.0.1:8086",
+      E2E_MINT_A_MANAGEMENT_URL: "http://127.0.0.1:10000",
     },
   });
 

--- a/test/e2e/specs/ecash.spec.ts
+++ b/test/e2e/specs/ecash.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Video } from "@playwright/test";
-import { MINT_A_URL } from "../fixtures/mint";
+import { MINT_A_URL, rotateMintAKeyset } from "../fixtures/mint";
 import { WalletPage } from "../pages/WalletPage";
 
 test("sends ecash between two isolated browser wallets and rejects replay", async ({
@@ -80,5 +80,121 @@ test("sends ecash between two isolated browser wallets and rejects replay", asyn
       : undefined;
     await Promise.allSettled([senderContext.close(), receiverContext.close()]);
     await videoCopies;
+  }
+});
+
+test("recovers when a mint rotates its keyset before receiving old ecash", async ({
+  browser,
+  request,
+}) => {
+  const senderContext = await browser.newContext({
+    permissions: ["clipboard-read", "clipboard-write"],
+    reducedMotion: "reduce",
+    serviceWorkers: "block",
+  });
+  const receiverContext = await browser.newContext({
+    permissions: ["clipboard-read", "clipboard-write"],
+    reducedMotion: "reduce",
+    serviceWorkers: "block",
+  });
+
+  try {
+    const senderPage = await senderContext.newPage();
+    const receiverPage = await receiverContext.newPage();
+    const sender = new WalletPage(senderPage);
+    const receiver = new WalletPage(receiverPage);
+    await sender.onboard(MINT_A_URL);
+    await receiver.onboard(MINT_A_URL);
+    await sender.mintBolt11(100);
+
+    await sender.openSend("ecash");
+    await sender.enterAmount(37);
+    await sender.page.getByTestId("send-ecash").click();
+    await sender.page.getByTestId("copy-ecash-token").click();
+    const token = await sender.page.evaluate(() =>
+      navigator.clipboard.readText()
+    );
+    await expect.poll(() => sender.balanceSats()).toBe(63);
+
+    const initialKeysetsResponse = await request.get(
+      `${MINT_A_URL}/v1/keysets`
+    );
+    expect(initialKeysetsResponse.ok()).toBeTruthy();
+    const initialKeysets = await initialKeysetsResponse.json();
+    const oldActiveKeyset = initialKeysets.keysets.find(
+      (keyset: { unit: string; active: boolean }) =>
+        keyset.unit === "sat" && keyset.active
+    );
+    expect(oldActiveKeyset).toBeDefined();
+
+    await rotateMintAKeyset();
+
+    await expect
+      .poll(async () => {
+        const response = await request.get(`${MINT_A_URL}/v1/keysets`);
+        const { keysets } = await response.json();
+        return keysets.find(
+          (keyset: { unit: string; active: boolean }) =>
+            keyset.unit === "sat" && keyset.active
+        )?.id;
+      })
+      .not.toBe(oldActiveKeyset.id);
+
+    const rotatedKeysetsResponse = await request.get(
+      `${MINT_A_URL}/v1/keysets`
+    );
+    expect(rotatedKeysetsResponse.ok()).toBeTruthy();
+    const rotatedKeysets = await rotatedKeysetsResponse.json();
+    const newActiveKeyset = rotatedKeysets.keysets.find(
+      (keyset: { unit: string; active: boolean }) =>
+        keyset.unit === "sat" && keyset.active
+    );
+    expect(newActiveKeyset).toBeDefined();
+    expect(
+      rotatedKeysets.keysets.find(
+        (keyset: { id: string }) => keyset.id === oldActiveKeyset.id
+      )?.active
+    ).toBe(false);
+
+    const swapOutputKeysets: string[][] = [];
+    const failedSwapStatuses: number[] = [];
+    receiver.page.on("request", (swapRequest) => {
+      if (
+        new URL(swapRequest.url()).pathname !== "/v1/swap" ||
+        swapRequest.method() !== "POST"
+      ) {
+        return;
+      }
+      const body = JSON.parse(swapRequest.postData() ?? "{}");
+      swapOutputKeysets.push(
+        Array.from(
+          new Set(body.outputs?.map((output: { id: string }) => output.id))
+        )
+      );
+    });
+    receiver.page.on("response", (swapResponse) => {
+      if (
+        new URL(swapResponse.url()).pathname === "/v1/swap" &&
+        !swapResponse.ok()
+      ) {
+        failedSwapStatuses.push(swapResponse.status());
+      }
+    });
+
+    await receiver.page.evaluate(
+      (cashuToken) => navigator.clipboard.writeText(cashuToken),
+      token
+    );
+    await receiver.openReceive("ecash");
+    await receiver.page.getByTestId("receive-ecash-paste").click();
+    await receiver.page.getByTestId("receive-ecash").click();
+
+    await expect.poll(() => receiver.balanceSats()).toBe(37);
+    await expect.poll(() => failedSwapStatuses.length).toBeGreaterThan(0);
+    await expect.poll(() => swapOutputKeysets.length).toBeGreaterThanOrEqual(2);
+    expect(swapOutputKeysets[0]).toContain(oldActiveKeyset.id);
+    expect(swapOutputKeysets.at(-1)).toContain(newActiveKeyset.id);
+  } finally {
+    await Promise.allSettled([senderContext.close(), receiverContext.close()]);
   }
 });

--- a/test/vitest/__tests__/p2pkPaymentRequest.test.ts
+++ b/test/vitest/__tests__/p2pkPaymentRequest.test.ts
@@ -81,13 +81,13 @@ describe("walletStore.sendToLock pubkey normalization", () => {
     const asP2PK = vi.fn().mockReturnValue({
       run: vi.fn().mockResolvedValue({ keep: [], send: sendProofs }),
     });
+    const keyset = vi.fn().mockReturnValue({ asP2PK });
     const mockWallet = {
       unit: "sat",
+      keysetId: "ks1",
       mint: { mintUrl: "https://mint.test" },
       ops: {
-        send: vi
-          .fn()
-          .mockReturnValue({ keyset: vi.fn().mockReturnValue({ asP2PK }) }),
+        send: vi.fn().mockReturnValue({ keyset }),
       },
     } as any;
     wallet.spendableProofs = vi.fn().mockReturnValue(walletProofs);
@@ -95,12 +95,13 @@ describe("walletStore.sendToLock pubkey normalization", () => {
     wallet.getKeyset = vi.fn().mockReturnValue("ks1");
     proofs.removeProofs = vi.fn().mockResolvedValue(undefined);
     proofs.addProofs = vi.fn().mockResolvedValue(undefined);
-    return { wallet, mockWallet, asP2PK, sendProofs, walletProofs };
+    return { wallet, mockWallet, keyset, asP2PK, sendProofs, walletProofs };
   };
 
   test("wraps a bare pubkey string in P2PKOptions", async () => {
-    const { wallet, mockWallet, asP2PK, sendProofs } = setup();
+    const { wallet, mockWallet, keyset, asP2PK, sendProofs } = setup();
     const result = await wallet.sendToLock([], mockWallet, 21, PUBKEY);
+    expect(keyset).toHaveBeenCalledWith("ks1");
     expect(asP2PK).toHaveBeenCalledWith({ pubkey: PUBKEY });
     expect(result.sendProofs).toEqual(sendProofs);
   });


### PR DESCRIPTION
Uses Cashu TS v4.9 automatic keyset-rotation repair instead of prefetching mint keysets before every signing operation. Retries once after a repaired StaleKeysetError, persists the repaired keychain cache, resolves output keysets from the wallet at operation time, and removes duplicate signed-output handling from Bolt12 and on-chain minting.

Coverage includes unit regression tests and a real CDK browser integration test: two wallets learn the old keyset, the mint rotates it through its local management RPC, receiving pre-rotation ecash first fails with outputs on the inactive keyset, then retries with the newly active keyset and succeeds.

Verified with targeted wallet/transaction-worker tests, the focused CDK E2E spec, Prettier, and ESLint.