### PR TITLE
feat(pwa): fade in from splash screen on app launch

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,56 @@
     <link rel="icon" type="image/png" sizes="32x32" href="icons/32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="icons/16x16.png" />
     <link rel="icon" type="image/ico" href="favicon.ico" />
+
+    <style>
+      html {
+        background-color: #000000;
+      }
+      #app-splash {
+        position: fixed;
+        inset: 0;
+        z-index: 99999;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background-color: var(--cashu-splash-bg, #000000);
+        opacity: 1;
+        transition: opacity 0.4s ease;
+      }
+      #app-splash.app-splash-fade {
+        opacity: 0;
+        pointer-events: none;
+      }
+      #app-splash img {
+        width: 96px;
+        height: 96px;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        #app-splash {
+          transition: none;
+        }
+      }
+    </style>
+    <script>
+      (function () {
+        try {
+          var raw = window.localStorage.getItem("cashu.darkMode");
+          var isDark = true;
+          if (raw != null) {
+            var v = String(raw).replace(/^__q_[a-z]+\|/i, "");
+            isDark = v === "1" || v === "true";
+          }
+          var bg = isDark ? "#000000" : "#ffffff";
+          document.documentElement.style.backgroundColor = bg;
+          document.documentElement.style.setProperty("--cashu-splash-bg", bg);
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
+    <div id="app-splash">
+      <img src="icons/icon-192x192.png" alt="" />
+    </div>
     <!-- quasar:entry-point -->
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -45,10 +45,21 @@
       #app-splash img {
         width: 96px;
         height: 96px;
+        opacity: 0;
+        animation: app-splash-logo-in 0.4s ease 0.5s forwards;
+      }
+      @keyframes app-splash-logo-in {
+        to {
+          opacity: 1;
+        }
       }
       @media (prefers-reduced-motion: reduce) {
         #app-splash {
           transition: none;
+        }
+        #app-splash img {
+          animation: none;
+          opacity: 1;
         }
       }
     </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,6 +11,16 @@ import { defineComponent } from "vue";
 
 export default defineComponent({
   name: "App",
+  mounted() {
+    const splash = document.getElementById("app-splash");
+    if (!splash) return;
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        splash.classList.add("app-splash-fade");
+        window.setTimeout(() => splash.remove(), 500);
+      });
+    });
+  },
 });
 </script>
 


### PR DESCRIPTION
## Summary

When the wallet loads (especially as an installed PWA), it previously flashed a white page and visibly built the UI piece by piece like a website. This PR makes startup feel like a stable native app:

- **Pre-paint theming (`index.html`):** a tiny synchronous inline script reads the stored `cashu.darkMode` preference from localStorage (handling Quasar's `__q_bool|` value encoding) and sets the page background before first paint — no more white flash. Defaults to black, matching the app's dark default and the manifest `background_color`.
- **Static splash overlay (`index.html`):** the app icon centered on the theme background covers the viewport from the very first paint, so the OS-level PWA splash hands off seamlessly to an identical screen while the app loads behind it.
- **Fade-out on mount (`src/App.vue`):** once the Vue app has mounted and a frame has painted underneath, the splash fades out over 400ms and removes itself from the DOM — the fully-built wallet appears to fade in.

Respects `prefers-reduced-motion` (fade disabled) and also fixes the white flash in regular browsers, not just standalone PWA mode.

## Test plan

- [ ] Install as PWA, cold-launch: OS splash → black splash with icon → smooth fade into the wallet
- [ ] Reload in browser: no white flash, splash fades in the app
- [ ] Light-mode users (stored preference): splash is white instead of black
- [ ] `npm run lint` passes, `quasar build -m pwa` output verified