### PR TITLE
feat(mints): add-mint confirmation as bottom sheet with rich mint preview

### DIFF
--- a/src/components/AddMintDialog.vue
+++ b/src/components/AddMintDialog.vue
@@ -214,20 +214,20 @@ export default defineComponent({
         : "error";
     };
 
-    watch(showAddMintDialogLocal, (isOpen) => {
-      if (isOpen) {
-        showAuditInfo.value = false;
-        mintFetchState.value = "idle";
-        fetchMintPreview(mintUrl.value);
-      }
-    });
-
-    watch(mintUrl, (url) => {
-      if (showAddMintDialogLocal.value) {
-        mintFetchState.value = "idle";
-        fetchMintPreview(url);
-      }
-    });
+    // Fire on every open and URL change — and immediately on mount, because
+    // the sheet can be mounted *after* the open flag was set (deep link and
+    // QR scan flows set the store state before the sheet's host mounts).
+    watch(
+      [showAddMintDialogLocal, mintUrl],
+      ([isOpen, url]) => {
+        if (isOpen && url) {
+          showAuditInfo.value = false;
+          mintFetchState.value = "idle";
+          fetchMintPreview(url);
+        }
+      },
+      { immediate: true }
+    );
 
     // If the mint info arrives late (e.g. the fetch outlived our local
     // timeout), recover from the error/loading state automatically.

--- a/src/components/AddMintDialog.vue
+++ b/src/components/AddMintDialog.vue
@@ -1,46 +1,41 @@
 <template>
   <q-dialog
     v-model="showAddMintDialogLocal"
-    @keydown.enter.prevent="addMintLocal"
+    position="bottom"
     backdrop-filter="blur(4px) brightness(50%)"
-    transition-show="fade"
-    transition-hide="fade"
-    scrollable
+    transition-show="slide-up"
+    transition-hide="slide-down"
+    @keydown.enter.prevent="addMintLocal"
   >
-    <q-card class="add-mint-dialog">
+    <q-card class="add-mint-sheet" :class="isDark ? 'bg-dark' : 'bg-white'">
+      <!-- Drag handle -->
+      <div class="sheet-handle-container">
+        <div class="sheet-handle" />
+      </div>
+
       <!-- Header Section -->
-      <q-card-section class="add-mint-header q-pa-md">
-        <div class="add-mint-title-row">
-          <h4 class="add-mint-title q-my-none">
-            {{ $t("AddMintDialog.title") }}
-          </h4>
-        </div>
-      </q-card-section>
+      <div class="sheet-header q-px-lg">
+        <h4 class="sheet-title q-my-none">
+          {{ $t("AddMintDialog.title") }}
+        </h4>
+        <q-btn flat round dense icon="close" class="close-btn" v-close-popup />
+      </div>
 
       <!-- Scrollable Content Section -->
-      <q-card-section
-        class="add-mint-content q-px-md scroll"
-        style="max-height: 60vh"
-      >
-        <p class="add-mint-description q-mb-lg">
+      <div class="sheet-content q-px-lg scroll">
+        <p class="sheet-description q-mb-lg">
           {{ $t("AddMintDialog.description") }}
         </p>
 
-        <div class="q-mb-lg">
-          <label class="input-label">{{
-            $t("AddMintDialog.inputs.mint_url.label")
-          }}</label>
-          <q-input
-            outlined
-            readonly
-            :model-value="mintUrl"
-            dense
-            class="mint-input"
-            filled
-            type="textarea"
-            autogrow
-            style="font-family: monospace; font-size: 0.9em"
-          ></q-input>
+        <!-- Mint preview pill -->
+        <div class="mint-preview-pill q-mb-lg">
+          <MintInfoContainer
+            :url="mintUrl"
+            :name="mintDisplayName"
+            :iconUrl="mintIconUrl"
+            :loading="mintInfoLoading"
+            avatarSize="48px"
+          />
         </div>
 
         <!-- Audit Info Section -->
@@ -70,14 +65,13 @@
             </transition>
           </div>
         </div>
-      </q-card-section>
+      </div>
 
       <!-- Fixed Action Buttons Section -->
-      <q-card-actions class="action-buttons flex q-pa-md">
+      <div class="sheet-actions q-px-lg">
         <q-btn flat class="cancel-btn" v-close-popup>
           {{ $t("AddMintDialog.actions.cancel.label") }}
         </q-btn>
-        <q-spacer></q-spacer>
         <q-btn
           color="primary"
           class="add-btn"
@@ -93,21 +87,26 @@
             {{ $t("AddMintDialog.actions.add_mint.in_progress") }}
           </template>
         </q-btn>
-      </q-card-actions>
+      </div>
     </q-card>
   </q-dialog>
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref } from "vue";
+import { defineComponent, computed, ref, watch } from "vue";
+import { useQuasar } from "quasar";
 import { useSettingsStore } from "src/stores/settings";
+import { useMintRecommendationsStore } from "src/stores/mintRecommendations";
+import { getShortUrl } from "src/js/wallet-helpers";
 import MintAuditInfo from "./MintAuditInfo.vue";
+import MintInfoContainer from "./MintInfoContainer.vue";
 import { Info as InfoIcon } from "lucide-vue-next";
 
 export default defineComponent({
   name: "AddMintDialog",
   components: {
     MintAuditInfo,
+    MintInfoContainer,
     InfoIcon,
   },
   props: {
@@ -126,8 +125,11 @@ export default defineComponent({
   },
   emits: ["add", "update:showAddMintDialog"],
   setup(props, { emit }) {
+    const $q = useQuasar();
     const settings = useSettingsStore();
+    const mintRecommendations = useMintRecommendationsStore();
     const showAuditInfo = ref(false);
+    const mintInfoLoading = ref(false);
 
     const showAddMintDialogLocal = computed({
       get: () => props.showAddMintDialog,
@@ -140,54 +142,126 @@ export default defineComponent({
 
     const mintUrl = computed(() => props.addMintData.url);
 
+    const mintHttpInfo = computed(() => {
+      if (!mintUrl.value) return undefined;
+      return mintRecommendations.getHttpInfoForUrl(mintUrl.value);
+    });
+
+    const mintDisplayName = computed(() => {
+      return (
+        props.addMintData.nickname ||
+        mintHttpInfo.value?.name ||
+        (mintUrl.value ? getShortUrl(mintUrl.value) : "")
+      );
+    });
+
+    const mintIconUrl = computed(
+      () => mintHttpInfo.value?.icon_url || undefined
+    );
+
+    // Fetch the mint's info (name, icon) when the sheet opens so the user
+    // sees a rich preview instead of a bare URL.
+    const fetchMintPreview = async (url: string) => {
+      if (!url || mintRecommendations.hasHttpInfo(url)) return;
+      mintInfoLoading.value = true;
+      try {
+        await mintRecommendations.requestMintHttpInfo(url, 5000);
+      } finally {
+        // Only clear the loading state if the sheet is still showing
+        // the same mint URL.
+        if (mintUrl.value === url) {
+          mintInfoLoading.value = false;
+        }
+      }
+    };
+
+    watch(showAddMintDialogLocal, (isOpen) => {
+      if (isOpen) {
+        showAuditInfo.value = false;
+        mintInfoLoading.value = false;
+        fetchMintPreview(mintUrl.value);
+      }
+    });
+
+    watch(mintUrl, (url) => {
+      if (showAddMintDialogLocal.value) {
+        mintInfoLoading.value = false;
+        fetchMintPreview(url);
+      }
+    });
+
     return {
       addMintLocal,
       showAddMintDialogLocal,
       mintUrl,
+      mintDisplayName,
+      mintIconUrl,
+      mintInfoLoading,
       settings,
       showAuditInfo,
+      isDark: computed(() => $q.dark.isActive),
     };
   },
 });
 </script>
 
 <style scoped>
-.add-mint-dialog {
+.add-mint-sheet {
   width: 100%;
-  max-width: 450px;
+  max-width: 500px;
   max-height: 80vh;
-  border-radius: 16px;
+  border-radius: 20px 20px 0 0;
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
-.add-mint-header {
-  position: relative;
-  padding-top: 20px;
+/* Drag handle */
+.sheet-handle-container {
+  display: flex;
+  justify-content: center;
+  padding-top: 10px;
+  padding-bottom: 4px;
   flex-shrink: 0;
 }
 
-.add-mint-title-row {
+.sheet-handle {
+  width: 40px;
+  height: 4px;
+  border-radius: 2px;
+  background-color: rgba(128, 128, 128, 0.4);
+}
+
+/* Header */
+.sheet-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding-top: 8px;
+  padding-bottom: 16px;
+  flex-shrink: 0;
 }
 
-.add-mint-title {
-  font-size: 24px;
+.sheet-title {
+  font-size: 22px;
   font-weight: 700;
   letter-spacing: -0.5px;
   font-family: "Inter", sans-serif;
 }
 
-.add-mint-content {
+.close-btn {
+  opacity: 0.7;
+}
+
+/* Content */
+.sheet-content {
   padding-top: 0;
   flex: 1;
   overflow-y: auto;
 }
 
-.add-mint-description {
+.sheet-description {
   font-size: 15px;
   line-height: 1.5;
   font-weight: 400;
@@ -196,112 +270,42 @@ export default defineComponent({
   font-family: "Inter", sans-serif;
 }
 
-.input-label {
-  display: block;
-  font-size: 13px;
-  font-weight: 600;
-  margin-bottom: 8px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  opacity: 0.7;
-  font-family: "Inter", sans-serif;
+/* Mint preview pill (styled like the mint selector pill, but static) */
+.mint-preview-pill {
+  width: 100%;
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(128, 128, 128, 0.25);
+  background-color: rgba(128, 128, 128, 0.08);
 }
 
-.mint-data-display {
-  padding: 12px;
-  background-color: rgba(0, 0, 0, 0.03);
-  border-radius: 8px;
-  min-height: 48px;
-  display: flex;
-  align-items: center;
-  font-family: "Inter", sans-serif;
-}
-
-.body--dark .mint-data-display {
+.body--dark .mint-preview-pill {
+  border-color: rgba(255, 255, 255, 0.1);
   background-color: rgba(255, 255, 255, 0.05);
 }
 
-.mint-input {
-  border-radius: 8px;
-  height: 48px;
-  font-size: 16px;
+.body--light .mint-preview-pill {
+  border-color: rgba(0, 0, 0, 0.12);
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+.mint-preview-pill :deep(.q-avatar) {
+  margin-right: 16px !important;
+}
+
+/* Audit info */
+.audit-info-btn {
   font-family: "Inter", sans-serif;
 }
 
-/* Completely remove all input animations */
-:deep(.mint-input),
-:deep(.mint-input *) {
-  animation: none !important;
-}
-
-:deep(.mint-input *) {
-  transition: none !important;
-}
-
-/* Add a smooth transition just for the input background-color */
-:deep(.mint-input) {
-  transition: background-color 0.2s ease-in-out !important;
-}
-
-:deep(.mint-input .q-field__focus-target) {
-  border-radius: 8px;
-}
-
-:deep(.mint-input .q-focus-helper) {
-  /* Remove animation completely */
-  opacity: 0 !important;
-  display: none !important; /* Hide it completely */
-}
-
-/* Add subtle focus/active state - theme responsive */
-:deep(.mint-input.q-field--focused) {
-  background-color: rgba(255, 255, 255, 0.1);
-}
-
-/* For dark mode, adjust the focus color */
-:deep(.body--dark .mint-input.q-field--focused) {
-  background-color: rgba(255, 255, 255, 0.07);
-}
-
-/* For light mode, use a darker shade for contrast */
-:deep(.body--light .mint-input.q-field--focused) {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-
-/* Remove any ripple effects */
-:deep(.mint-input .q-ripple) {
-  display: none !important;
-}
-
-/* Remove any before/after pseudo-elements that might animate */
-:deep(.mint-input .q-field__control:before),
-:deep(.mint-input .q-field__control:after) {
-  display: none !important;
-}
-
-/* Ensure no border animations */
-:deep(.mint-input .q-field__control) {
-  height: 48px;
-  border-radius: 8px;
-  transition: none !important;
-}
-
-:deep(.mint-input .q-field__native) {
-  padding: 12px;
-  font-family: "Inter", sans-serif;
-}
-
-/* Make sure input placeholders use Inter font */
-:deep(.mint-input .q-field__native),
-:deep(.mint-input .q-field__input),
-:deep(.mint-input .q-placeholder) {
-  font-family: "Inter", sans-serif;
-}
-
-.action-buttons {
+/* Action buttons */
+.sheet-actions {
   display: flex;
   justify-content: space-between;
-  margin-top: 32px;
+  align-items: center;
+  padding-top: 8px;
+  padding-bottom: 16px;
+  flex-shrink: 0;
 }
 
 .cancel-btn {

--- a/src/components/AddMintDialog.vue
+++ b/src/components/AddMintDialog.vue
@@ -23,9 +23,24 @@
 
       <!-- Scrollable Content Section -->
       <div class="sheet-content q-px-lg scroll">
-        <p class="sheet-description q-mb-lg">
-          {{ $t("AddMintDialog.description") }}
-        </p>
+        <transition name="fade-slide" mode="out-in">
+          <p
+            v-if="mintInfoError"
+            key="error"
+            class="sheet-description sheet-error q-mb-lg"
+          >
+            <q-icon
+              name="error_outline"
+              color="negative"
+              size="18px"
+              class="q-mr-xs sheet-error-icon"
+            />
+            {{ $t("AddMintDialog.unreachable_error_text") }}
+          </p>
+          <p v-else key="description" class="sheet-description q-mb-lg">
+            {{ $t("AddMintDialog.description") }}
+          </p>
+        </transition>
 
         <!-- Mint preview pill -->
         <div class="mint-preview-pill q-mb-lg">
@@ -79,6 +94,7 @@
           @click="addMintLocal"
           v-close-popup
           :loading="addMintBlocking"
+          :disable="addMintDisabled"
           icon="check"
         >
           {{ $t("AddMintDialog.actions.add_mint.label") }}
@@ -129,7 +145,9 @@ export default defineComponent({
     const settings = useSettingsStore();
     const mintRecommendations = useMintRecommendationsStore();
     const showAuditInfo = ref(false);
-    const mintInfoLoading = ref(false);
+    // "idle" | "loading" | "ok" | "error"
+    const mintFetchState = ref("idle");
+    const MINT_INFO_TIMEOUT_MS = 8000;
 
     const showAddMintDialogLocal = computed({
       get: () => props.showAddMintDialog,
@@ -159,34 +177,63 @@ export default defineComponent({
       () => mintHttpInfo.value?.icon_url || undefined
     );
 
+    const mintInfoLoading = computed(() => mintFetchState.value === "loading");
+    const mintInfoError = computed(() => mintFetchState.value === "error");
+    const addMintDisabled = computed(
+      () =>
+        props.addMintBlocking || mintInfoLoading.value || mintInfoError.value
+    );
+
     // Fetch the mint's info (name, icon) when the sheet opens so the user
-    // sees a rich preview instead of a bare URL.
+    // sees a rich preview instead of a bare URL. If the mint cannot be
+    // reached, we show an error and disable the add button.
     const fetchMintPreview = async (url: string) => {
-      if (!url || mintRecommendations.hasHttpInfo(url)) return;
-      mintInfoLoading.value = true;
-      try {
-        await mintRecommendations.requestMintHttpInfo(url, 5000);
-      } finally {
-        // Only clear the loading state if the sheet is still showing
-        // the same mint URL.
-        if (mintUrl.value === url) {
-          mintInfoLoading.value = false;
-        }
+      if (!url) {
+        mintFetchState.value = "idle";
+        return;
       }
+      if (mintRecommendations.hasHttpInfo(url)) {
+        mintFetchState.value = "ok";
+        return;
+      }
+      mintFetchState.value = "loading";
+      const timeout = new Promise((resolve) =>
+        setTimeout(() => resolve("timeout"), MINT_INFO_TIMEOUT_MS)
+      );
+      const fetch = mintRecommendations
+        .requestMintHttpInfo(url, MINT_INFO_TIMEOUT_MS)
+        .then(() => "done")
+        .catch(() => "done");
+      await Promise.race([fetch, timeout]);
+      // Bail out if the sheet was closed or the URL changed meanwhile;
+      // the watcher on mintHttpInfo still flips the state if the info
+      // arrives late.
+      if (mintUrl.value !== url || !showAddMintDialogLocal.value) return;
+      mintFetchState.value = mintRecommendations.hasHttpInfo(url)
+        ? "ok"
+        : "error";
     };
 
     watch(showAddMintDialogLocal, (isOpen) => {
       if (isOpen) {
         showAuditInfo.value = false;
-        mintInfoLoading.value = false;
+        mintFetchState.value = "idle";
         fetchMintPreview(mintUrl.value);
       }
     });
 
     watch(mintUrl, (url) => {
       if (showAddMintDialogLocal.value) {
-        mintInfoLoading.value = false;
+        mintFetchState.value = "idle";
         fetchMintPreview(url);
+      }
+    });
+
+    // If the mint info arrives late (e.g. the fetch outlived our local
+    // timeout), recover from the error/loading state automatically.
+    watch(mintHttpInfo, (info) => {
+      if (info && showAddMintDialogLocal.value) {
+        mintFetchState.value = "ok";
       }
     });
 
@@ -197,6 +244,8 @@ export default defineComponent({
       mintDisplayName,
       mintIconUrl,
       mintInfoLoading,
+      mintInfoError,
+      addMintDisabled,
       settings,
       showAuditInfo,
       isDark: computed(() => $q.dark.isActive),
@@ -268,6 +317,32 @@ export default defineComponent({
   margin-top: 0;
   opacity: 0.7;
   font-family: "Inter", sans-serif;
+}
+
+.sheet-error {
+  opacity: 1;
+  color: var(--q-negative);
+  font-weight: 500;
+}
+
+.sheet-error-icon {
+  vertical-align: -3px;
+}
+
+/* Smooth swap between description and unreachable-mint error */
+.fade-slide-enter-active,
+.fade-slide-leave-active {
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.fade-slide-enter-from {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+
+.fade-slide-leave-to {
+  opacity: 0;
+  transform: translateY(6px);
 }
 
 /* Mint preview pill (styled like the mint selector pill, but static) */

--- a/src/components/MintInfoContainer.vue
+++ b/src/components/MintInfoContainer.vue
@@ -1,41 +1,32 @@
 <template>
   <div class="row items-center">
-    <q-avatar :size="avatarSize" class="q-mr-sm">
-      <transition name="mint-icon" mode="out-in">
-        <q-spinner
-          v-if="loading"
-          key="loading"
-          color="grey-5"
-          :size="fallbackIconSize"
-        />
-        <q-img
-          v-else-if="iconUrl"
-          key="icon"
-          :src="iconUrl"
-          spinner-color="white"
-          spinner-size="xs"
-          :style="`height: ${avatarSize}; max-width: ${avatarSize}; font-size: 12px;`"
-        >
-          <template v-slot:error>
-            <div
-              class="row items-center justify-center"
-              style="height: 100%; width: 100%; padding: 0px"
-            >
-              <q-icon
-                name="account_balance"
-                color="grey-7"
-                :size="fallbackIconSize"
-              />
-            </div>
-          </template>
-        </q-img>
-        <q-icon
-          v-else
-          key="fallback"
-          name="account_balance"
-          color="grey-7"
-          :size="fallbackIconSize"
-        />
+    <q-avatar :size="avatarSize" class="q-mr-sm mint-avatar">
+      <q-img
+        v-if="iconUrl && !imgError"
+        :src="iconUrl"
+        :style="`height: ${avatarSize}; max-width: ${avatarSize}; font-size: 12px;`"
+        @load="imgLoaded = true"
+        @error="imgError = true"
+      >
+        <!-- suppress the default inner spinner; the overlay spinner below
+             already covers the image download -->
+        <template v-slot:loading />
+      </q-img>
+      <q-icon
+        v-else-if="!loading || imgError"
+        name="account_balance"
+        color="grey-7"
+        :size="fallbackIconSize"
+        class="mint-avatar-fallback"
+      />
+      <!-- Single spinner for the whole network chain: mint info fetch
+           and icon image download. The transition wraps a plain div on
+           purpose: transitioning a q-spinner directly breaks Vue's
+           transition timing because of its infinite CSS animation. -->
+      <transition name="mint-avatar-fade">
+        <div v-if="showSpinner" class="mint-avatar-spinner">
+          <q-spinner color="grey-5" :size="fallbackIconSize" />
+        </div>
       </transition>
     </q-avatar>
 
@@ -58,11 +49,30 @@ export default defineComponent({
     avatarSize: { type: String, default: "34px" },
     loading: { type: Boolean, default: false },
   },
+  data() {
+    return {
+      imgLoaded: false,
+      imgError: false,
+    };
+  },
   computed: {
     fallbackIconSize(): string {
       // pick a slightly smaller icon inside the avatar
       const n = parseInt(String(this.avatarSize).replace(/px$/, "")) || 34;
       return Math.max(16, Math.floor(n * 0.6)) + "px";
+    },
+    // The spinner represents the full network delay: while the mint info
+    // is being fetched (loading) and while the icon image is downloading.
+    showSpinner(): boolean {
+      return (
+        this.loading || (!!this.iconUrl && !this.imgLoaded && !this.imgError)
+      );
+    },
+  },
+  watch: {
+    iconUrl() {
+      this.imgLoaded = false;
+      this.imgError = false;
     },
   },
 });
@@ -105,15 +115,45 @@ export default defineComponent({
   max-width: 100%;
 }
 
-/* Smooth cross-fade between loading spinner, icon and fallback icon */
-.mint-icon-enter-active,
-.mint-icon-leave-active {
-  transition: opacity 0.25s ease, transform 0.25s ease;
+/* Avatar states */
+.mint-avatar {
+  position: relative;
 }
 
-.mint-icon-enter-from,
-.mint-icon-leave-to {
+.mint-avatar-fallback {
+  animation: mint-avatar-fade-in 0.3s ease;
+}
+
+.mint-avatar-spinner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Fade for the spinner overlay */
+.mint-avatar-fade-enter-active,
+.mint-avatar-fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.mint-avatar-fade-enter-from,
+.mint-avatar-fade-leave-to {
   opacity: 0;
-  transform: scale(0.8);
+}
+
+@keyframes mint-avatar-fade-in {
+  from {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 </style>

--- a/src/components/MintInfoContainer.vue
+++ b/src/components/MintInfoContainer.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="row items-center">
-    <q-avatar v-if="iconUrl" :size="avatarSize" class="q-mr-sm">
+    <q-avatar :size="avatarSize" class="q-mr-sm">
+      <q-spinner v-if="loading" color="grey-5" :size="fallbackIconSize" />
       <q-img
+        v-else-if="iconUrl"
         :src="iconUrl"
         spinner-color="white"
         spinner-size="xs"
@@ -20,6 +22,12 @@
           </div>
         </template>
       </q-img>
+      <q-icon
+        v-else
+        name="account_balance"
+        color="grey-7"
+        :size="fallbackIconSize"
+      />
     </q-avatar>
 
     <div class="mint-info-container">
@@ -39,6 +47,7 @@ export default defineComponent({
     name: { type: String, required: false },
     iconUrl: { type: String, required: false },
     avatarSize: { type: String, default: "34px" },
+    loading: { type: Boolean, default: false },
   },
   computed: {
     fallbackIconSize(): string {
@@ -50,4 +59,40 @@ export default defineComponent({
 });
 </script>
 
-<style scoped></style>
+<style scoped>
+/* Self-contained styles (mirrors src/css/mintlist.css) so this component
+   renders correctly even when that global stylesheet is not loaded. */
+.mint-info-container {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  /* This is crucial for text wrapping */
+  flex: 1;
+}
+
+.mint-name {
+  text-align: left;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 20px;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  white-space: normal;
+  max-width: 100%;
+}
+
+.mint-url {
+  text-align: left;
+  font-size: 12px;
+  line-height: 16px;
+  font-family: monospace !important;
+  margin-top: 4px;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: break-all;
+  /* For URLs, break-all is better */
+  white-space: normal;
+  max-width: 100%;
+}
+</style>

--- a/src/components/MintInfoContainer.vue
+++ b/src/components/MintInfoContainer.vue
@@ -1,33 +1,42 @@
 <template>
   <div class="row items-center">
     <q-avatar :size="avatarSize" class="q-mr-sm">
-      <q-spinner v-if="loading" color="grey-5" :size="fallbackIconSize" />
-      <q-img
-        v-else-if="iconUrl"
-        :src="iconUrl"
-        spinner-color="white"
-        spinner-size="xs"
-        :style="`height: ${avatarSize}; max-width: ${avatarSize}; font-size: 12px;`"
-      >
-        <template v-slot:error>
-          <div
-            class="row items-center justify-center"
-            style="height: 100%; width: 100%; padding: 0px"
-          >
-            <q-icon
-              name="account_balance"
-              color="grey-7"
-              :size="fallbackIconSize"
-            />
-          </div>
-        </template>
-      </q-img>
-      <q-icon
-        v-else
-        name="account_balance"
-        color="grey-7"
-        :size="fallbackIconSize"
-      />
+      <transition name="mint-icon" mode="out-in">
+        <q-spinner
+          v-if="loading"
+          key="loading"
+          color="grey-5"
+          :size="fallbackIconSize"
+        />
+        <q-img
+          v-else-if="iconUrl"
+          key="icon"
+          :src="iconUrl"
+          spinner-color="white"
+          spinner-size="xs"
+          :style="`height: ${avatarSize}; max-width: ${avatarSize}; font-size: 12px;`"
+        >
+          <template v-slot:error>
+            <div
+              class="row items-center justify-center"
+              style="height: 100%; width: 100%; padding: 0px"
+            >
+              <q-icon
+                name="account_balance"
+                color="grey-7"
+                :size="fallbackIconSize"
+              />
+            </div>
+          </template>
+        </q-img>
+        <q-icon
+          v-else
+          key="fallback"
+          name="account_balance"
+          color="grey-7"
+          :size="fallbackIconSize"
+        />
+      </transition>
     </q-avatar>
 
     <div class="mint-info-container">
@@ -94,5 +103,17 @@ export default defineComponent({
   /* For URLs, break-all is better */
   white-space: normal;
   max-width: 100%;
+}
+
+/* Smooth cross-fade between loading spinner, icon and fallback icon */
+.mint-icon-enter-active,
+.mint-icon-leave-active {
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.mint-icon-enter-from,
+.mint-icon-leave-to {
+  opacity: 0;
+  transform: scale(0.8);
 }
 </style>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1538,6 +1538,8 @@ export default {
     title: "Do you trust this mint?",
     description:
       "Before using this mint, make sure you trust it. Mints could become malicious or cease operation at any time.",
+    unreachable_error_text:
+      "This mint is not reachable. Check the URL and your connection, then try again.",
     inputs: {
       mint_url: {
         label: "@:global.inputs.mint_url.label",

--- a/src/stores/__tests__/wallet.test.js
+++ b/src/stores/__tests__/wallet.test.js
@@ -36,6 +36,7 @@ const h = vi.hoisted(() => {
     lockMutex: vi.fn(async () => {}),
     unlockMutex: vi.fn(),
     closeDialogs: vi.fn(),
+    setTab: vi.fn(),
     formatCurrency: vi.fn((amount, unit) => `${amount} ${unit}`),
     vibrate: vi.fn(),
   };
@@ -77,6 +78,7 @@ const h = vi.hoisted(() => {
       h.mintsStore.activeMintUrl = url;
     }),
     addMintData: { url: "", nickname: "" },
+    showAddMintDialog: false,
     mints: [],
     mintUnitKeysets: vi.fn((mint, unit) =>
       mint.keysets.filter((k) => k.unit === unit)
@@ -2067,6 +2069,8 @@ describe("wallet store", () => {
     expect(h.receiveTokensStore.receiveData.tokensBase64).toBe("cashuAabcdef");
     expect(h.sendTokensStore.sendData.p2pkPubkey).toBe("02abcdef");
     expect(h.mintsStore.addMintData.url).toBe("https://mint-b.example");
+    expect(h.mintsStore.showAddMintDialog).toBe(true);
+    expect(h.uiStore.setTab).toHaveBeenCalledWith("mints");
     expect(wallet.handlePaymentRequest).toHaveBeenCalledWith("creqA123");
     expect(wallet.handlePaymentRequest).toHaveBeenCalledWith("creqb1xyz");
     expect(wallet.handlePaymentRequest).toHaveBeenCalledWith(

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -1588,8 +1588,12 @@ export const useWalletStore = defineStore("wallet", {
       } else if (p2pkStore.isValidPubkey(req)) {
         this.handleP2PK(req);
       } else if (req.startsWith("http")) {
+        // Scanned/pasted mint URL: open the add-mint confirmation sheet on
+        // the mints tab instead of only filling the input box.
         const mintStore = useMintsStore();
         mintStore.addMintData = { url: req, nickname: "" };
+        useUiStore().setTab("mints");
+        mintStore.showAddMintDialog = true;
       } else if (
         req.toLowerCase().startsWith("creqa") ||
         req.toLowerCase().startsWith("creqb")


### PR DESCRIPTION
## Summary

Reworks the add-mint confirmation from a centered dialog into an animated **bottom sheet** (matching the mint selection sheet) and replaces the readonly URL input with a **mint preview pill** — mint icon, name and URL — using the reusable `MintInfoContainer` component.

### Bottom sheet
- `q-dialog position="bottom"` with slide-up/slide-down transitions, drag handle, rounded top corners, safe-area padding, and dark/light theming like other dialogs.

### Rich mint preview
- On open, the sheet probes the mint's `/v1/info` (via the existing `mintRecommendations` store, Dexie-cached) and shows the mint's icon and name in the pill.
- **Loading:** a spinner replaces the avatar while fetching; the Add mint button is disabled until the probe resolves.
- **Unreachable mint:** the trust description smoothly swaps to an error message and the Add mint button stays disabled; late-arriving info recovers the sheet automatically.
- All state changes (sheet slide, description/error swap, spinner/icon cross-fade) are animated.

### `MintInfoContainer` enhancements
- Always renders an avatar: spinner (new `loading` prop), mint icon, or `account_balance` fallback (consistent with `ChooseMint`).
- Now ships its own scoped styles instead of depending on the global `mintlist.css`.

## Test plan
- `npm run test:ci` — 186/186 pass; `npm run build` OK; eslint/prettier clean.
- Browser-verified (mobile viewport, dark + light): loading spinner, unreachable-mint error with disabled button, happy path with fetched icon/name, cancel + confirm flows, audit info expansion.
- `data-testid="confirm-add-mint"` preserved for e2e (button starts disabled until probe resolves; Playwright actionability waits handle this).