### PR TITLE
Polish mint details page, mint selector pill, and wallet motion

### DIFF
--- a/docs/DESIGN_UPDATE.md
+++ b/docs/DESIGN_UPDATE.md
@@ -1,0 +1,344 @@
+# Design Update — Mint Details Page Pattern
+
+This document specifies the design pattern introduced with the rework of
+`src/pages/MintDetailsPage.vue` (branch `feat/wallet-ui-polish`). It is written
+as a **reusable specification**: the same pattern applies to any detail /
+settings-style page in the app (token details, invoice details, settings
+subpages).
+
+The pattern is grounded in two principles:
+
+1. **Hierarchy through grouping, not chrome.** Sections are separated by a
+   small uppercase muted label and whitespace — not by heavy divider lines.
+   Related rows live together in a single rounded "surface card", iOS
+   grouped-list style.
+2. **Every interaction has instant, physical feedback.** Pressable elements
+   scale subtly on pointer-down, enters use strong ease-out curves, exits are
+   faster than enters, and nothing animates properties that trigger layout.
+
+---
+
+## 1. Page structure & element ordering
+
+The page reads as a top-down narrative: **identity → communication → facts →
+trust → actions.** Progressive disclosure keeps advanced content one tap away
+instead of cluttering the first viewport.
+
+| # | Block | Contents | Ordering rationale |
+| - | ----- | -------- | ------------------ |
+| 1 | **Header card** | Mint avatar (64px), mint name, QR toggle | Answers "where am I?" instantly. The QR (secondary, rarely needed) is hidden behind a small icon button anchored to the card's top-right corner. |
+| 2 | **Descriptions** | MOTD banner (dismissible), `description`, `description_long` | What the mint wants to communicate. MOTD is dismissible and collapses smoothly. |
+| 3 | **CONTACT** | One row per contact method (icon · value · copy) | Only rendered when contacts exist — no empty chrome. |
+| 4 | **MINT DETAILS** | URL, Nuts, Currency, Currency units, Version | Objective facts about the mint. Nuts collapse behind "View all" (progressive disclosure). |
+| 5 | **AUDIT INFO** | Audit status (only when the auditor is enabled) | Trust assessment comes after the facts. |
+| 6 | **ACTIONS** | Edit · Copy URL · Review · **Delete** | What the user can do. The destructive action is last and visually isolated in red. |
+
+Layout rules:
+
+- Page content is capped at `max-width: 600px`, centered, in **normal document
+  flow** (no absolute-position hacks, no magic `margin-top` offsets).
+- Vertical rhythm comes from the section labels (`margin: 28px 0 8px 4px`),
+  not from ad-hoc spacers between blocks.
+- The page root is theme-aware:
+  `:class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"`.
+
+---
+
+## 2. Design tokens
+
+### 2.1 Color — theme-aware via CSS custom properties
+
+All colors on the page resolve through locally scoped custom properties, so
+the page works in dark and light mode without branching markup:
+
+```scss
+.mint-details {
+  --md-text: #ffffff;
+  --md-muted: #8e8e93;           // secondary text, icons
+  --md-surface: rgba(255, 255, 255, 0.05);
+  --md-surface-hover: rgba(255, 255, 255, 0.1);
+  --md-danger: #ff453a;          // destructive actions
+}
+body:not(.body--dark) .mint-details {
+  --md-text: #1d1d1d;
+  --md-muted: #6e6e73;
+  --md-surface: rgba(0, 0, 0, 0.04);
+  --md-surface-hover: rgba(0, 0, 0, 0.08);
+  --md-danger: #d70015;
+}
+```
+
+Never hardcode `#9E9E9E`-style greys in templates; use `var(--md-muted)`.
+Brand-dependent accents use `var(--q-primary)` so all nine app themes work.
+
+### 2.2 Motion — shared tokens (defined in `src/css/app.scss`)
+
+```scss
+:root {
+  --ease-out: cubic-bezier(0.23, 1, 0.32, 1);      // enter / UI interactions
+  --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);  // on-screen movement
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);     // hover / color changes
+  --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);   // sheets
+
+  --dur-press: 160ms;  // press feedback
+  --dur-fast: 200ms;   // small UI (hovers, tooltips)
+  --dur-ui: 250ms;     // expands, small panels
+}
+```
+
+Built-in CSS easings (`ease`, `ease-in`) are too weak for UI — always use the
+tokens. **Never `ease-in` on entering elements** (delayed initial movement
+feels sluggish).
+
+---
+
+## 3. Typography
+
+Hierarchy is built from **weight + size + tracking as a set**, not size alone.
+All type is Inter.
+
+| Role | Spec | Notes |
+| ---- | ---- | ----- |
+| Mint name | 22px / 600 / `letter-spacing: -0.02em` | Display text gets *negative* tracking |
+| Section label | 12px / 600 / `letter-spacing: 0.08em` / uppercase / `--md-muted` | The only "chrome" between sections |
+| Description | 16px / 600 / line-height 24px / `-0.01em` | |
+| Long description | 14px / 500 / line-height 20px / `--md-muted` | |
+| Row label | 15px / 500 / `--md-muted` | Left side of a detail row |
+| Row value | 15px / 600 / `--md-text` | Right side, truncates with ellipsis |
+| Numeric values | `font-variant-numeric: tabular-nums` | `.tnum` utility or inline; prevents jitter |
+
+---
+
+## 4. Component recipes
+
+### 4.1 Section label
+
+```html
+<div class="section-label">{{ $t("...") }}</div>
+```
+
+```scss
+.section-label {
+  color: var(--md-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  margin: 28px 0 8px 4px;   /* whitespace creates the grouping */
+  text-transform: uppercase;
+}
+```
+
+Replaces the old `line — TEXT — line` dividers. The 4px left offset aligns
+the label optically with the 10px row padding inside the card.
+
+### 4.2 Surface card (group container)
+
+```scss
+.surface-card {
+  background-color: var(--md-surface);
+  border-radius: 16px;
+  overflow: hidden;   /* clips row press/hover backgrounds to the radius */
+  padding: 4px;       /* rows float inside with 12px radius */
+  width: 100%;
+}
+```
+
+One card per section. Rows inside the card have `border-radius: 12px` so
+their hover/press backgrounds read as inset, not as sharp rectangles
+touching the card edge.
+
+### 4.3 Detail row (label left, value right)
+
+```html
+<div class="detail-item detail-item--clickable pressable cursor-pointer">
+  <div class="detail-label">
+    <link-icon :size="18" class="detail-icon" />
+    <div class="detail-name">URL</div>
+  </div>
+  <div class="detail-value">
+    <span class="detail-value-text">https://…</span>
+    <copy-icon :size="14" class="detail-value-icon" />
+  </div>
+</div>
+```
+
+- Row: `min-height: 44px` (touch target), `padding: 8px 10px`.
+- Icon: 18px, `--md-muted`, `margin-right: 12px` — same size across all rows.
+- Label: muted, 15px/500. Value: 15px/600, right-aligned, `max-width: 60%`,
+  truncates with ellipsis.
+- If the row performs an action (copy): add `detail-item--clickable
+  pressable cursor-pointer` and a small (14px) trailing affordance icon.
+- If the row only expands content (Nuts): the value becomes a toggle in
+  `var(--q-primary)` with a chevron that rotates 180° when open
+  (`transition: transform var(--dur-ui) var(--ease-out)`).
+
+### 4.4 Expansion content (Nuts chips)
+
+Expanded content renders as chips, not bare text lines:
+
+```scss
+.nut-pill {
+  background-color: var(--md-surface);
+  border-radius: 8px;
+  padding: 8px 12px;
+}
+.nut-number {
+  color: var(--md-muted);
+  font-variant-numeric: tabular-nums;
+  min-width: 18px;        /* numbers align in a clean column */
+  margin-right: 8px;
+}
+```
+
+Single-column, `gap: 6px`, inset inside the details card.
+
+### 4.5 Action row
+
+```html
+<div class="action-button pressable cursor-pointer">
+  <pencil-icon :size="18" class="action-icon" />
+  <div class="action-label">Edit mint</div>
+</div>
+```
+
+- Row: `min-height: 44px`, `padding: 10px`, `gap: 14px`, `border-radius: 12px`.
+- Icon 18px `--md-muted`; label 15px/500.
+- **Destructive** (`.delete-button`): icon + label in `var(--md-danger)`;
+  hover background `color-mix(in srgb, var(--md-danger) 10%, transparent)`;
+  active background at 14%. Danger is communicated by color alone — never by
+  animation.
+
+### 4.6 Header card + anchored toggle
+
+The page header is a surface card containing identity (avatar, name).
+Secondary affordances (QR code toggle) are **anchored to the card** as small
+icon buttons — not floating loose in the layout:
+
+```scss
+.mint-header { position: relative; }
+.qr-toggle-btn {
+  color: var(--md-muted);
+  position: absolute;
+  right: 10px;
+  top: 10px;
+}
+```
+
+The revealed content (QR) expands *inside* the same card via the
+`smooth-slide` transition, so the spatial relationship trigger → content is
+obvious.
+
+---
+
+## 5. Motion specification
+
+### 5.1 Rules
+
+1. **Only `transform` and `opacity` animate** (plus `max-height`/margins for
+   expand-collapse, accepted as a pragmatic exception — see below).
+   Never `transition: all`; always list explicit properties.
+2. **Enter = strong ease-out. Never ease-in.**
+3. **Asymmetric timing:** enter slower, exit faster (the interface responds
+   quickly when dismissing, arrives gently when appearing).
+4. **Never animate from `scale(0)`.** Start at `scale(0.95)`–`0.98` + opacity 0
+   — nothing in the real world appears from nothing.
+5. UI transitions stay **≤ 300ms**.
+
+### 5.2 Expand / collapse (`smooth-slide`, `expand`)
+
+Used for the QR reveal and the Nuts list:
+
+```scss
+.smooth-slide-enter-active {
+  transition: max-height 0.3s var(--ease-out), opacity 0.25s var(--ease-out),
+    transform 0.3s var(--ease-out), margin-bottom 0.3s var(--ease-out);
+  max-height: 350px;
+}
+.smooth-slide-leave-active {
+  transition: max-height 0.2s var(--ease-out), opacity 0.15s var(--ease-out),
+    transform 0.2s var(--ease-out), margin-bottom 0.2s var(--ease-out);
+  max-height: 350px;
+}
+.smooth-slide-enter-from,
+.smooth-slide-leave-to {
+  max-height: 0;
+  opacity: 0;
+  transform: translateY(-8px) scale(0.98);
+}
+```
+
+`expand` is the same pattern with `max-height: 1200px` for long content
+(transform left out — plain height/opacity reveal).
+
+> Expanding stacked content needs a height change; `max-height` is the
+> pragmatic tool. Keep the cap close to the real content height (350px QR,
+> 1200px nuts) so the easing curve maps honestly to the visible motion.
+
+### 5.3 Press feedback
+
+Defined globally in `app.scss`; the details page consumes it via `q-btn` and
+`.pressable`:
+
+```scss
+.q-btn { transition: transform var(--dur-press) var(--ease-out), box-shadow 0.2s var(--ease-standard); }
+.q-btn:active { transform: scale(0.97); }
+
+.pressable { transition: transform var(--dur-press) var(--ease-out),
+                         background-color var(--dur-press) var(--ease-standard); }
+.pressable:active { transform: scale(0.98); }
+```
+
+Press feedback fires on **pointer-down**, not on release — that is what makes
+the interface feel like it's listening.
+
+### 5.4 Hover states
+
+Only on devices with a real pointer; on touch, `:hover` sticks after the tap:
+
+```scss
+@media (hover: hover) and (pointer: fine) {
+  .action-button:hover { background-color: var(--md-surface-hover); }
+}
+```
+
+### 5.5 Reduced motion
+
+```scss
+@media (prefers-reduced-motion: reduce) {
+  .smooth-slide-enter-active, .expand-enter-active /* … */ {
+    transition: opacity 0.15s ease;
+    transform: none;
+  }
+}
+```
+
+Reduced motion keeps **opacity/color** feedback (comprehension) and drops
+**movement** (vestibular safety).
+
+---
+
+## 6. Interaction checklist for new rows/buttons
+
+When adding a row or button in this pattern, verify:
+
+- [ ] Tap target ≥ 44px tall.
+- [ ] Press feedback present (`q-btn` or `.pressable`), scale 0.97–0.98.
+- [ ] Hover styles only inside `@media (hover: hover) and (pointer: fine)`.
+- [ ] Transition lists explicit properties; durations from tokens; ease-out.
+- [ ] Colors via `--md-*` / `var(--q-primary)` — no hardcoded hex in markup.
+- [ ] Icon-only buttons have an `aria-label`.
+- [ ] Destructive actions come last, colored `var(--md-danger)`.
+- [ ] Numbers use `tabular-nums`.
+- [ ] Icon sizes consistent within a context (18px rows, 14–16px affordances).
+- [ ] New expands/collapses reuse `smooth-slide`/`expand`; new swaps reuse
+      the keyed micro-transition pattern (leaving element `position: absolute`
+      so layout doesn't jump).
+
+---
+
+## 7. Reference implementation
+
+- Page: `src/pages/MintDetailsPage.vue` (structure, tokens, recipes above)
+- Shared tokens & global press/hover/reduced-motion rules: `src/css/app.scss`
+- Micro-transition pattern (keyed swap with absolute leaving element):
+  `src/components/BalanceView.vue` → `.mint-chip-*`

--- a/docs/DESIGN_UPDATE.md
+++ b/docs/DESIGN_UPDATE.md
@@ -24,14 +24,14 @@ The page reads as a top-down narrative: **identity → communication → facts �
 trust → actions.** Progressive disclosure keeps advanced content one tap away
 instead of cluttering the first viewport.
 
-| # | Block | Contents | Ordering rationale |
-| - | ----- | -------- | ------------------ |
-| 1 | **Header card** | Mint avatar (64px), mint name, QR toggle | Answers "where am I?" instantly. The QR (secondary, rarely needed) is hidden behind a small icon button anchored to the card's top-right corner. |
-| 2 | **Descriptions** | MOTD banner (dismissible), `description`, `description_long` | What the mint wants to communicate. MOTD is dismissible and collapses smoothly. |
-| 3 | **CONTACT** | One row per contact method (icon · value · copy) | Only rendered when contacts exist — no empty chrome. |
-| 4 | **MINT DETAILS** | URL, Nuts, Currency, Currency units, Version | Objective facts about the mint. Nuts collapse behind "View all" (progressive disclosure). |
-| 5 | **AUDIT INFO** | Audit status (only when the auditor is enabled) | Trust assessment comes after the facts. |
-| 6 | **ACTIONS** | Edit · Copy URL · Review · **Delete** | What the user can do. The destructive action is last and visually isolated in red. |
+| #   | Block            | Contents                                                     | Ordering rationale                                                                                                                               |
+| --- | ---------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | **Header card**  | Mint avatar (64px), mint name, QR toggle                     | Answers "where am I?" instantly. The QR (secondary, rarely needed) is hidden behind a small icon button anchored to the card's top-right corner. |
+| 2   | **Descriptions** | MOTD banner (dismissible), `description`, `description_long` | What the mint wants to communicate. MOTD is dismissible and collapses smoothly.                                                                  |
+| 3   | **CONTACT**      | One row per contact method (icon · value · copy)             | Only rendered when contacts exist — no empty chrome.                                                                                             |
+| 4   | **MINT DETAILS** | URL, Nuts, Currency, Currency units, Version                 | Objective facts about the mint. Nuts collapse behind "View all" (progressive disclosure).                                                        |
+| 5   | **AUDIT INFO**   | Audit status (only when the auditor is enabled)              | Trust assessment comes after the facts.                                                                                                          |
+| 6   | **ACTIONS**      | Edit · Copy URL · Review · **Delete**                        | What the user can do. The destructive action is last and visually isolated in red.                                                               |
 
 Layout rules:
 
@@ -54,10 +54,10 @@ the page works in dark and light mode without branching markup:
 ```scss
 .mint-details {
   --md-text: #ffffff;
-  --md-muted: #8e8e93;           // secondary text, icons
+  --md-muted: #8e8e93; // secondary text, icons
   --md-surface: rgba(255, 255, 255, 0.05);
   --md-surface-hover: rgba(255, 255, 255, 0.1);
-  --md-danger: #ff453a;          // destructive actions
+  --md-danger: #ff453a; // destructive actions
 }
 body:not(.body--dark) .mint-details {
   --md-text: #1d1d1d;
@@ -75,14 +75,14 @@ Brand-dependent accents use `var(--q-primary)` so all nine app themes work.
 
 ```scss
 :root {
-  --ease-out: cubic-bezier(0.23, 1, 0.32, 1);      // enter / UI interactions
-  --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);  // on-screen movement
-  --ease-standard: cubic-bezier(0.2, 0, 0, 1);     // hover / color changes
-  --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);   // sheets
+  --ease-out: cubic-bezier(0.23, 1, 0.32, 1); // enter / UI interactions
+  --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1); // on-screen movement
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1); // hover / color changes
+  --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1); // sheets
 
-  --dur-press: 160ms;  // press feedback
-  --dur-fast: 200ms;   // small UI (hovers, tooltips)
-  --dur-ui: 250ms;     // expands, small panels
+  --dur-press: 160ms; // press feedback
+  --dur-fast: 200ms; // small UI (hovers, tooltips)
+  --dur-ui: 250ms; // expands, small panels
 }
 ```
 
@@ -97,15 +97,15 @@ feels sluggish).
 Hierarchy is built from **weight + size + tracking as a set**, not size alone.
 All type is Inter.
 
-| Role | Spec | Notes |
-| ---- | ---- | ----- |
-| Mint name | 22px / 600 / `letter-spacing: -0.02em` | Display text gets *negative* tracking |
-| Section label | 12px / 600 / `letter-spacing: 0.08em` / uppercase / `--md-muted` | The only "chrome" between sections |
-| Description | 16px / 600 / line-height 24px / `-0.01em` | |
-| Long description | 14px / 500 / line-height 20px / `--md-muted` | |
-| Row label | 15px / 500 / `--md-muted` | Left side of a detail row |
-| Row value | 15px / 600 / `--md-text` | Right side, truncates with ellipsis |
-| Numeric values | `font-variant-numeric: tabular-nums` | `.tnum` utility or inline; prevents jitter |
+| Role             | Spec                                                             | Notes                                      |
+| ---------------- | ---------------------------------------------------------------- | ------------------------------------------ |
+| Mint name        | 22px / 600 / `letter-spacing: -0.02em`                           | Display text gets _negative_ tracking      |
+| Section label    | 12px / 600 / `letter-spacing: 0.08em` / uppercase / `--md-muted` | The only "chrome" between sections         |
+| Description      | 16px / 600 / line-height 24px / `-0.01em`                        |                                            |
+| Long description | 14px / 500 / line-height 20px / `--md-muted`                     |                                            |
+| Row label        | 15px / 500 / `--md-muted`                                        | Left side of a detail row                  |
+| Row value        | 15px / 600 / `--md-text`                                         | Right side, truncates with ellipsis        |
+| Numeric values   | `font-variant-numeric: tabular-nums`                             | `.tnum` utility or inline; prevents jitter |
 
 ---
 
@@ -123,7 +123,7 @@ All type is Inter.
   font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 0.08em;
-  margin: 28px 0 8px 4px;   /* whitespace creates the grouping */
+  margin: 28px 0 8px 4px; /* whitespace creates the grouping */
   text-transform: uppercase;
 }
 ```
@@ -137,8 +137,8 @@ the label optically with the 10px row padding inside the card.
 .surface-card {
   background-color: var(--md-surface);
   border-radius: 16px;
-  overflow: hidden;   /* clips row press/hover backgrounds to the radius */
-  padding: 4px;       /* rows float inside with 12px radius */
+  overflow: hidden; /* clips row press/hover backgrounds to the radius */
+  padding: 4px; /* rows float inside with 12px radius */
   width: 100%;
 }
 ```
@@ -167,7 +167,7 @@ touching the card edge.
 - Label: muted, 15px/500. Value: 15px/600, right-aligned, `max-width: 60%`,
   truncates with ellipsis.
 - If the row performs an action (copy): add `detail-item--clickable
-  pressable cursor-pointer` and a small (14px) trailing affordance icon.
+pressable cursor-pointer` and a small (14px) trailing affordance icon.
 - If the row only expands content (Nuts): the value becomes a toggle in
   `var(--q-primary)` with a chevron that rotates 180° when open
   (`transition: transform var(--dur-ui) var(--ease-out)`).
@@ -185,7 +185,7 @@ Expanded content renders as chips, not bare text lines:
 .nut-number {
   color: var(--md-muted);
   font-variant-numeric: tabular-nums;
-  min-width: 18px;        /* numbers align in a clean column */
+  min-width: 18px; /* numbers align in a clean column */
   margin-right: 8px;
 }
 ```
@@ -215,7 +215,9 @@ Secondary affordances (QR code toggle) are **anchored to the card** as small
 icon buttons — not floating loose in the layout:
 
 ```scss
-.mint-header { position: relative; }
+.mint-header {
+  position: relative;
+}
 .qr-toggle-btn {
   color: var(--md-muted);
   position: absolute;
@@ -224,7 +226,7 @@ icon buttons — not floating loose in the layout:
 }
 ```
 
-The revealed content (QR) expands *inside* the same card via the
+The revealed content (QR) expands _inside_ the same card via the
 `smooth-slide` transition, so the spatial relationship trigger → content is
 obvious.
 
@@ -280,12 +282,21 @@ Defined globally in `app.scss`; the details page consumes it via `q-btn` and
 `.pressable`:
 
 ```scss
-.q-btn { transition: transform var(--dur-press) var(--ease-out), box-shadow 0.2s var(--ease-standard); }
-.q-btn:active { transform: scale(0.97); }
+.q-btn {
+  transition: transform var(--dur-press) var(--ease-out), box-shadow 0.2s var(--ease-standard);
+}
+.q-btn:active {
+  transform: scale(0.97);
+}
 
-.pressable { transition: transform var(--dur-press) var(--ease-out),
-                         background-color var(--dur-press) var(--ease-standard); }
-.pressable:active { transform: scale(0.98); }
+.pressable {
+  transition: transform var(--dur-press) var(--ease-out), background-color var(
+        --dur-press
+      ) var(--ease-standard);
+}
+.pressable:active {
+  transform: scale(0.98);
+}
 ```
 
 Press feedback fires on **pointer-down**, not on release — that is what makes
@@ -297,7 +308,9 @@ Only on devices with a real pointer; on touch, `:hover` sticks after the tap:
 
 ```scss
 @media (hover: hover) and (pointer: fine) {
-  .action-button:hover { background-color: var(--md-surface-hover); }
+  .action-button:hover {
+    background-color: var(--md-surface-hover);
+  }
 }
 ```
 

--- a/src/components/AddMintDialog.vue
+++ b/src/components/AddMintDialog.vue
@@ -204,11 +204,15 @@ export default defineComponent({
         : "description"
     );
     const addMintDisabled = computed(
+      // Gate on the resolved preview, not just the absence of loading:
+      // there is a brief "idle" window between the sheet opening and the
+      // watcher kicking off the fetch, and a click landing in it races the
+      // probe (the button flips state mid-click and the close/add handlers
+      // can be dropped).
       () =>
         props.addMintBlocking ||
-        mintInfoLoading.value ||
-        mintInfoError.value ||
-        mintAlreadyAdded.value
+        mintAlreadyAdded.value ||
+        mintFetchState.value !== "ok"
     );
 
     // Fetch the mint's info (name, icon) when the sheet opens so the user

--- a/src/components/AnimatedNumber.vue
+++ b/src/components/AnimatedNumber.vue
@@ -14,7 +14,7 @@ export default defineComponent({
     },
     duration: {
       type: Number,
-      default: 1000, // Animation duration in milliseconds
+      default: 600, // Animation duration in milliseconds
     },
     format: {
       type: Function,
@@ -25,6 +25,13 @@ export default defineComponent({
     const displayedValue = ref(props.value);
     // value to remember that we do not want to animate the very first update (when the component is created)
     const initialized = ref(false);
+    const reduceMotion =
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    // Ease-out cubic: the count starts fast and settles gently,
+    // which feels responsive instead of mechanical (linear).
+    const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
 
     watch(
       () => props.value,
@@ -37,6 +44,10 @@ export default defineComponent({
           }
           return;
         }
+        if (reduceMotion) {
+          displayedValue.value = newValue;
+          return;
+        }
         const startTime = performance.now();
         const startValue = oldValue !== undefined ? oldValue : newValue;
         const endValue = newValue;
@@ -44,7 +55,8 @@ export default defineComponent({
         const animate = (currentTime: number) => {
           const elapsed = currentTime - startTime;
           const progress = Math.max(Math.min(elapsed / props.duration, 1), 0);
-          const currentValue = startValue + (endValue - startValue) * progress;
+          const currentValue =
+            startValue + (endValue - startValue) * easeOutCubic(progress);
           displayedValue.value = currentValue;
           if (progress < 1) {
             requestAnimationFrame(animate);

--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- <q-card class="q-my-md q-py-sm">
     <q-card-section class="q-mt-sm q-py-xs"> -->
-  <div class="q-pt-md q-pb-md">
+  <div class="q-pt-none q-pb-md">
     <!-- mint selector pill -->
     <div class="row justify-center q-mb-none" v-if="activeMintUrl">
       <div class="mint-chip pressable cursor-pointer" @click="openMintChooser">
@@ -34,7 +34,7 @@
       leave-active-class="animated fadeInDown"
       mode="out-in"
     >
-      <div class="balance-carousel-shell q-mt-lg q-mb-xl text-primary">
+      <div class="balance-carousel-shell q-mb-xl text-primary">
         <transition
           appear
           enter-active-class="animated fadeIn"
@@ -364,6 +364,7 @@ export default defineComponent({
   animation-timing-function: var(--ease-out);
 }
 .balance-carousel-shell {
+  margin-top: 40px; /* centers the mint pill in the fixed header-to-balance band */
   overflow-x: hidden;
   overscroll-behavior-x: contain;
   position: relative;

--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -1,14 +1,14 @@
 <template>
   <!-- <q-card class="q-my-md q-py-sm">
     <q-card-section class="q-mt-sm q-py-xs"> -->
-  <div class="q-pt-lg q-pb-sm">
+  <div class="q-pt-xl q-pb-md">
     <transition
       appear
       enter-active-class="animated fadeInDown"
       leave-active-class="animated fadeInDown"
       mode="out-in"
     >
-      <div class="balance-carousel-shell q-mt-md q-mb-md text-primary">
+      <div class="balance-carousel-shell q-mt-lg q-mb-xl text-primary">
         <transition
           appear
           enter-active-class="animated fadeIn"

--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -1,7 +1,33 @@
 <template>
   <!-- <q-card class="q-my-md q-py-sm">
     <q-card-section class="q-mt-sm q-py-xs"> -->
-  <div class="q-pt-xl q-pb-md">
+  <div class="q-pt-md q-pb-md">
+    <!-- mint selector pill -->
+    <div class="row justify-center q-mb-none" v-if="activeMintUrl">
+      <div class="mint-chip pressable cursor-pointer" @click="openMintChooser">
+        <transition name="mint-chip-avatar">
+          <img
+            v-if="showMintAvatar"
+            :key="activeMintIconUrl"
+            :src="activeMintIconUrl"
+            class="mint-chip-avatar"
+            alt=""
+            @error="avatarLoadFailed = true"
+          />
+        </transition>
+        <transition name="mint-chip-name">
+          <span
+            :key="activeMintLabel"
+            class="mint-chip-name text-weight-medium"
+            >{{ activeMintLabel }}</span
+          >
+        </transition>
+      </div>
+      <!-- Hidden selector that owns the mint-selection bottom sheet -->
+      <div class="hidden">
+        <ChooseMint ref="chooseMint" />
+      </div>
+    </div>
     <transition
       appear
       enter-active-class="animated fadeInDown"
@@ -110,32 +136,6 @@
           {{ $t("BalanceView.mintError.label") }}
           <q-icon name="error" class="q-ml-xs" size="xs" />
         </span>
-      </div>
-    </div>
-    <!-- mint url -->
-    <div class="row justify-center q-mt-sm q-mb-none" v-if="activeMintUrl">
-      <div class="mint-chip pressable cursor-pointer" @click="openMintChooser">
-        <transition name="mint-chip-avatar">
-          <img
-            v-if="showMintAvatar"
-            :key="activeMintIconUrl"
-            :src="activeMintIconUrl"
-            class="mint-chip-avatar"
-            alt=""
-            @error="avatarLoadFailed = true"
-          />
-        </transition>
-        <transition name="mint-chip-name">
-          <span
-            :key="activeMintLabel"
-            class="mint-chip-name text-weight-medium"
-            >{{ activeMintLabel }}</span
-          >
-        </transition>
-      </div>
-      <!-- Hidden selector that owns the mint-selection bottom sheet -->
-      <div class="hidden">
-        <ChooseMint ref="chooseMint" />
       </div>
     </div>
   </div>

--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -1,17 +1,17 @@
 <template>
   <!-- <q-card class="q-my-md q-py-sm">
     <q-card-section class="q-mt-sm q-py-xs"> -->
-  <div class="q-pt-xl q-pb-md">
+  <div class="q-pt-lg q-pb-sm">
     <transition
       appear
       enter-active-class="animated fadeInDown"
       leave-active-class="animated fadeInDown"
       mode="out-in"
     >
-      <div class="balance-carousel-shell q-mt-lg q-mb-xl text-primary">
+      <div class="balance-carousel-shell q-mt-md q-mb-md text-primary">
         <transition
           appear
-          enter-active-class="animated pulse"
+          enter-active-class="animated fadeIn"
           leave-active-class="animated fadeOut"
         >
           <q-spinner
@@ -113,26 +113,29 @@
       </div>
     </div>
     <!-- mint url -->
-    <div class="row q-mt-md q-mb-none text-secondary" v-if="activeMintUrl">
-      <div class="col-12 cursor-pointer">
-        <span class="text-weight-light" @click="setTab('mints')">
-          {{ $t("BalanceView.mintUrl.label") }}: <b>{{ activeMintLabel }}</b>
-        </span>
+    <div class="row justify-center q-mt-sm q-mb-none" v-if="activeMintUrl">
+      <div class="mint-chip pressable cursor-pointer" @click="openMintChooser">
+        <transition name="mint-chip-avatar">
+          <img
+            v-if="showMintAvatar"
+            :key="activeMintIconUrl"
+            :src="activeMintIconUrl"
+            class="mint-chip-avatar"
+            alt=""
+            @error="avatarLoadFailed = true"
+          />
+        </transition>
+        <transition name="mint-chip-name">
+          <span
+            :key="activeMintLabel"
+            class="mint-chip-name text-weight-medium"
+            >{{ activeMintLabel }}</span
+          >
+        </transition>
       </div>
-    </div>
-    <!-- mint balance -->
-    <div class="row q-mb-none text-secondary" v-if="mints.length > 1">
-      <div class="col-12">
-        <span class="q-my-none q-py-none text-weight-regular">
-          {{ $t("BalanceView.mintBalance.label") }}:
-          <b>
-            <AnimatedNumber
-              :value="getActiveBalance"
-              :format="(val) => formatCurrency(val, activeUnit)"
-              class="q-my-none q-py-none cursor-pointer"
-            />
-          </b>
-        </span>
+      <!-- Hidden selector that owns the mint-selection bottom sheet -->
+      <div class="hidden">
+        <ChooseMint ref="chooseMint" />
       </div>
     </div>
   </div>
@@ -150,6 +153,7 @@ import { useUiStore } from "src/stores/ui";
 import { useWalletStore } from "src/stores/wallet";
 import { usePriceStore } from "src/stores/price";
 import AnimatedNumber from "src/components/AnimatedNumber.vue";
+import ChooseMint from "src/components/ChooseMint.vue";
 import { sumProofAmounts } from "src/js/proofs";
 import { useProofsStore } from "src/stores/proofs";
 
@@ -158,6 +162,7 @@ export default defineComponent({
   mixins: [windowMixin],
   components: {
     AnimatedNumber,
+    ChooseMint,
   },
   props: {
     setTab: Function,
@@ -166,7 +171,6 @@ export default defineComponent({
     ...mapState(useMintsStore, [
       "activeMintUrl",
       "activeProofs",
-      "activeBalance",
       "mints",
       "totalUnitBalance",
       "activeUnit",
@@ -222,9 +226,6 @@ export default defineComponent({
     getTotalBalance: function () {
       return this.totalUnitBalance;
     },
-    getActiveBalance: function () {
-      return this.activeBalance;
-    },
     activeMintLabel: function () {
       const mintClass = this.activeMint();
 
@@ -234,6 +235,13 @@ export default defineComponent({
         getShortUrl(this.activeMintUrl)
       );
     },
+    activeMintIconUrl: function () {
+      const mintClass = this.activeMint();
+      return mintClass?.mint?.info?.icon_url || null;
+    },
+    showMintAvatar: function () {
+      return Boolean(this.activeMintIconUrl) && !this.avatarLoadFailed;
+    },
     getBalance: function () {
       return sumProofAmounts(this.activeProofs.flat());
     },
@@ -241,6 +249,7 @@ export default defineComponent({
   data() {
     return {
       priceLabel: null,
+      avatarLoadFailed: false,
     };
   },
   mounted() {
@@ -255,12 +264,20 @@ export default defineComponent({
         }
       },
     },
+    activeMintIconUrl() {
+      // New icon URL -> give the new avatar a chance to load
+      this.avatarLoadFailed = false;
+    },
   },
   methods: {
     ...mapActions(useWalletStore, ["checkPendingTokens"]),
     ...mapActions(usePriceStore, ["fetchBitcoinPrice"]),
     setActiveUnit(unit: string) {
       this.activeUnit = unit;
+    },
+    openMintChooser() {
+      // Open the mint-selection bottom sheet owned by the hidden ChooseMint
+      this.$refs.chooseMint.showMintSheet = true;
     },
     toggleUnit: function () {
       const units = this.activeMint().units;
@@ -339,11 +356,12 @@ export default defineComponent({
 });
 </script>
 <style scoped>
-.animated.pulse {
-  animation-duration: 0.5s;
+.animated.fadeIn {
+  animation-duration: 0.2s;
 }
 .animated.fadeInDown {
   animation-duration: 0.3s;
+  animation-timing-function: var(--ease-out);
 }
 .balance-carousel-shell {
   overflow-x: hidden;
@@ -372,15 +390,97 @@ export default defineComponent({
   align-items: center;
   display: flex;
   justify-content: center;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
   line-height: 1.05;
   min-height: 50px;
   white-space: nowrap;
+  transition: opacity var(--dur-fast) var(--ease-standard);
 }
 .balance-secondary-line {
   align-items: center;
   display: flex;
   justify-content: center;
   min-height: 24px;
+  font-variant-numeric: tabular-nums;
+}
+.mint-chip {
+  align-items: center;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--q-primary) 10%, transparent);
+  display: inline-flex;
+  font-size: 0.85rem;
+  gap: 6px;
+  max-width: 100%;
+  padding: 6px 14px;
+  position: relative;
+}
+.mint-chip-avatar {
+  border-radius: 50%;
+  flex-shrink: 0;
+  height: 18px;
+  object-fit: cover;
+  width: 18px;
+}
+.mint-chip-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Mint chip microanimations (mint switched, avatar (dis)appears).
+   Enter is gentle, exit faster (asymmetric timing); never animate from
+   scale(0); leaving elements are taken out of flow so the chip width
+   doesn't jump mid-swap. */
+.mint-chip-avatar-enter-active {
+  transition: opacity 180ms var(--ease-out), transform 180ms var(--ease-out);
+}
+.mint-chip-avatar-leave-active {
+  position: absolute;
+  transition: opacity 120ms var(--ease-out), transform 120ms var(--ease-out);
+}
+.mint-chip-avatar-enter-from,
+.mint-chip-avatar-leave-to {
+  opacity: 0;
+  transform: scale(0.9);
+}
+
+.mint-chip-name-enter-active {
+  transition: opacity 160ms var(--ease-out), transform 160ms var(--ease-out),
+    filter 160ms var(--ease-out);
+}
+.mint-chip-name-leave-active {
+  position: absolute;
+  transition: opacity 100ms var(--ease-out), transform 100ms var(--ease-out),
+    filter 100ms var(--ease-out);
+}
+.mint-chip-name-enter-from {
+  filter: blur(2px);
+  opacity: 0;
+  transform: translateY(4px);
+}
+.mint-chip-name-leave-to {
+  filter: blur(2px);
+  opacity: 0;
+  transform: translateY(-4px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mint-chip-avatar-enter-active,
+  .mint-chip-avatar-leave-active,
+  .mint-chip-name-enter-active,
+  .mint-chip-name-leave-active {
+    transition: opacity 120ms ease;
+  }
+  .mint-chip-avatar-enter-from,
+  .mint-chip-avatar-leave-to,
+  .mint-chip-name-enter-from,
+  .mint-chip-name-leave-to {
+    filter: none;
+    transform: none;
+  }
 }
 .balance-unit-dots {
   align-items: center;
@@ -404,7 +504,8 @@ export default defineComponent({
   justify-content: center;
   opacity: 0.28;
   padding: 0;
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  transition: opacity var(--dur-fast) var(--ease-standard),
+    transform var(--dur-fast) var(--ease-standard);
   width: 14px;
 }
 .balance-unit-dot::after {

--- a/src/components/FullscreenHeader.vue
+++ b/src/components/FullscreenHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-header class="bg-dark">
+  <q-header :class="$q.dark.isActive ? 'bg-dark' : 'bg-white'">
     <q-toolbar>
       <q-btn
         flat

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -3,6 +3,71 @@
 // Import Inter font from Google Fonts
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
 
+// ---------------------------------------------------------------------------
+// Motion & interaction design tokens
+// (easing curves are intentionally stronger than the CSS defaults:
+//  built-in easings lack the punch that makes UI feel intentional)
+// ---------------------------------------------------------------------------
+:root {
+  // Strong ease-out for enter animations / UI interactions (starts fast)
+  --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+  // Strong ease-in-out for elements moving/morphing on screen
+  --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
+  // Gentle standard curve for hover/color changes
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  // iOS-like drawer/sheet curve
+  --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
+
+  --dur-press: 160ms; // button press feedback
+  --dur-fast: 200ms; // tooltips, small popovers, hovers
+  --dur-ui: 250ms; // dropdowns, expands, small panels
+}
+
+// Buttons must feel responsive: instant, subtle scale on press.
+// Quasar's ripple confirms the tap; the scale confirms the *press*.
+// (box-shadow kept in the list so Quasar's elevation transition survives)
+.q-btn {
+  transition: transform var(--dur-press) var(--ease-out),
+    box-shadow 0.2s var(--ease-standard);
+}
+.q-btn:active {
+  transform: scale(0.97);
+}
+
+// Utility for custom pressable rows/cards that are not q-btns
+.pressable {
+  transition: transform var(--dur-press) var(--ease-out),
+    background-color var(--dur-press) var(--ease-standard);
+}
+.pressable:active {
+  transform: scale(0.98);
+}
+
+// Hover states only make sense on devices with a real pointer.
+// On touch, :hover sticks after the tap and reads as a bug.
+@media (hover: hover) and (pointer: fine) {
+  .hoverable:hover {
+    background-color: rgba(128, 128, 128, 0.14);
+  }
+}
+
+// Financial figures: equal-width digits so amounts don't jitter while counting
+.tnum {
+  font-variant-numeric: tabular-nums;
+}
+
+// Reduced motion: keep opacity/color feedback, drop movement.
+@media (prefers-reduced-motion: reduce) {
+  .q-btn,
+  .pressable {
+    transition: none;
+  }
+  .q-btn:active,
+  .pressable:active {
+    transform: none;
+  }
+}
+
 // Apply Inter as the primary font throughout the application
 body {
   font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,

--- a/src/pages/MintDetailsPage.vue
+++ b/src/pages/MintDetailsPage.vue
@@ -742,7 +742,9 @@ body:not(.body--dark) .mint-details {
 
 /* Nuts toggle + expanded section */
 .nuts-toggle {
-  color: var(--q-primary);
+  /* theme-aware: --q-primary is near-white in the classic theme, which is
+     unreadable on light surfaces */
+  color: var(--md-text);
   cursor: pointer;
   gap: 2px;
 }

--- a/src/pages/MintDetailsPage.vue
+++ b/src/pages/MintDetailsPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="mint-details q-px-md"
+    class="mint-details"
     :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
   >
     <div class="mint-details-page-content">
@@ -19,7 +19,7 @@
       <div class="mint-content-container q-px-md">
         <!-- Mint Header Profile Name Section -->
         <div class="mint-header-container q-mb-md">
-          <div class="mint-header q-pa-lg">
+          <div class="mint-header q-pa-md">
             <!-- QR Code Toggle -->
             <q-btn
               flat

--- a/src/pages/MintDetailsPage.vue
+++ b/src/pages/MintDetailsPage.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="bg-dark text-white q-pa-md flex flex-center">
+  <div
+    class="mint-details q-pa-md"
+    :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
+  >
     <div class="mint-details-page-content">
       <EditMintDialog
         :mint="mintToEdit"
@@ -15,10 +18,23 @@
 
       <div class="mint-content-container q-px-md">
         <!-- Mint Header Profile Name Section -->
-        <div class="mint-header-container q-mb-lg">
-          <div class="mint-header q-pa-md">
+        <div class="mint-header-container q-mb-md">
+          <div class="mint-header q-pa-lg">
+            <!-- QR Code Toggle -->
+            <q-btn
+              flat
+              dense
+              round
+              size="sm"
+              class="qr-toggle-btn"
+              aria-label="Toggle mint QR code"
+              @click="showQrCode = !showQrCode"
+            >
+              <qr-code-icon :size="20" />
+            </q-btn>
+
             <!-- Mint Profile Name Section -->
-            <q-avatar size="56px" class="mint-profile-icon q-mb-sm">
+            <q-avatar size="64px" class="mint-profile-icon q-mb-sm">
               <img
                 v-if="mintData.info?.icon_url"
                 :src="mintData.info.icon_url"
@@ -30,18 +46,9 @@
               {{ mintData.info?.name || "Mint" }}
             </div>
 
-            <!-- QR Code Icon -->
-            <div class="top-icons">
-              <qr-code-icon
-                size="24"
-                class="qr-icon cursor-pointer text-white"
-                @click="showQrCode = !showQrCode"
-              />
-            </div>
-
             <!-- QR Code Section (toggleable) -->
             <div class="qr-code-container">
-              <transition appear name="smooth-slide">
+              <transition name="smooth-slide">
                 <div
                   v-if="showQrCode"
                   class="qr-code-section q-my-md"
@@ -57,13 +64,9 @@
             </div>
           </div>
 
-          <div class="mint-descriptions q-mt-lg">
+          <div class="mint-descriptions q-mt-md">
             <!-- MOTD Component -->
-            <transition
-              appear
-              enter-active-class="animated pulse"
-              name="smooth-slide"
-            >
+            <transition name="smooth-slide">
               <mint-motd-message
                 v-if="mintData.info?.motd && !mintData.motdDismissed"
                 :message="mintData.info.motd"
@@ -77,7 +80,7 @@
               {{ mintData.info.description }}
             </div>
             <div
-              class="mint-description-long q-mt-md"
+              class="mint-description-long q-mt-sm"
               v-if="mintData.info?.description_long"
             >
               {{ mintData.info.description_long }}
@@ -94,30 +97,26 @@
           </transition>
         </div>
 
-        <!-- Section Divider -->
-        <div
-          class="section-divider q-mb-md"
-          v-if="mintData.info?.contact?.length > 0"
-        >
-          <div class="divider-line"></div>
-          <div class="divider-text">
-            {{ $t("MintDetailsDialog.contact.title") }}
-          </div>
-          <div class="divider-line"></div>
+        <!-- Section Label -->
+        <div class="section-label" v-if="mintData.info?.contact?.length > 0">
+          {{ $t("MintDetailsDialog.contact.title") }}
         </div>
 
         <!-- Contact Info Section -->
-        <div class="contact-section q-mb-lg">
+        <div
+          class="contact-section surface-card"
+          v-if="mintData.info?.contact?.length > 0"
+        >
           <div
             v-for="contactInfo in mintData.info?.contact"
             :key="contactInfo.method"
-            class="contact-item q-mb-md"
+            class="contact-item pressable cursor-pointer"
+            @click="copyText(contactInfo.info)"
           >
             <div class="contact-icon-container">
               <mail-icon
                 v-if="contactInfo.method === 'email'"
-                size="20"
-                color="#9E9E9E"
+                size="18"
                 class="contact-icon"
               />
               <img
@@ -143,84 +142,85 @@
               </div>
             </div>
             <div class="contact-text">{{ contactInfo.info }}</div>
-            <copy-icon
-              @click="copyText(contactInfo.info)"
-              size="20"
-              color="#9E9E9E"
-              class="copy-icon cursor-pointer"
-            />
+            <copy-icon size="16" class="copy-icon" />
           </div>
         </div>
 
-        <!-- Section Divider -->
-        <div class="section-divider q-mb-md">
-          <div class="divider-line"></div>
-          <div class="divider-text">
-            {{ $t("MintDetailsDialog.details.title") }}
-          </div>
-          <div class="divider-line"></div>
+        <!-- Section Label -->
+        <div class="section-label">
+          {{ $t("MintDetailsDialog.details.title") }}
         </div>
 
         <!-- Mint Details Section -->
-        <div class="mint-details-section q-mb-lg">
+        <div class="mint-details-section surface-card">
           <!-- URL -->
-          <div class="detail-item q-mb-md">
+          <div
+            class="detail-item detail-item--clickable pressable cursor-pointer"
+            @click="copyText(mintData.url)"
+          >
             <div class="detail-label">
-              <link-icon size="20" color="#9E9E9E" class="detail-icon" />
+              <link-icon size="18" class="detail-icon" />
               <div class="detail-name">
                 {{ $t("MintDetailsDialog.details.url.label") }}
               </div>
             </div>
-            <div
-              class="detail-value items-center"
-              @click="copyText(mintData.url)"
-            >
-              {{ mintData.url }}
+            <div class="detail-value items-center">
+              <span class="detail-value-text">{{ mintData.url }}</span>
+              <copy-icon size="14" class="detail-value-icon" />
             </div>
           </div>
 
           <!-- Nuts -->
-          <div class="detail-item q-mb-md" v-if="mintData.info?.nuts">
+          <div class="detail-item" v-if="mintData.info?.nuts">
             <div class="detail-label">
-              <nut-icon size="20" color="#9E9E9E" class="detail-icon" />
+              <nut-icon size="18" class="detail-icon" />
               <div class="detail-name">
                 {{ $t("MintDetailsDialog.details.nuts.label") }}
               </div>
             </div>
             <div
-              class="detail-value"
-              v-if="!showAllNuts"
-              @click="showAllNuts = true"
+              class="detail-value nuts-toggle"
+              @click="showAllNuts = !showAllNuts"
             >
-              {{ $t("MintDetailsDialog.details.nuts.actions.show.label") }}
-            </div>
-            <div class="detail-value" v-else @click="showAllNuts = false">
-              {{ $t("MintDetailsDialog.details.nuts.actions.hide.label") }}
+              <span>{{
+                showAllNuts
+                  ? $t("MintDetailsDialog.details.nuts.actions.hide.label")
+                  : $t("MintDetailsDialog.details.nuts.actions.show.label")
+              }}</span>
+              <q-icon
+                name="keyboard_arrow_down"
+                size="18px"
+                class="nuts-toggle-chevron"
+                :class="{ 'nuts-toggle-chevron--open': showAllNuts }"
+              />
             </div>
           </div>
 
           <!-- Expanded Nuts Section (when showAllNuts is true) -->
-          <div
-            class="nuts-expanded-section"
-            v-if="showAllNuts && mintData.info?.nuts"
-          >
-            <div class="nuts-grid">
-              <div
-                v-for="(nutName, nutNumber) in visibleNuts"
-                :key="nutNumber"
-                class="nut-pill"
-              >
-                <div class="nut-content">
-                  <span class="nut-number">{{ nutNumber }}:</span> {{ nutName }}
+          <transition name="expand">
+            <div
+              class="nuts-expanded-section"
+              v-if="showAllNuts && mintData.info?.nuts"
+            >
+              <div class="nuts-grid">
+                <div
+                  v-for="(nutName, nutNumber) in visibleNuts"
+                  :key="nutNumber"
+                  class="nut-pill"
+                >
+                  <div class="nut-content">
+                    <span class="nut-number">{{ nutNumber }}</span>
+                    {{ nutName }}
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
+          </transition>
 
           <!-- Currency (if available) -->
-          <div class="detail-item q-mb-md" v-if="mintData.info?.currencies">
+          <div class="detail-item" v-if="mintData.info?.currencies">
             <div class="detail-label">
-              <currency-icon size="20" color="#9E9E9E" class="detail-icon" />
+              <currency-icon size="18" class="detail-icon" />
               <div class="detail-name">
                 {{ $t("MintDetailsDialog.details.currency.label") }}
               </div>
@@ -229,12 +229,9 @@
           </div>
 
           <!-- Currency Units (if available) -->
-          <div
-            class="detail-item q-mb-md"
-            v-if="mintUnits && mintUnits.length > 0"
-          >
+          <div class="detail-item" v-if="mintUnits && mintUnits.length > 0">
             <div class="detail-label">
-              <banknote-icon size="20" color="#9E9E9E" class="detail-icon" />
+              <banknote-icon size="18" class="detail-icon" />
               <div class="detail-name">
                 {{ $t("MintDetailsDialog.details.currencies.label") }}
               </div>
@@ -247,7 +244,7 @@
           <!-- Version -->
           <div class="detail-item" v-if="mintData.info?.version">
             <div class="detail-label">
-              <info-icon size="20" color="#9E9E9E" class="detail-icon" />
+              <info-icon size="18" class="detail-icon" />
               <div class="detail-name">
                 {{ $t("MintDetailsDialog.details.version.label") }}
               </div>
@@ -256,11 +253,9 @@
           </div>
         </div>
 
-        <!-- Section Divider for Audit Info -->
-        <div v-if="settings.auditorEnabled" class="section-divider q-mb-md">
-          <div class="divider-line"></div>
-          <div class="divider-text">AUDIT INFO</div>
-          <div class="divider-line"></div>
+        <!-- Section Label for Audit Info -->
+        <div v-if="settings.auditorEnabled" class="section-label">
+          AUDIT INFO
         </div>
 
         <!-- Mint Audit Info Section -->
@@ -270,51 +265,47 @@
           @close="() => {}"
         />
 
-        <!-- Section Divider -->
-        <div class="section-divider q-mb-md">
-          <div class="divider-line"></div>
-          <div class="divider-text">
-            {{ $t("MintDetailsDialog.actions.title") }}
-          </div>
-          <div class="divider-line"></div>
+        <!-- Section Label -->
+        <div class="section-label">
+          {{ $t("MintDetailsDialog.actions.title") }}
         </div>
 
         <!-- Action Buttons -->
         <div class="action-buttons-section">
-          <div class="action-buttons-container">
+          <div class="action-buttons-container surface-card">
             <div
-              class="action-button cursor-pointer"
+              class="action-button pressable cursor-pointer"
               @click="openEditMintDialog"
             >
-              <pencil-icon size="20" color="#9E9E9E" class="action-icon" />
+              <pencil-icon size="18" class="action-icon" />
               <div class="action-label">
                 {{ $t("MintDetailsDialog.actions.edit.label") }}
               </div>
             </div>
 
             <div
-              class="action-button cursor-pointer"
+              class="action-button pressable cursor-pointer"
               @click="copyText(mintData.url)"
             >
-              <copy-icon size="20" color="#9E9E9E" class="action-icon" />
+              <copy-icon size="18" class="action-icon" />
               <div class="action-label">
                 {{ $t("MintDetailsDialog.actions.copy_mint_url.label") }}
               </div>
             </div>
 
             <div
-              class="action-button cursor-pointer"
+              class="action-button pressable cursor-pointer"
               @click="openCreateReviewDialog"
             >
-              <q-icon name="rate_review" size="20px" class="action-icon" />
+              <q-icon name="rate_review" size="18px" class="action-icon" />
               <div class="action-label">Review Mint</div>
             </div>
 
             <div
-              class="action-button delete-button cursor-pointer"
+              class="action-button delete-button pressable cursor-pointer"
               @click="openRemoveMintDialog"
             >
-              <trash-icon size="20" color="#FF453A" class="action-icon" />
+              <trash-icon size="18" class="action-icon" />
               <div class="action-label">
                 {{ $t("MintDetailsDialog.actions.delete.label") }}
               </div>
@@ -527,33 +518,33 @@ export default defineComponent({
 </script>
 
 <style scoped>
+/* Theme-aware design tokens: dark values by default (the app is dark-first),
+   light overrides below. Keeps the page working in both modes. */
+.mint-details {
+  --md-text: #ffffff;
+  --md-muted: #8e8e93;
+  --md-surface: rgba(255, 255, 255, 0.05);
+  --md-surface-hover: rgba(255, 255, 255, 0.1);
+  --md-danger: #ff453a;
+}
+body:not(.body--dark) .mint-details {
+  --md-text: #1d1d1d;
+  --md-muted: #6e6e73;
+  --md-surface: rgba(0, 0, 0, 0.04);
+  --md-surface-hover: rgba(0, 0, 0, 0.08);
+  --md-danger: #d70015;
+}
+
 .mint-details-page-content {
   max-width: 600px;
   margin: 0 auto;
-  color: white;
-  height: 100%;
-  overflow-y: auto;
-  position: absolute;
-  top: 0;
-  width: 100%;
+  color: var(--md-text);
 }
 
 .mint-content-container {
   max-width: 600px;
   margin: 0 auto;
-  color: white;
-  height: 100%;
-  overflow-y: auto;
-  position: relative;
-}
-
-/* Top Icons */
-.top-icons {
-  padding-top: 10px;
-  position: relative;
-  width: 100%;
-  display: flex;
-  justify-content: center;
+  color: var(--md-text);
 }
 
 /* Mint Header */
@@ -562,28 +553,30 @@ export default defineComponent({
   flex-direction: column;
   align-items: center;
   width: 100%;
-  margin-top: 50px;
 }
 
 .mint-header {
-  width: 100%;
-  border-radius: 12px;
+  background-color: var(--md-surface);
+  border-radius: 16px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background-color: rgba(255, 255, 255, 0.05);
+  position: relative;
+  width: 100%;
+}
+
+.qr-toggle-btn {
+  color: var(--md-muted);
+  position: absolute;
+  right: 10px;
+  top: 10px;
 }
 
 .mint-name {
-  font-size: 24px;
+  font-size: 22px;
   font-weight: 600;
-  text-align: center;
-}
-
-.mint-balance {
-  font-size: 20px;
-  font-weight: 600;
+  letter-spacing: -0.02em;
   text-align: center;
 }
 
@@ -598,6 +591,7 @@ export default defineComponent({
   font-size: 16px;
   font-weight: 600;
   line-height: 24px;
+  letter-spacing: -0.01em;
   width: 100%;
 }
 
@@ -606,30 +600,28 @@ export default defineComponent({
   position: relative;
   font-size: 14px;
   line-height: 20px;
-  color: #9e9e9e;
+  color: var(--md-muted);
   width: 100%;
   font-weight: 500;
 }
 
-/* Section Divider */
-.section-divider {
-  display: flex;
-  align-items: center;
-  width: 100%;
-}
-
-.divider-line {
-  flex: 1;
-  height: 1px;
-  background-color: #333;
-}
-
-.divider-text {
-  padding: 0 10px;
-  font-size: 14px;
+/* Section labels (iOS grouped-list style) */
+.section-label {
+  color: var(--md-muted);
+  font-size: 0.75rem;
   font-weight: 600;
-  color: #ffffff;
+  letter-spacing: 0.08em;
+  margin: 28px 0 8px 4px;
   text-transform: uppercase;
+}
+
+/* Grouped surface cards */
+.surface-card {
+  background-color: var(--md-surface);
+  border-radius: 16px;
+  overflow: hidden;
+  padding: 4px;
+  width: 100%;
 }
 
 /* Contact Section */
@@ -638,35 +630,47 @@ export default defineComponent({
 }
 
 .contact-item {
-  display: flex;
   align-items: center;
+  border-radius: 12px;
+  display: flex;
+  min-height: 44px;
+  padding: 8px 10px;
   width: 100%;
 }
 
+@media (hover: hover) and (pointer: fine) {
+  .contact-item:hover {
+    background-color: var(--md-surface-hover);
+  }
+}
+
 .contact-icon-container {
-  width: 24px;
+  align-items: center;
   display: flex;
   justify-content: center;
-  margin-right: 10px;
+  margin-right: 12px;
+  width: 24px;
 }
 
 .contact-icon {
-  width: 20px;
-  height: 20px;
-  color: #636366;
+  width: 18px;
+  height: 18px;
+  color: var(--md-muted);
 }
 
 .contact-text {
+  color: var(--md-text);
   flex: 1;
-  font-size: 16px;
-  font-weight: 600;
+  font-size: 15px;
+  font-weight: 500;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .copy-icon {
-  color: #636366;
+  color: var(--md-muted);
+  flex-shrink: 0;
   margin-left: 10px;
 }
 
@@ -676,96 +680,176 @@ export default defineComponent({
 }
 
 .detail-item {
+  align-items: center;
+  border-radius: 12px;
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  min-height: 44px;
+  padding: 8px 10px;
   width: 100%;
 }
 
+.detail-item--clickable {
+  transition: transform var(--dur-press) var(--ease-out),
+    background-color var(--dur-press) var(--ease-standard);
+}
+@media (hover: hover) and (pointer: fine) {
+  .detail-item--clickable:hover {
+    background-color: var(--md-surface-hover);
+  }
+}
+
 .detail-label {
-  display: flex;
   align-items: center;
+  display: flex;
+  flex-shrink: 0;
 }
 
 .detail-icon {
-  margin-right: 10px;
+  color: var(--md-muted);
+  margin-right: 12px;
 }
 
 .detail-name {
-  font-size: 16px;
-  font-weight: 600;
-  color: #9e9e9e;
+  color: var(--md-muted);
+  font-size: 15px;
+  font-weight: 500;
 }
 
 .detail-value {
-  font-size: 16px;
+  align-items: center;
+  color: var(--md-text);
+  display: flex;
+  font-size: 15px;
   font-weight: 600;
-  color: white;
-  text-align: right;
+  justify-content: flex-end;
   max-width: 60%;
+  min-width: 0;
+  text-align: right;
+}
+
+.detail-value-text {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.detail-value-icon {
+  color: var(--md-muted);
+  flex-shrink: 0;
+  margin-left: 6px;
+}
+
+/* Nuts toggle + expanded section */
+.nuts-toggle {
+  color: var(--q-primary);
+  cursor: pointer;
+  gap: 2px;
+}
+
+.nuts-toggle-chevron {
+  transition: transform var(--dur-ui) var(--ease-out);
+}
+
+.nuts-toggle-chevron--open {
+  transform: rotate(180deg);
+}
+
+.nuts-expanded-section {
+  overflow: hidden;
+  width: 100%;
+}
+
+.nuts-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 4px 4px 8px;
+  width: 100%;
+}
+
+.nut-pill {
+  background-color: var(--md-surface);
+  border-radius: 8px;
+  padding: 8px 12px;
+  width: 100%;
+}
+body:not(.body--dark) .nut-pill {
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+.nut-content {
+  color: var(--md-text);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+}
+
+.nut-number {
+  color: var(--md-muted);
+  display: inline-block;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  margin-right: 8px;
+  min-width: 18px;
+}
+
 /* Action Buttons */
 .action-buttons-section {
   width: 100%;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  margin-top: 16px;
   margin-bottom: 32px;
 }
 
 .action-buttons-container {
-  align-self: stretch;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: center;
   width: 100%;
 }
 
 .action-button {
-  display: flex;
-  flex-direction: row;
   align-items: center;
-  justify-content: flex-start;
-  gap: 16px;
-  padding: 8px;
-  border-radius: 8px;
-  transition: background-color 0.3s;
+  border-radius: 12px;
+  display: flex;
+  gap: 14px;
+  min-height: 44px;
+  padding: 10px;
   width: 100%;
-  margin-bottom: 16px;
 }
 
-.action-button:last-child {
-  margin-bottom: 0;
+@media (hover: hover) and (pointer: fine) {
+  .action-button:hover {
+    background-color: var(--md-surface-hover);
+  }
+  .delete-button:hover {
+    background-color: color-mix(in srgb, var(--md-danger) 10%, transparent);
+  }
 }
 
-.action-button:hover {
-  background-color: rgba(255, 255, 255, 0.1);
+.action-button:active {
+  background-color: var(--md-surface-hover);
+}
+.delete-button:active {
+  background-color: color-mix(in srgb, var(--md-danger) 14%, transparent);
 }
 
 .action-icon {
-  min-width: 20px;
+  color: var(--md-muted);
+  min-width: 18px;
 }
 
 .action-label {
-  position: relative;
-  line-height: 24px;
+  color: var(--md-text);
+  font-size: 15px;
   font-weight: 500;
-  font-size: 16px;
+  line-height: 24px;
 }
 
-.delete-button {
-  color: #ff453a;
+.delete-button .action-icon,
+.delete-button .action-label {
+  color: var(--md-danger);
 }
 
-/* QR Code Container and Animation */
+/* QR Code Container and expand/collapse animation.
+   Explicit properties only — never `transition: all`. Enter is slower than
+   exit (asymmetric timing: slow when deciding, fast when responding). */
 .qr-code-container {
   min-height: 0;
   display: flex;
@@ -775,13 +859,15 @@ export default defineComponent({
 }
 
 .qr-code-section {
-  width: 100%;
   display: flex;
   justify-content: center;
+  overflow: hidden;
+  width: 100%;
 }
 
 .smooth-slide-enter-active {
-  transition: all 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition: max-height 0.3s var(--ease-out), opacity 0.25s var(--ease-out),
+    transform 0.3s var(--ease-out), margin-bottom 0.3s var(--ease-out);
   max-height: 350px;
   margin-bottom: 16px;
   opacity: 1;
@@ -789,7 +875,8 @@ export default defineComponent({
 }
 
 .smooth-slide-leave-active {
-  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: max-height 0.2s var(--ease-out), opacity 0.15s var(--ease-out),
+    transform 0.2s var(--ease-out), margin-bottom 0.2s var(--ease-out);
   max-height: 350px;
   margin-bottom: 16px;
   opacity: 1;
@@ -800,62 +887,38 @@ export default defineComponent({
   max-height: 0;
   margin-bottom: 0;
   opacity: 0;
-  transform: translateY(-10px);
+  transform: translateY(-8px) scale(0.98);
   pointer-events: none;
 }
 
-.nuts-expanded-section {
-  width: 100%;
-  margin-bottom: 16px;
+.expand-enter-active {
+  transition: max-height 0.3s var(--ease-out), opacity 0.25s var(--ease-out);
+  max-height: 1200px;
+  opacity: 1;
 }
 
-.nuts-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  width: 100%;
+.expand-leave-active {
+  transition: max-height 0.2s var(--ease-out), opacity 0.15s var(--ease-out);
+  max-height: 1200px;
+  opacity: 1;
 }
 
-.nut-pill {
-  border-radius: 4px;
-  padding: 8px;
-  width: 100%;
+.expand-enter-from,
+.expand-leave-to {
+  max-height: 0;
+  opacity: 0;
 }
 
-.nut-content {
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 24px;
-  color: white;
-}
-
-.nut-number {
-  color: #9e9e9e;
-}
-
-/* Make "View all" and "Hide" text clickable */
-.detail-value[v-if="!showAllNuts"],
-.detail-value[v-else] {
-  cursor: pointer;
-  color: white;
-  font-weight: 600;
-}
-
-/* Currency Units */
-.currency-units-container {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  justify-content: flex-end;
-}
-
-.currency-unit-pill {
-  border-radius: 4px;
-  background-color: #1d1d1d;
-  padding: 4px 8px;
-  font-size: 14px;
-  font-weight: 600;
-  color: white;
-  display: inline-block;
+@media (prefers-reduced-motion: reduce) {
+  .smooth-slide-enter-active,
+  .smooth-slide-leave-active,
+  .expand-enter-active,
+  .expand-leave-active {
+    transition: opacity 0.15s ease;
+    transform: none;
+  }
+  .nuts-toggle-chevron {
+    transition: none;
+  }
 }
 </style>

--- a/src/pages/MintDetailsPage.vue
+++ b/src/pages/MintDetailsPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="mint-details q-pa-md"
+    class="mint-details q-px-md"
     :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
   >
     <div class="mint-details-page-content">
@@ -865,6 +865,14 @@ body:not(.body--dark) .nut-pill {
   justify-content: center;
   overflow: hidden;
   width: 100%;
+}
+
+/* The QR canvas has a fixed pixel width; scale it down on narrow screens
+   instead of letting the section's overflow clip off its rounded corners. */
+.qr-code-section canvas,
+.qr-code-section img {
+  max-width: 100%;
+  height: auto;
 }
 
 .smooth-slide-enter-active {

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -4,44 +4,46 @@
       <NoMintWarnBanner v-if="mints.length == 0" />
       <BalanceView v-else :set-tab="setTab" />
       <div
-        class="wallet-actions row items-center justify-center no-wrap q-mx-auto q-pt-md q-pb-md"
+        class="row items-center justify-center no-wrap q-mb-none q-mx-none q-px-none q-pt-lg q-pb-md position-relative"
       >
-        <q-btn
-          rounded
-          unelevated
-          data-testid="wallet-receive"
-          class="wallet-action-btn"
-          color="primary"
-          @click="showReceiveDialog = true"
-        >
-          <ArrowDownIcon :size="18" class="q-mr-sm" />
-          <span>{{ $t("WalletPage.actions.receive.label") }}</span>
-        </q-btn>
+        <div class="col-6 q-mb-md flex justify-center items-center">
+          <q-btn
+            rounded
+            dense
+            data-testid="wallet-receive"
+            class="q-px-md q-mr-md wallet-action-btn"
+            color="primary"
+            @click="showReceiveDialog = true"
+          >
+            <div class="button-content">
+              <span>{{ $t("WalletPage.actions.receive.label") }}</span>
+            </div>
+          </q-btn>
+        </div>
 
-        <q-btn
-          size="lg"
-          outline
-          color="primary"
-          flat
-          class="q-mx-md"
-          :aria-label="$t('global.actions.scan.label')"
-          @click="showCamera"
-        >
-          <ScanIcon size="2em" />
-        </q-btn>
+        <transition appear enter-active-class="animated pulse">
+          <div class="scan-button-container">
+            <q-btn size="lg" outline color="primary" flat @click="showCamera">
+              <ScanIcon size="2em" />
+            </q-btn>
+          </div>
+        </transition>
 
         <!-- button to showSendDialog -->
-        <q-btn
-          rounded
-          unelevated
-          data-testid="wallet-send"
-          class="wallet-action-btn"
-          color="primary"
-          @click="showSendDialog = true"
-        >
-          <ArrowUpIcon :size="18" class="q-mr-sm" />
-          <span>{{ $t("WalletPage.actions.send.label") }}</span>
-        </q-btn>
+        <div class="col-6 q-mb-md flex justify-center items-center">
+          <q-btn
+            rounded
+            dense
+            data-testid="wallet-send"
+            class="q-px-md q-ml-md wallet-action-btn"
+            color="primary"
+            @click="showSendDialog = true"
+          >
+            <div class="button-content">
+              <span>{{ $t("WalletPage.actions.send.label") }}</span>
+            </div>
+          </q-btn>
+        </div>
         <ReceiveDialog v-model="showReceiveDialog" />
         <SendDialog v-model="showSendDialog" />
       </div>
@@ -183,18 +185,29 @@
   grid-area: 1 / 4 / 5 / 4;
 }
 
-.wallet-actions {
-  max-width: 430px;
+.wallet-action-btn {
+  min-width: 140px;
+  width: auto;
+  white-space: nowrap;
+  font-size: 1.2rem;
 }
 
-.wallet-action-btn {
-  flex: 1 1 0;
-  min-width: 0;
-  height: 48px;
+.button-content {
+  display: flex;
+  align-items: center;
   white-space: nowrap;
-  font-size: 1.05rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
+}
+
+/* Apply equal widths to wallet action buttons after render */
+.equal-width-buttons {
+  display: flex;
+  justify-content: space-between;
+}
+
+.scan-button-container {
+  position: absolute;
+  z-index: 1;
+  padding-bottom: 15px;
 }
 </style>
 <script lang="ts">
@@ -249,8 +262,6 @@ import {
   Banknote as BanknoteIcon,
   Zap as ZapIcon,
   Scan as ScanIcon,
-  ArrowDown as ArrowDownIcon,
-  ArrowUp as ArrowUpIcon,
 } from "lucide-vue-next";
 
 import { useMigrationsStore } from "src/stores/migrations";
@@ -277,8 +288,6 @@ export default {
     iOSPWAPrompt,
     AndroidPWAPrompt,
     ScanIcon,
-    ArrowDownIcon,
-    ArrowUpIcon,
   },
   data: function () {
     return {
@@ -550,11 +559,42 @@ export default {
         }
       };
     },
+    equalizeButtonWidths: function () {
+      this.$nextTick(() => {
+        const actionBtns = document.querySelectorAll(".wallet-action-btn");
+        if (actionBtns.length >= 2) {
+          // Reset widths first
+          actionBtns.forEach((btn) => {
+            (btn as HTMLElement).style.width = "auto";
+          });
+
+          // Get the maximum width
+          let maxWidth = 0;
+          actionBtns.forEach((btn) => {
+            maxWidth = Math.max(maxWidth, (btn as HTMLElement).offsetWidth);
+          });
+
+          // Apply the maximum width to all buttons
+          actionBtns.forEach((btn) => {
+            (btn as HTMLElement).style.width = `${maxWidth}px`;
+          });
+        }
+      });
+    },
   },
   watch: {},
 
   mounted: function () {
     this.initializeNpubCash();
+    // Ensure wallet action buttons have equal width
+    this.$nextTick(this.equalizeButtonWidths);
+    // Add window resize listener to handle responsive layouts
+    window.addEventListener("resize", this.equalizeButtonWidths);
+  },
+
+  beforeUnmount: function () {
+    // Remove event listener when component is destroyed
+    window.removeEventListener("resize", this.equalizeButtonWidths);
   },
 
   created: async function () {

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -4,46 +4,44 @@
       <NoMintWarnBanner v-if="mints.length == 0" />
       <BalanceView v-else :set-tab="setTab" />
       <div
-        class="row items-center justify-center no-wrap q-mb-none q-mx-none q-px-none q-pt-lg q-pb-md position-relative"
+        class="wallet-actions row items-center justify-center no-wrap q-mx-auto q-pt-md q-pb-md"
       >
-        <div class="col-6 q-mb-md flex justify-center items-center">
-          <q-btn
-            rounded
-            dense
-            data-testid="wallet-receive"
-            class="q-px-md q-mr-md wallet-action-btn"
-            color="primary"
-            @click="showReceiveDialog = true"
-          >
-            <div class="button-content">
-              <span>{{ $t("WalletPage.actions.receive.label") }}</span>
-            </div>
-          </q-btn>
-        </div>
+        <q-btn
+          rounded
+          unelevated
+          data-testid="wallet-receive"
+          class="wallet-action-btn"
+          color="primary"
+          @click="showReceiveDialog = true"
+        >
+          <ArrowDownIcon :size="18" class="q-mr-sm" />
+          <span>{{ $t("WalletPage.actions.receive.label") }}</span>
+        </q-btn>
 
-        <transition appear enter-active-class="animated pulse">
-          <div class="scan-button-container">
-            <q-btn size="lg" outline color="primary" flat @click="showCamera">
-              <ScanIcon size="2em" />
-            </q-btn>
-          </div>
-        </transition>
+        <q-btn
+          size="lg"
+          outline
+          color="primary"
+          flat
+          class="q-mx-md"
+          :aria-label="$t('global.actions.scan.label')"
+          @click="showCamera"
+        >
+          <ScanIcon size="2em" />
+        </q-btn>
 
         <!-- button to showSendDialog -->
-        <div class="col-6 q-mb-md flex justify-center items-center">
-          <q-btn
-            rounded
-            dense
-            data-testid="wallet-send"
-            class="q-px-md q-ml-md wallet-action-btn"
-            color="primary"
-            @click="showSendDialog = true"
-          >
-            <div class="button-content">
-              <span>{{ $t("WalletPage.actions.send.label") }}</span>
-            </div>
-          </q-btn>
-        </div>
+        <q-btn
+          rounded
+          unelevated
+          data-testid="wallet-send"
+          class="wallet-action-btn"
+          color="primary"
+          @click="showSendDialog = true"
+        >
+          <ArrowUpIcon :size="18" class="q-mr-sm" />
+          <span>{{ $t("WalletPage.actions.send.label") }}</span>
+        </q-btn>
         <ReceiveDialog v-model="showReceiveDialog" />
         <SendDialog v-model="showSendDialog" />
       </div>
@@ -108,17 +106,20 @@
         <div class="row q-pt-sm">
           <div class="col-12 q-pt-xs">
             <q-btn
-              class="q-mx-xs q-px-sm q-my-sm"
+              class="q-mx-xs q-px-md q-my-sm"
               outline
-              size="0.6rem"
+              rounded
+              no-caps
+              size="sm"
               v-if="
                 getPwaDisplayMode() == 'browser' &&
                 deferredPWAInstallPrompt != null
               "
               color="primary"
+              icon="download"
               @click="triggerPwaInstall()"
-              ><b>{{ $t("WalletPage.install.text") }}</b
-              ><q-tooltip>{{
+              >{{ $t("WalletPage.install.text")
+              }}<q-tooltip>{{
                 $t("WalletPage.install.tooltip")
               }}</q-tooltip></q-btn
             >
@@ -182,29 +183,18 @@
   grid-area: 1 / 4 / 5 / 4;
 }
 
+.wallet-actions {
+  max-width: 430px;
+}
+
 .wallet-action-btn {
-  min-width: 140px;
-  width: auto;
+  flex: 1 1 0;
+  min-width: 0;
+  height: 48px;
   white-space: nowrap;
-  font-size: 1.2rem;
-}
-
-.button-content {
-  display: flex;
-  align-items: center;
-  white-space: nowrap;
-}
-
-/* Apply equal widths to wallet action buttons after render */
-.equal-width-buttons {
-  display: flex;
-  justify-content: space-between;
-}
-
-.scan-button-container {
-  position: absolute;
-  z-index: 1;
-  padding-bottom: 15px;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 </style>
 <script lang="ts">
@@ -259,6 +249,8 @@ import {
   Banknote as BanknoteIcon,
   Zap as ZapIcon,
   Scan as ScanIcon,
+  ArrowDown as ArrowDownIcon,
+  ArrowUp as ArrowUpIcon,
 } from "lucide-vue-next";
 
 import { useMigrationsStore } from "src/stores/migrations";
@@ -285,6 +277,8 @@ export default {
     iOSPWAPrompt,
     AndroidPWAPrompt,
     ScanIcon,
+    ArrowDownIcon,
+    ArrowUpIcon,
   },
   data: function () {
     return {
@@ -556,42 +550,11 @@ export default {
         }
       };
     },
-    equalizeButtonWidths: function () {
-      this.$nextTick(() => {
-        const actionBtns = document.querySelectorAll(".wallet-action-btn");
-        if (actionBtns.length >= 2) {
-          // Reset widths first
-          actionBtns.forEach((btn) => {
-            (btn as HTMLElement).style.width = "auto";
-          });
-
-          // Get the maximum width
-          let maxWidth = 0;
-          actionBtns.forEach((btn) => {
-            maxWidth = Math.max(maxWidth, (btn as HTMLElement).offsetWidth);
-          });
-
-          // Apply the maximum width to all buttons
-          actionBtns.forEach((btn) => {
-            (btn as HTMLElement).style.width = `${maxWidth}px`;
-          });
-        }
-      });
-    },
   },
   watch: {},
 
   mounted: function () {
     this.initializeNpubCash();
-    // Ensure wallet action buttons have equal width
-    this.$nextTick(this.equalizeButtonWidths);
-    // Add window resize listener to handle responsive layouts
-    window.addEventListener("resize", this.equalizeButtonWidths);
-  },
-
-  beforeUnmount: function () {
-    // Remove event listener when component is destroyed
-    window.removeEventListener("resize", this.equalizeButtonWidths);
   },
 
   created: async function () {

--- a/test/e2e/pages/WalletPage.ts
+++ b/test/e2e/pages/WalletPage.ts
@@ -39,7 +39,13 @@ export class WalletPage {
     await mintInput.fill(mintUrl);
     await this.page.getByTestId("onboarding-add-mint").click();
     await this.page.getByTestId("confirm-add-mint").click();
-    await expect(this.page.getByText(mintUrl, { exact: true })).toBeVisible();
+    // Assert against the added-mints list specifically: the full mint URL is
+    // legitimately rendered in several places at once (the add-mint sheet's
+    // preview while it closes, mint discovery results), so a bare exact-text
+    // lookup can resolve to multiple elements.
+    await expect(
+      this.page.locator(".mint-item").getByText(mintUrl, { exact: true })
+    ).toBeVisible();
 
     await this.page.getByTestId("onboarding-next").click();
     await expect(this.page.getByTestId("wallet-send")).toBeVisible();


### PR DESCRIPTION
## Summary

Design polish pass on the mint details page and the main wallet screen, applying Emil Kowalski's design-engineering principles (easing curves, press feedback, grouped-list hierarchy). Full pattern spec documented in **`docs/DESIGN_UPDATE.md`**.

### Mint details page (reworked)

- **Element ordering as a narrative**: identity (header card) → communication (MOTD, descriptions) → facts (contact, details) → trust (audit) → actions (edit / copy / review / delete)
- iOS grouped-list pattern: uppercase muted section labels + rounded **surface cards** replace the heavy line/text/line dividers
- Theme-aware `--md-*` color tokens (works in dark and light mode; previously hardcoded dark)
- QR code toggle anchored to the header card's top-right corner; reveal via explicit `max-height/opacity/transform` transition (was `transition: all` with an overshoot curve)
- Nuts expansion: primary toggle + rotating chevron + animated expand; nuts render as chips
- Action rows: 44px touch targets, press scale, gated hover, destructive action isolated in red
- Removed the absolute-position layout hack — normal document flow

### Mint selector pill (balance view)

- The "Mint: url" text line is now a **pill** that opens the existing **ChooseMint bottom sheet** to switch the active mint (instead of jumping to the Mints tab)
- Shows the mint's **avatar** when `icon_url` is loaded (nothing rendered when missing/broken)
- Micro-transitions on mint switch: avatar scale/fade swap, blur-masked name crossfade (leaving elements pulled out of flow so the pill doesn't jump)
- Pill sits above the balance, relatively centered in the header-to-balance band; balance position is pixel-identical to before
- Removed the per-mint balance line

### Shared motion foundation (`app.scss`)

- Easing tokens (`--ease-out` `cubic-bezier(0.23,1,0.32,1)` etc.) + duration tokens
- **Global press feedback**: every `.q-btn` scales to 0.97 on pointer-down (160ms) — the whole app feels more responsive
- `.pressable` utility, hover gating behind `@media (hover: hover)`, `prefers-reduced-motion` support throughout
- Balance count-up is now ease-out cubic (600ms) instead of linear 1000ms

### Smaller fixes

- `FullscreenHeader` respects light/dark mode (was hardcoded `bg-dark`)
- PWA install button readable size (was `0.6rem` text), now with download icon
- Main wallet screen geometry (button sizes/positions, balance spacing, history toggle, history table) verified **unchanged** from main

## Verification

- 186/186 unit tests pass (26 files), eslint + prettier clean
- e2e selectors (`wallet-receive`/`wallet-send`/`wallet-balance` testids) untouched
- Visually verified: empty/populated/pending history, collapse/expand, receive/send dialogs, QR + nuts toggles, mint switching via pill, avatar states, desktop width, `bitcoin` theme, and original-vs-new layout geometry (balance top offset identical)