### PR TITLE
fix(pwa): clip splash logo to a circle to hide its non-black edges

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
       #app-splash img {
         width: 96px;
         height: 96px;
+        border-radius: 50%;
         opacity: 0;
         animation: app-splash-logo-in 0.4s ease 0.5s forwards;
       }


### PR DESCRIPTION
## Problem

The PWA splash screen shows `icons/icon-192x192.png` centered on a pure-black (`#000000`) background. The logo is a **square, fully opaque** PNG (alpha 249–255, no rounded corners) whose background is a dark radial gradient rather than pure black:

- exact corners: ~`#000000`
- edge midpoints: `#090909`–`#0C0C0C`
- interior background behind the character: up to ~`#212121`

98.9% of the icon's pixels are non-black, so on the black splash the square outline of the icon was faintly visible (especially on OLED screens / high brightness), making the logo look cropped.

## Fix

Add `border-radius: 50%` to `#app-splash img`, clipping the square icon to a circle. The square boundary disappears entirely; the residual edge just inside the circle is only ~`#0D0D0D` vs the `#000000` background (Δ ~5% brightness) and, being a smooth radial falloff, now reads as an intentional soft glow behind the character instead of a hard square crop.

One-line change, no assets modified. Also improves light mode, where the icon previously appeared as a hard dark square on the white splash.

## Verification

- Pixel analysis of the icon before/after masking (corner/edge/interior values above)
- Rendered the splash markup with the fix in Chromium and screenshotted it: the logo now appears as a circular glow with no visible square boundary