### PR TITLE
test: expand wallet payment resilience coverage

### DIFF
--- a/.github/workflows/wallet-e2e.yml
+++ b/.github/workflows/wallet-e2e.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install Chromium and system dependencies
         run: npx playwright install --with-deps chromium
 
+      - name: Run unit and store regression tests
+        run: npm run test:ci -- --reporter=dot
+
       - name: Build wallet
         run: npm run build
 

--- a/README.md
+++ b/README.md
@@ -1,87 +1,141 @@
-# Cashu (cashu)
+<div align="center">
+  <img src="icon-round.png" alt="Cashu.me logo" width="120" />
 
-Cashu Wallet
+# Cashu.me
 
-## One-liner build & run
+**A free and open-source Cashu ecash wallet for the web.**
 
-```
+[![Build](https://github.com/cashubtc/cashu.me/actions/workflows/build.yaml/badge.svg)](https://github.com/cashubtc/cashu.me/actions/workflows/build.yaml)
+[![Tests](https://github.com/cashubtc/cashu.me/actions/workflows/test.yml/badge.svg)](https://github.com/cashubtc/cashu.me/actions/workflows/test.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.md)
+
+[Cashu protocol](https://cashu.space) &middot; [Documentation](https://docs.cashu.space)
+
+</div>
+
+---
+
+## About
+
+Cashu.me is a progressive web app (PWA) wallet for [Cashu](https://github.com/cashubtc) — an open-source Chaumian ecash protocol. It lets you send and receive funds instantly and privately as ecash that only you control.
+
+The wallet runs entirely on your device: keys and tokens are stored locally in your browser's IndexedDB. You can install it as an app or self-host it with Docker.
+
+## Features
+
+- **Send & receive ecash** — create, scan, and redeem Cashu tokens, including animated QR codes for large tokens
+- **Lightning payments** — pay and create BOLT11 invoices, with BOLT12 offer support
+- **On-chain** — deposit and withdraw on-chain bitcoin where supported by the mint
+- **Multi-mint** — connect to any number of mints, with mint discovery, community ratings, and mint audit insights
+- **Multinut payments** — pay a single invoice with funds split across multiple mints (NUT-15)
+- **Seed phrase backup** — restore your wallet deterministically from a 12-word seed phrase
+- **Nostr integration** — encrypted wallet backups on Nostr (NIP-60), Nostr Wallet Connect (NWC), and npub.cash Lightning addresses
+- **P2PK** — lock ecash tokens to a public key so only the intended recipient can spend them
+- **Payment requests** — request payments from other wallets
+- **Private by design** — your proofs never leave your device
+- **Internationalized** — available in 14 languages
+- **Runs everywhere** — PWA, Android & iOS (Capacitor), desktop (Electron), and a browser extension
+
+## Quick start with Docker
+
+The fastest way to run Cashu.me yourself:
+
+```bash
+git clone https://github.com/cashubtc/cashu.me.git
+cd cashu.me
 docker compose up -d
 ```
 
-access at http://localhost:3000 or serve it behind a reverse proxy.
+Access the wallet at http://localhost:3000, or serve it behind a reverse proxy (see [Self-hosting](#self-hosting-behind-a-reverse-proxy)).
 
-## Install the dependencies
+## Development
+
+**Requirements:** Node.js >= 22.4 and npm.
 
 ```bash
 npm install
+npm run dev
 ```
 
-### Start the app in development mode (hot-code reloading, error reporting, etc.)
+### Common commands
+
+| Command                  | Description                                                         |
+| ------------------------ | ------------------------------------------------------------------- |
+| `npm run dev`            | Start the dev server (hot reloading, error reporting)               |
+| `npm run build:pwa`      | Production PWA build, output in `dist/pwa`                          |
+| `npm run build`          | SPA production build                                                |
+| `npm run build:electron` | Desktop app build                                                   |
+| `npm test`               | Run unit tests with Vitest (watch mode)                             |
+| `npm run test:ci`        | Run unit tests once (CI mode)                                       |
+| `npm run test:e2e`       | End-to-end tests: boots local test mints in Docker, runs Playwright |
+| `npm run lint`           | Lint with ESLint                                                    |
+| `npm run format`         | Format all files with Prettier                                      |
+| `npm run checkformat`    | Check Prettier formatting without writing                           |
+| `npm run i18n:check`     | Verify non-English translations are in sync with the English source |
+
+### Testing
+
+Unit tests use [Vitest](https://vitest.dev/). To run a single test file:
 
 ```bash
-quasar dev
+npx vitest src/path/to/test.ts
 ```
 
-### Run unit tests
+End-to-end tests use [Playwright](https://playwright.dev/) against a local test stack (two CDK mints with a Lightning backend) started via Docker Compose:
 
 ```bash
-npm test
+# Full run: brings the stack up, runs the tests, tears it down
+npm run test:e2e
+
+# Or manage the stack yourself and run Playwright directly
+npm run test:e2e:stack:up
+npm run test:e2e:playwright
+npm run test:e2e:stack:down
 ```
 
-### Lint the files
+## Mobile & desktop
+
+Cashu.me ships as native apps via [Capacitor](https://capacitorjs.com/) (Android & iOS) and Electron (desktop).
 
 ```bash
-npm run lint
-```
-
-### Format the files
-
-```bash
-npm run format
-```
-
-### Check translations
-
-Use this to verify non-English translations are in sync with the English source:
-
-```bash
-npm run i18n:check
-```
-
-### Build the app for production
-
-```bash
-quasar build -m pwa
-```
-
-### Capacitor
-
-After updating code, run:
-
-```
-quasar build -m pwa
+# Build the web assets, then sync them into the native projects
+npm run build:pwa
 npx cap copy
 npx cap sync
-npx cap open android / ios
+
+# Open the native projects
+npx cap open android
+npx cap open ios
 ```
 
-Regenerate assets:
+Regenerate app icons and splash screens after changing `icon.png`:
 
-```
+```bash
 npx capacitor-assets generate
 ```
 
-### Customize the configuration
+For the desktop app: `make electron` starts an Electron dev build, `npm run build:electron` produces a production build.
 
-See [Configuring quasar.config.js](https://v2.quasar.dev/quasar-cli-webpack/quasar-config-js).
+## Project structure
 
-### Reverse proxy
+```
+src/
+  components/   Vue components (dialogs, mint management, QR, ...)
+  pages/        Route pages (wallet, restore, mint details, settings)
+  stores/       Pinia stores — the core business logic (wallet, mints, proofs, ...)
+  boot/         Quasar boot files (app initialization)
+  i18n/         Translations (en-US is the source of truth)
+  js/           Shared helpers (notifications, utilities)
+src-pwa/        Service worker & PWA manifest
+src-electron/   Electron main/preload scripts
+test/e2e/       Playwright e2e tests and Docker test stack
+```
 
-For Quasar Vue Router with history mode, add this fallback URL to allow refreshes: https://router.vuejs.org/guide/essentials/history-mode.html#HTML5-Mode
+See [AGENTS.md](AGENTS.md) for architecture details and coding conventions.
 
-More info: https://stackoverflow.com/questions/36399319/vue-router-return-404-when-revisit-to-the-url
+## Self-hosting behind a reverse proxy
 
-`Caddyfile`:
+The app is a single-page application using Vue Router in history mode, so your web server needs a fallback to `index.html` to allow page refreshes. It should also send proper headers for the service worker. Example `Caddyfile`:
 
 ```
 # CORS snippet by https://kalnytskyi.com/posts/setup-cors-caddy-2/
@@ -102,6 +156,7 @@ More info: https://stackoverflow.com/questions/36399319/vue-router-return-404-wh
     header Access-Control-Expose-Headers "Link"
   }
 }
+
 host.com {
     import cors *
     encode gzip
@@ -120,3 +175,23 @@ host.com {
     file_server
 }
 ```
+
+Background: [Vue Router history mode](https://router.vuejs.org/guide/essentials/history-mode.html#HTML5-Mode).
+
+## Contributing
+
+Contributions are welcome! Before opening a pull request:
+
+1. Run `npm run format` and `npm run lint`.
+2. Make sure `npm run test:ci` passes.
+3. If you touched UI text, update translations and run `npm run i18n:check`.
+
+Translations live in `src/i18n/`. English (`en-US`) is the source of truth — the `i18n:check` script verifies that other languages stay in sync.
+
+## Security
+
+To report a vulnerability, please email **cashu-security@pm.me** — see [SECURITY.md](SECURITY.md).
+
+## License
+
+[MIT](LICENSE.md) &copy; Cashu

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -6,14 +6,22 @@ on-chain settlement; the mint APIs and wallet cryptography are not mocked.
 
 ## What runs
 
-| Area        | Browser behavior                                      | Backend assertion                             |
-| ----------- | ----------------------------------------------------- | --------------------------------------------- |
-| Onboarding  | Creates a new seed and adds the local mint            | Mint info and keys load over HTTP             |
-| Incoming    | Creates BOLT11, BOLT12, and on-chain requests         | Fake backend settles; wallet mints proofs     |
-| Outgoing    | Pays BOLT11, amountless BOLT12, and on-chain requests | Wallet melts proofs and receives change       |
-| Ecash       | Sends between two isolated browser contexts           | Receiver swaps proofs; replay is rejected     |
-| Persistence | Reloads after minting and receiving                   | IndexedDB-backed balances survive reload      |
-| Protocol    | Checks both mints and all quote types directly        | NUT-04/NUT-05 advertise every configured rail |
+| Area        | Browser behavior                                                                                                   | Backend assertion                                 |
+| ----------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
+| Onboarding  | Creates a new seed and adds the local mint                                                                         | Mint info and keys load over HTTP                 |
+| Incoming    | Creates BOLT11, BOLT12, and on-chain requests                                                                      | Fake backend settles; wallet mints proofs         |
+| Outgoing    | Pays BOLT11, amountless BOLT12, and on-chain requests                                                              | Wallet melts proofs and receives change           |
+| Ecash       | Sends between two isolated browser contexts                                                                        | Receiver swaps proofs; replay is rejected         |
+| Persistence | Reloads after minting and receiving                                                                                | IndexedDB-backed balances survive reload          |
+| Protocol    | Checks both mints and all quote types directly                                                                     | NUT-04/NUT-05 advertise every configured rail     |
+| Resilience  | Exercises malformed input, insufficient balance, pending and failed payments, quote recovery, and duplicate clicks | Balances and proof reservations remain consistent |
+
+The resilience specs use Playwright's local route interception to make real CDK
+responses appear unpaid, pending, or failed after the quote has been created.
+This keeps error-state coverage deterministic while still exercising the real
+wallet UI, quote parsing, proof selection, reservation cleanup, and history
+updates. The protocol-failure specs separately verify that the CDK mint rejects
+unknown quotes and malformed payment requests.
 
 The second mint creates counterparty payment requests for outgoing tests. That
 keeps payment decoding and quote creation realistic without coupling the test

--- a/test/e2e/fixtures/scenarios.ts
+++ b/test/e2e/fixtures/scenarios.ts
@@ -1,0 +1,84 @@
+import type { Page, Route } from "@playwright/test";
+
+import type { PaymentMethod } from "./mint";
+
+export type MintQuoteState = "UNPAID" | "PAID" | "ISSUED";
+export type MeltQuoteState = "UNPAID" | "PENDING" | "PAID";
+
+function withState(body: unknown, state: MintQuoteState | MeltQuoteState) {
+  if (!body || typeof body !== "object") return body;
+
+  const updated = body as Record<string, any>;
+  if ("state" in updated) updated.state = state;
+  if (updated.quote && typeof updated.quote === "object") {
+    updated.quote.state = state;
+  }
+  return updated;
+}
+
+async function fulfillWithState(
+  route: Route,
+  state: MintQuoteState | MeltQuoteState
+) {
+  const response = await route.fetch();
+  const body = withState(await response.json(), state);
+  await route.fulfill({ response, json: body });
+}
+
+/** Force the quote checker to observe a deterministic mint state. */
+export async function forceMintQuoteState(
+  page: Page,
+  mintUrl: string,
+  method: PaymentMethod,
+  state: MintQuoteState
+) {
+  await page.route(`${mintUrl}/v1/mint/quote/${method}/**`, async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    await fulfillWithState(route, state);
+  });
+}
+
+/** Force complete-melt and subsequent quote checks to report one state. */
+export async function forceMeltQuoteState(
+  page: Page,
+  mintUrl: string,
+  method: PaymentMethod,
+  state: MeltQuoteState
+) {
+  await page.route(`${mintUrl}/v1/melt/${method}`, async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.continue();
+      return;
+    }
+    await fulfillWithState(route, state);
+  });
+
+  await page.route(`${mintUrl}/v1/melt/quote/${method}/**`, async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    await fulfillWithState(route, state);
+  });
+}
+
+/** Return a sequence of states for quote polling, retaining the last state. */
+export async function forceMintQuoteStateSequence(
+  page: Page,
+  mintUrl: string,
+  method: PaymentMethod,
+  states: MintQuoteState[]
+) {
+  let index = 0;
+  await page.route(`${mintUrl}/v1/mint/quote/${method}/**`, async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    const state = states[Math.min(index++, states.length - 1)];
+    await fulfillWithState(route, state);
+  });
+}

--- a/test/e2e/pages/WalletPage.ts
+++ b/test/e2e/pages/WalletPage.ts
@@ -115,6 +115,16 @@ export class WalletPage {
   }
 
   async payRequest(request: string, amount?: number) {
+    await this.quoteRequest(request, amount);
+
+    const pay = this.page.getByTestId("pay-payment-request");
+    await expect(pay).toBeEnabled();
+    await pay.click();
+    await expect(this.page.getByText("Paid", { exact: false })).toBeVisible();
+    await this.page.getByRole("button", { name: "Close", exact: true }).click();
+  }
+
+  async quoteRequest(request: string, amount?: number, expectPayButton = true) {
     const input = this.page
       .getByTestId("payment-request-input")
       .locator("textarea");
@@ -122,13 +132,12 @@ export class WalletPage {
 
     if (amount !== undefined) {
       await this.enterAmount(amount);
-      await this.page.getByTestId("quote-payment-request").click();
+      const quote = this.page.getByTestId("quote-payment-request");
+      if (await quote.isEnabled()) {
+        await quote.click();
+      }
+    } else if (expectPayButton) {
+      await expect(this.page.getByTestId("pay-payment-request")).toBeVisible();
     }
-
-    const pay = this.page.getByTestId("pay-payment-request");
-    await expect(pay).toBeEnabled();
-    await pay.click();
-    await expect(this.page.getByText("Paid", { exact: false })).toBeVisible();
-    await this.page.getByRole("button", { name: "Close", exact: true }).click();
   }
 }

--- a/test/e2e/pages/WalletPage.ts
+++ b/test/e2e/pages/WalletPage.ts
@@ -39,7 +39,12 @@ export class WalletPage {
     await mintInput.fill(mintUrl);
     await this.page.getByTestId("onboarding-add-mint").click();
     await this.page.getByTestId("confirm-add-mint").click();
-    await expect(this.page.getByText(mintUrl, { exact: true })).toBeVisible();
+    await expect(
+      this.page
+        .getByText(mintUrl, { exact: true })
+        .filter({ visible: true })
+        .first()
+    ).toBeVisible();
 
     await this.page.getByTestId("onboarding-next").click();
     await expect(this.page.getByTestId("wallet-send")).toBeVisible();

--- a/test/e2e/specs/protocol-failures.spec.ts
+++ b/test/e2e/specs/protocol-failures.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+
+import { MINT_A_URL, type PaymentMethod } from "../fixtures/mint";
+
+for (const method of ["bolt11", "bolt12", "onchain"] as PaymentMethod[]) {
+  test(`rejects an unknown ${method} mint quote`, async ({ request }) => {
+    const response = await request.get(
+      `${MINT_A_URL}/v1/mint/quote/${method}/missing-quote`
+    );
+    expect(response.ok()).toBeFalsy();
+  });
+}
+
+test("rejects an invalid BOLT11 melt quote", async ({ request }) => {
+  const response = await request.post(`${MINT_A_URL}/v1/melt/quote/bolt11`, {
+    data: { unit: "sat", request: "lnbc-invalid" },
+  });
+  expect(response.ok()).toBeFalsy();
+});
+
+test("rejects an invalid BOLT12 melt quote", async ({ request }) => {
+  const response = await request.post(`${MINT_A_URL}/v1/melt/quote/bolt12`, {
+    data: { unit: "sat", request: "lno1-invalid", amount_msat: 1_000 },
+  });
+  expect(response.ok()).toBeFalsy();
+});
+
+test("rejects an invalid on-chain melt quote", async ({ request }) => {
+  const response = await request.post(`${MINT_A_URL}/v1/melt/quote/onchain`, {
+    data: { unit: "usd", request: "not-a-bitcoin-address", amount: 10 },
+  });
+  expect(response.ok()).toBeFalsy();
+});

--- a/test/e2e/specs/resilience.spec.ts
+++ b/test/e2e/specs/resilience.spec.ts
@@ -1,0 +1,211 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  counterpartyRequest,
+  MINT_A_URL,
+  type PaymentMethod,
+} from "../fixtures/mint";
+import {
+  forceMeltQuoteState,
+  forceMintQuoteState,
+  forceMintQuoteStateSequence,
+} from "../fixtures/scenarios";
+import { WalletPage } from "../pages/WalletPage";
+
+test.describe("payment input and balance safety", () => {
+  test("does not create a payment from malformed input", async ({ page }) => {
+    const wallet = new WalletPage(page);
+    await wallet.onboard(MINT_A_URL);
+    await wallet.openSend("lightning");
+
+    const input = page.getByTestId("payment-request-input").locator("textarea");
+    await input.fill("not-a-lightning-payment-request");
+
+    await expect(page.getByTestId("pay-payment-request")).toHaveCount(0);
+    await expect.poll(() => wallet.balanceSats()).toBe(0);
+  });
+
+  for (const scenario of [
+    {
+      name: "BOLT11",
+      method: "bolt11" as PaymentMethod,
+      sendMethod: "lightning" as const,
+      requestAmount: 25,
+      quoteAmount: undefined,
+    },
+    {
+      name: "BOLT12",
+      method: "bolt12" as PaymentMethod,
+      sendMethod: "lightning" as const,
+      requestAmount: 25,
+      quoteAmount: undefined,
+    },
+    {
+      name: "on-chain",
+      method: "onchain" as PaymentMethod,
+      sendMethod: "onchain" as const,
+      requestAmount: undefined,
+      quoteAmount: 25,
+    },
+  ]) {
+    test(`blocks ${scenario.name} payment when the wallet has insufficient balance`, async ({
+      page,
+      request,
+    }) => {
+      const wallet = new WalletPage(page);
+      await wallet.onboard(MINT_A_URL);
+
+      const paymentRequest = await counterpartyRequest(
+        request,
+        scenario.method,
+        scenario.requestAmount
+      );
+      await wallet.openSend(scenario.sendMethod);
+      await wallet.quoteRequest(paymentRequest, scenario.quoteAmount, false);
+
+      if (scenario.method === "onchain") {
+        await expect(page.getByTestId("quote-payment-request")).toBeDisabled();
+      } else {
+        await expect(
+          page.getByText("Balance too low", { exact: true })
+        ).toBeVisible();
+        await expect(page.getByTestId("pay-payment-request")).toHaveCount(0);
+      }
+      await expect.poll(() => wallet.balanceSats()).toBe(0);
+    });
+  }
+});
+
+test.describe("incoming quote recovery", () => {
+  test("keeps an unpaid BOLT11 quote pending without minting proofs", async ({
+    page,
+  }) => {
+    const wallet = new WalletPage(page);
+    await wallet.onboard(MINT_A_URL);
+    await forceMintQuoteState(page, MINT_A_URL, "bolt11", "UNPAID");
+
+    await wallet.openReceive("lightning");
+    await wallet.enterAmount(19);
+    await page.getByTestId("create-payment-request").click();
+
+    await expect(
+      page.getByText("Lightning invoice", { exact: true })
+    ).toBeVisible();
+    await expect.poll(() => wallet.balanceSats()).toBe(0);
+  });
+
+  test("mints after a quote changes from unpaid to paid", async ({ page }) => {
+    const wallet = new WalletPage(page);
+    await wallet.onboard(MINT_A_URL);
+    await forceMintQuoteStateSequence(page, MINT_A_URL, "bolt11", [
+      "UNPAID",
+      "PAID",
+    ]);
+
+    await wallet.openReceive("lightning");
+    await wallet.enterAmount(23);
+    await page.getByTestId("create-payment-request").click();
+
+    await expect.poll(() => wallet.balanceSats()).toBe(23);
+  });
+});
+
+test.describe("outgoing quote recovery", () => {
+  for (const scenario of [
+    {
+      name: "BOLT11",
+      method: "bolt11" as PaymentMethod,
+      sendMethod: "lightning" as const,
+      requestAmount: 31,
+      quoteAmount: undefined,
+    },
+    {
+      name: "BOLT12",
+      method: "bolt12" as PaymentMethod,
+      sendMethod: "lightning" as const,
+      requestAmount: 32,
+      quoteAmount: undefined,
+    },
+    {
+      name: "on-chain",
+      method: "onchain" as PaymentMethod,
+      sendMethod: "onchain" as const,
+      requestAmount: undefined,
+      quoteAmount: 33,
+    },
+  ]) {
+    test(`releases funds after a failed ${scenario.name} melt`, async ({
+      page,
+      request,
+    }) => {
+      const wallet = new WalletPage(page);
+      await wallet.onboard(MINT_A_URL);
+      await wallet.mintBolt11(250);
+      const before = await wallet.balanceSats();
+
+      const paymentRequest = await counterpartyRequest(
+        request,
+        scenario.method,
+        scenario.requestAmount
+      );
+      await forceMeltQuoteState(page, MINT_A_URL, scenario.method, "UNPAID");
+      await wallet.openSend(scenario.sendMethod);
+      await wallet.quoteRequest(paymentRequest, scenario.quoteAmount);
+      await page.getByTestId("pay-payment-request").click();
+
+      await expect(page.getByText("Unpaid", { exact: true })).toBeVisible();
+      await expect.poll(() => wallet.balanceSats()).toBe(before);
+    });
+
+    test(`does not spend funds while a ${scenario.name} melt is pending`, async ({
+      page,
+      request,
+    }) => {
+      const wallet = new WalletPage(page);
+      await wallet.onboard(MINT_A_URL);
+      await wallet.mintBolt11(250);
+      const before = await wallet.balanceSats();
+
+      const paymentRequest = await counterpartyRequest(
+        request,
+        scenario.method,
+        scenario.requestAmount
+      );
+      await forceMeltQuoteState(page, MINT_A_URL, scenario.method, "PENDING");
+      await wallet.openSend(scenario.sendMethod);
+      await wallet.quoteRequest(paymentRequest, scenario.quoteAmount);
+      await page.getByTestId("pay-payment-request").click();
+
+      await expect(page.getByTestId("wallet-send")).toBeVisible();
+      await expect.poll(() => wallet.balanceSats()).toBe(before);
+    });
+  }
+});
+
+test("prevents duplicate melt submissions from a double click", async ({
+  page,
+  request,
+}) => {
+  const wallet = new WalletPage(page);
+  await wallet.onboard(MINT_A_URL);
+  await wallet.mintBolt11(250);
+
+  const paymentRequest = await counterpartyRequest(request, "bolt11", 31);
+  await wallet.openSend("lightning");
+  await wallet.quoteRequest(paymentRequest);
+
+  let meltSubmissions = 0;
+  page.on("request", (outgoingRequest) => {
+    if (
+      outgoingRequest.method() === "POST" &&
+      new URL(outgoingRequest.url()).pathname.includes("/v1/melt/")
+    ) {
+      meltSubmissions += 1;
+    }
+  });
+
+  const pay = page.getByTestId("pay-payment-request");
+  await Promise.all([pay.click(), pay.click().catch(() => undefined)]);
+  await expect(page.getByText("Paid", { exact: false })).toBeVisible();
+  await expect.poll(() => meltSubmissions).toBe(1);
+});


### PR DESCRIPTION
## Summary\n\n- Add deterministic CDK/Playwright state controls for mint and melt quotes.\n- Cover malformed input, insufficient funds, unpaid-to-paid recovery, failed and pending BOLT11/BOLT12/on-chain melts, protocol failures, and duplicate submissions.\n- Run the Vitest regression suite in the wallet E2E workflow before the production build.\n- Document the expanded resilience coverage.\n\n## Validation\n\n- 28/28 Playwright wallet E2E tests passed.\n- Vitest regression suite passed.\n- ESLint passed for changed test files.\n- SPA production build passed.\n\n## Notes\n\nThe new payment-state coverage remains deterministic on CDK fakewallet rails. A real bitcoind plus Lightning-node regtest tier remains separate follow-up work.