### PR TITLE
Type amounts as whole numbers, with a decimal key

### DIFF
--- a/src/components/AmountInputComponent.vue
+++ b/src/components/AmountInputComponent.vue
@@ -45,9 +45,16 @@ import { mapState } from "pinia";
 import { useMintsStore } from "src/stores/mints";
 import { useSettingsStore } from "src/stores/settings";
 import { usePriceStore } from "src/stores/price";
+import {
+  canonicalAmountBuffer,
+  parseAmountBuffer,
+  sanitizeAmountBuffer,
+} from "src/js/amount-entry";
 declare const windowMixin: any;
 
 const MAX_AMOUNT = 999_999_999;
+// fraction digits of the fiat keyboard (used when typing over a sat unit)
+const FIAT_FRACTION_DIGITS = 2;
 
 export default defineComponent({
   name: "AmountInputComponent",
@@ -98,6 +105,11 @@ export default defineComponent({
     ),
     ...mapState(useSettingsStore, ["bitcoinPriceCurrency"]),
     ...mapState(usePriceStore, ["bitcoinPrice", "currentCurrencyPrice"]),
+    // fraction digits of the active unit: fiat-style units are entered as
+    // major units with two decimals (usd/eur cents), sat/msat are indivisible
+    maxFractionDigits(): number {
+      return this.activeUnitCurrencyMultiplyer === 100 ? 2 : 0;
+    },
     formattedAmountDisplay(): string {
       const amount = this.modelValue || 0;
       return (this as any).formatCurrency(
@@ -108,7 +120,7 @@ export default defineComponent({
     },
     primaryAmountDisplay(): string {
       if (this.fiatMode) {
-        const fiat = this.getFiatBufferNumber();
+        const fiat = parseAmountBuffer(this.fiatEditBuffer);
         return (this as any).formatCurrency(
           fiat,
           this.bitcoinPriceCurrency,
@@ -153,7 +165,7 @@ export default defineComponent({
     },
     derivedSatsFromFiatBuffer(): number {
       if (!this.bitcoinPrice || !this.currentCurrencyPrice) return 0;
-      const fiat = this.getFiatBufferNumber();
+      const fiat = parseAmountBuffer(this.fiatEditBuffer);
       if (!isFinite(fiat) || fiat <= 0) return 0;
       // sats = fiat * 100_000_000 / price_per_BTC
       let sats = Math.round((fiat * 100000000) / this.currentCurrencyPrice);
@@ -184,15 +196,14 @@ export default defineComponent({
       }
       if (clampedVal !== newVal) {
         this.$emit("update:modelValue", clampedVal);
-        const isFiatInput =
-          this.fiatMode || this.activeUnitCurrencyMultiplyer === 100;
-        this.amountEditBuffer = isFiatInput
-          ? Number(clampedVal).toFixed(2)
-          : String(clampedVal);
+        this.amountEditBuffer = canonicalAmountBuffer(
+          clampedVal,
+          this.maxFractionDigits
+        );
         if (this.fiatMode) {
           // keep fiat buffer in sync with clamped sat value
           const fiat = this.fiatFromSats(clampedVal);
-          this.fiatEditBuffer = this.numberToFiatBuffer(fiat);
+          this.fiatEditBuffer = canonicalAmountBuffer(fiat);
         }
         return;
       }
@@ -201,13 +212,12 @@ export default defineComponent({
         // Do not override user's fiat typing buffer during input
         if (this.isFiatTyping) return;
         const fiat = this.fiatFromSats(newVal);
-        this.fiatEditBuffer = this.numberToFiatBuffer(fiat);
+        this.fiatEditBuffer = canonicalAmountBuffer(fiat);
       } else {
-        const isFiatInput =
-          this.fiatMode || this.activeUnitCurrencyMultiplyer === 100;
-        this.amountEditBuffer = isFiatInput
-          ? Number(newVal).toFixed(2)
-          : String(newVal);
+        this.amountEditBuffer = canonicalAmountBuffer(
+          newVal,
+          this.maxFractionDigits
+        );
       }
     },
     enabled(val: boolean) {
@@ -253,11 +263,13 @@ export default defineComponent({
         // initialize fiat buffer from current model value
         const sats = this.modelValue == null ? 0 : this.modelValue;
         const fiat = this.fiatFromSats(sats);
-        this.fiatEditBuffer = this.numberToFiatBuffer(fiat);
+        this.fiatEditBuffer = canonicalAmountBuffer(fiat);
       } else {
         // initialize sats buffer from current model value
         this.amountEditBuffer =
-          this.modelValue == null ? "0" : String(this.modelValue);
+          this.modelValue == null
+            ? "0"
+            : canonicalAmountBuffer(this.modelValue, this.maxFractionDigits);
       }
       this.$nextTick(() => this.adjustAmountFontSize());
       this.$emit("fiat-mode-changed", this.fiatMode);
@@ -271,30 +283,15 @@ export default defineComponent({
       const sats = Math.round((fiat * 100000000) / this.currentCurrencyPrice);
       return Math.max(0, Math.min(sats, MAX_AMOUNT));
     },
-    getFiatBufferNumber(): number {
-      const buf = this.fiatEditBuffer;
-      if (!buf || buf === ".") return 0;
-      const num = Number(buf.replace(/,/g, "."));
-      return isNaN(num) ? 0 : num;
-    },
-    numberToFiatBuffer(num: number): string {
-      // keep exactly 2 decimals for fiat buffer
-      return (Math.round(num * 100) / 100).toFixed(2);
-    },
     initializeKeyHandling(): void {
-      const isFiatInput =
-        this.fiatMode || this.activeUnitCurrencyMultiplyer === 100;
-      // initialize buffer from current value
-      if (this.modelValue == null) {
-        this.amountEditBuffer = isFiatInput ? "0.00" : "0";
-      } else {
-        this.amountEditBuffer = isFiatInput
-          ? Number(this.modelValue).toFixed(2)
-          : String(this.modelValue);
-      }
+      // seed the buffer from the current value (canonical whole-number form)
+      this.amountEditBuffer =
+        this.modelValue == null
+          ? "0"
+          : canonicalAmountBuffer(this.modelValue, this.maxFractionDigits);
       if (this.currentCurrencyPrice && this.activeUnit === "sat") {
         const fiat = this.fiatFromSats(this.modelValue || 0);
-        this.fiatEditBuffer = this.numberToFiatBuffer(fiat);
+        this.fiatEditBuffer = canonicalAmountBuffer(fiat);
       } else {
         this.fiatEditBuffer = "";
       }
@@ -322,56 +319,30 @@ export default defineComponent({
       const allowDecimal = this.fiatMode
         ? true
         : this.activeUnit !== "sat" && this.activeUnit !== "msat";
-      const isFiatInput =
-        this.fiatMode || this.activeUnitCurrencyMultiplyer === 100;
+      // fraction digits of what is being typed (fiat keyboard vs active unit)
+      const fractionDigits = this.fiatMode
+        ? FIAT_FRACTION_DIGITS
+        : this.maxFractionDigits;
       const key = (e as KeyboardEvent).key;
       let buf = this.fiatMode
         ? this.fiatEditBuffer ||
-          this.numberToFiatBuffer(this.fiatFromSats(this.modelValue || 0))
+          canonicalAmountBuffer(this.fiatFromSats(this.modelValue || 0))
         : this.amountEditBuffer ||
           (this.modelValue == null ? "0" : String(this.modelValue));
       let handled = false;
 
       if (/^[0-9]$/.test(key)) {
-        if (isFiatInput) {
-          const num = Number(buf.replace(/,/g, "."));
-          const cents = isNaN(num) ? 0 : Math.round(num * 100);
-          let centsStr = cents.toString();
-          if (centsStr === "0") centsStr = "";
-          centsStr += key;
-          const parsed = parseInt(centsStr, 10);
-          const newCents = isNaN(parsed) ? 0 : parsed;
-          buf = (newCents / 100).toFixed(2);
-        } else {
-          // If buffer represents zero (0, 0.0, 0.00, etc.), reset completely
-          const bufNum = allowDecimal
-            ? Number(buf.replace(/,/g, "."))
-            : Number(buf);
-          if (bufNum === 0 || isNaN(bufNum)) {
-            buf = key;
-          } else {
-            buf = buf + key;
-          }
-        }
+        // digits build the integer part left to right ("21" is twenty-one);
+        // a lone "0" acts as the empty state
+        buf = buf === "0" ? key : buf + key;
         handled = true;
       } else if (key === "Backspace" || key === "Delete") {
-        if (isFiatInput) {
-          const num = Number(buf.replace(/,/g, "."));
-          const cents = isNaN(num) ? 0 : Math.round(num * 100);
-          let centsStr = cents.toString();
-          centsStr = centsStr.length > 1 ? centsStr.slice(0, -1) : "0";
-          const parsed = parseInt(centsStr, 10);
-          const newCents = isNaN(parsed) ? 0 : parsed;
-          buf = (newCents / 100).toFixed(2);
-        } else {
-          buf = buf.length > 1 ? buf.slice(0, -1) : "0";
-        }
+        buf = buf.length > 1 ? buf.slice(0, -1) : "0";
         handled = true;
       } else if ((key === "." || key === ",") && allowDecimal) {
-        if (!isFiatInput) {
-          if (!buf.includes(".")) {
-            buf = buf + ".";
-          }
+        // the decimal key arms the fraction; a trailing "." is the armed state
+        if (!buf.includes(".")) {
+          buf = buf + ".";
         }
         handled = true;
       } else if (key === "Enter") {
@@ -383,92 +354,54 @@ export default defineComponent({
       if (!handled) return;
       (e as Event).preventDefault();
 
-      // sanitize buffer
-      if (allowDecimal) {
-        if (!isFiatInput) {
-          buf = buf.replace(/,/g, ".");
-          buf = buf.replace(/[^\d.]/g, "").replace(/^(\d*\.\d*).*$/, "$1");
-          if (buf.includes(".")) {
-            const parts = buf.split(".");
-            const decimals = parts[1] ?? "";
-            buf = parts[0] + "." + decimals.slice(0, 2);
-          }
-        }
-      } else {
-        buf = buf.replace(/[^\d]/g, "");
-      }
-      if (
-        !isFiatInput &&
-        buf.startsWith("0") &&
-        buf.length > 1 &&
-        buf[1] !== "."
-      ) {
-        buf = String(parseInt(buf, 10) || 0);
-      }
+      // enforce the entry grammar: integer cap, fraction cap, leading zeros,
+      // canonical "." separator
+      buf = sanitizeAmountBuffer(buf, fractionDigits);
+
       if (this.fiatMode) {
         this.fiatEditBuffer = buf;
-        if (buf === "" || buf === ".") {
-          this.$emit("update:modelValue", null);
-        } else {
-          const fiatNum = Number(buf);
-          if (isNaN(fiatNum)) {
-            this.$emit("update:modelValue", null);
-          } else {
-            let sats = this.satsFromFiat(fiatNum);
-            if (sats >= MAX_AMOUNT) {
-              sats = MAX_AMOUNT;
-              // reflect clamp back into fiat buffer
-              this.fiatEditBuffer = this.numberToFiatBuffer(
-                this.fiatFromSats(MAX_AMOUNT)
-              );
-            }
-            // Apply min/max constraints
-            if (this.minAmount != null && sats < this.minAmount) {
-              sats = this.minAmount;
-              this.fiatEditBuffer = this.numberToFiatBuffer(
-                this.fiatFromSats(this.minAmount)
-              );
-            } else if (this.maxAmount != null && sats > this.maxAmount) {
-              sats = this.maxAmount;
-              this.fiatEditBuffer = this.numberToFiatBuffer(
-                this.fiatFromSats(this.maxAmount)
-              );
-            }
-            this.isFiatTyping = true;
-            this.$emit("update:modelValue", sats);
-            this.$nextTick(() => {
-              this.isFiatTyping = false;
-            });
-          }
+        const fiatNum = parseAmountBuffer(buf);
+        let sats = this.satsFromFiat(fiatNum);
+        if (sats >= MAX_AMOUNT) {
+          sats = MAX_AMOUNT;
+          // reflect clamp back into fiat buffer
+          this.fiatEditBuffer = canonicalAmountBuffer(
+            this.fiatFromSats(MAX_AMOUNT)
+          );
         }
+        // Apply min/max constraints
+        if (this.minAmount != null && sats < this.minAmount) {
+          sats = this.minAmount;
+          this.fiatEditBuffer = canonicalAmountBuffer(
+            this.fiatFromSats(this.minAmount)
+          );
+        } else if (this.maxAmount != null && sats > this.maxAmount) {
+          sats = this.maxAmount;
+          this.fiatEditBuffer = canonicalAmountBuffer(
+            this.fiatFromSats(this.maxAmount)
+          );
+        }
+        this.isFiatTyping = true;
+        this.$emit("update:modelValue", sats);
+        this.$nextTick(() => {
+          this.isFiatTyping = false;
+        });
       } else {
         this.amountEditBuffer = buf;
-        if (buf === "" || buf === ".") {
-          this.$emit("update:modelValue", null);
+        const num = parseAmountBuffer(buf);
+        // Apply min/max constraints
+        if (this.minAmount != null && num < this.minAmount) {
+          this.amountEditBuffer = String(this.minAmount);
+          this.$emit("update:modelValue", this.minAmount);
+        } else if (this.maxAmount != null && num > this.maxAmount) {
+          this.amountEditBuffer = String(this.maxAmount);
+          this.$emit("update:modelValue", this.maxAmount);
+        } else if (num > MAX_AMOUNT) {
+          // entry cap: stop accepting growth instead of zeroing out
+          this.amountEditBuffer = String(MAX_AMOUNT);
+          this.$emit("update:modelValue", MAX_AMOUNT);
         } else {
-          let num = Number(buf);
-          if (isNaN(num)) {
-            this.$emit("update:modelValue", null);
-          } else {
-            // Apply min/max constraints
-            if (this.minAmount != null && num < this.minAmount) {
-              num = this.minAmount;
-              this.amountEditBuffer = isFiatInput
-                ? num.toFixed(2)
-                : String(this.minAmount);
-            } else if (this.maxAmount != null && num > this.maxAmount) {
-              num = this.maxAmount;
-              this.amountEditBuffer = isFiatInput
-                ? num.toFixed(2)
-                : String(this.maxAmount);
-            } else if (num > MAX_AMOUNT) {
-              num = MAX_AMOUNT;
-              this.amountEditBuffer = isFiatInput
-                ? num.toFixed(2)
-                : String(MAX_AMOUNT);
-            }
-            this.$emit("update:modelValue", num);
-          }
+          this.$emit("update:modelValue", num);
         }
       }
     },

--- a/src/components/CreateInvoiceDialog.vue
+++ b/src/components/CreateInvoiceDialog.vue
@@ -259,6 +259,7 @@ import { usePriceStore } from "src/stores/price";
 import type { InvoiceHistory } from "src/stores/wallet";
 import { PaymentMethod } from "src/stores/walletTypes";
 import { mintSupportsPaymentMethod } from "src/js/mint-payment-methods";
+import { displayAmountToBaseUnits } from "src/js/amount-entry";
 import { useNpubCashStore } from "src/stores/npubcash";
 import { lightningAddressToLnurl } from "src/js/lnurl";
 
@@ -609,8 +610,9 @@ export default defineComponent({
       }
       try {
         this.showNumericKeyboard = false;
-        const amount = Math.floor(
-          (this.invoiceData.amount || 0) * this.activeUnitCurrencyMultiplyer
+        const amount = displayAmountToBaseUnits(
+          this.invoiceData.amount || 0,
+          this.activeUnitCurrencyMultiplyer
         );
         this.createInvoiceButtonBlocked = true;
 

--- a/src/components/NumericKeyboard.vue
+++ b/src/components/NumericKeyboard.vue
@@ -20,7 +20,15 @@
         <q-btn flat class="text-h5" @click="addDigit('8')">8</q-btn>
         <q-btn flat class="text-h5" @click="addDigit('9')">9</q-btn>
 
-        <q-btn flat class="text-h5 invisible" disable>•</q-btn>
+        <q-btn
+          v-if="!hideComma"
+          flat
+          class="text-h5"
+          aria-label="Decimal separator"
+          @click="addDecimalSeparator"
+          >.</q-btn
+        >
+        <q-btn v-else flat class="text-h5 invisible" disable>•</q-btn>
         <q-btn flat class="text-h5" @click="addDigit('0')">0</q-btn>
         <q-btn flat class="text-h5" @click="backspace">
           <q-icon name="chevron_left" size="md" />
@@ -63,6 +71,12 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    // hide the decimal key for indivisible units (e.g. sat/msat): a fraction
+    // could only produce a rounding surprise there, so the slot stays blank
+    hideComma: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: ["update:modelValue", "done"],
   data() {
@@ -81,6 +95,10 @@ export default defineComponent({
     },
     addDigit(digit: string) {
       this.sendKey(digit);
+    },
+    addDecimalSeparator() {
+      // canonical "." — the entry grammar normalizes "," too
+      this.sendKey(".");
     },
     backspace() {
       this.sendKey("Backspace");

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -283,6 +283,7 @@ import { useProofsStore } from "src/stores/proofs";
 import { useMintsStore } from "src/stores/mints";
 import { useTokensStore } from "src/stores/tokens";
 import { getShortUrl } from "src/js/wallet-helpers";
+import { displayAmountToBaseUnits } from "src/js/amount-entry";
 import { useSettingsStore } from "src/stores/settings";
 import { useTransactionWorkerStore } from "src/stores/transactionWorker";
 import { usePriceStore } from "src/stores/price";
@@ -563,8 +564,9 @@ export default defineComponent({
           ) as string
         );
       }
-      const sendAmount = Math.floor(
-        this.sendData.amount * this.activeUnitCurrencyMultiplyer
+      const sendAmount = displayAmountToBaseUnits(
+        this.sendData.amount,
+        this.activeUnitCurrencyMultiplyer
       );
       const mintWallet = await this.mintWallet(
         this.activeMintUrl,
@@ -619,8 +621,9 @@ export default defineComponent({
       if (!this.sendData.amount) {
         throw new Error("Amount is required");
       }
-      const sendAmount = Math.floor(
-        this.sendData.amount * this.activeUnitCurrencyMultiplyer
+      const sendAmount = displayAmountToBaseUnits(
+        this.sendData.amount,
+        this.activeUnitCurrencyMultiplyer
       );
       try {
         // keep firstProofs, send scndProofs and delete them (invalidate=true)
@@ -679,8 +682,9 @@ export default defineComponent({
           return;
         }
 
-        const sendAmount = Math.floor(
-          this.sendData.amount * this.activeUnitCurrencyMultiplyer
+        const sendAmount = displayAmountToBaseUnits(
+          this.sendData.amount,
+          this.activeUnitCurrencyMultiplyer
         );
         const mintWallet = await this.mintWallet(
           this.activeMintUrl,

--- a/src/js/__tests__/amount-entry.test.ts
+++ b/src/js/__tests__/amount-entry.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_INTEGER_DIGITS,
+  canonicalAmountBuffer,
+  displayAmountToBaseUnits,
+  parseAmountBuffer,
+  sanitizeAmountBuffer,
+} from "src/js/amount-entry";
+
+describe("amount entry grammar (cashubtc/wallet#307 parity)", () => {
+  describe("sanitizeAmountBuffer", () => {
+    it("keeps whole numbers as typed left to right", () => {
+      expect(sanitizeAmountBuffer("21", 2)).toBe("21");
+      expect(sanitizeAmountBuffer("0", 2)).toBe("0");
+      expect(sanitizeAmountBuffer("00", 2)).toBe("0");
+    });
+
+    it("strips leading zeros but keeps the fraction armed state", () => {
+      expect(sanitizeAmountBuffer("012", 2)).toBe("12");
+      expect(sanitizeAmountBuffer("0.", 2)).toBe("0.");
+      expect(sanitizeAmountBuffer(".", 2)).toBe("0.");
+      expect(sanitizeAmountBuffer("", 2)).toBe("0");
+    });
+
+    it("caps fraction digits at the unit's decimals", () => {
+      expect(sanitizeAmountBuffer("12.345", 2)).toBe("12.34");
+      expect(sanitizeAmountBuffer("4.1", 2)).toBe("4.1");
+      // sat/msat: indivisible, separators are dropped entirely
+      expect(sanitizeAmountBuffer("4.1", 0)).toBe("41");
+      expect(sanitizeAmountBuffer("21.", 0)).toBe("21");
+    });
+
+    it("canonicalizes commas and collapses extra separators", () => {
+      expect(sanitizeAmountBuffer("4,1", 2)).toBe("4.1");
+      expect(sanitizeAmountBuffer("1.2.3", 2)).toBe("1.23");
+    });
+
+    it("caps the integer part at 12 digits", () => {
+      const twelveNines = "9".repeat(MAX_INTEGER_DIGITS);
+      expect(sanitizeAmountBuffer(twelveNines + "9", 2)).toBe(twelveNines);
+    });
+  });
+
+  describe("canonicalAmountBuffer", () => {
+    it("seeds buffers without forced or trailing fraction zeros", () => {
+      expect(canonicalAmountBuffer(0)).toBe("0");
+      expect(canonicalAmountBuffer(21)).toBe("21");
+      expect(canonicalAmountBuffer(21.5)).toBe("21.5");
+      expect(canonicalAmountBuffer(21.05, 2)).toBe("21.05");
+      expect(canonicalAmountBuffer(0.29, 2)).toBe("0.29");
+      expect(canonicalAmountBuffer(1234, 0)).toBe("1234");
+    });
+
+    it("tolerates non-number values passed before user input", () => {
+      // dialogs mount with v-model bound to an empty string
+      expect(canonicalAmountBuffer("" as unknown as number)).toBe("0");
+      expect(canonicalAmountBuffer(null as unknown as number)).toBe("0");
+      expect(canonicalAmountBuffer(undefined as unknown as number)).toBe("0");
+      // numeric strings still seed correctly
+      expect(canonicalAmountBuffer("21.50" as unknown as number)).toBe("21.5");
+    });
+  });
+
+  describe("parseAmountBuffer", () => {
+    it("parses grammar states, treating armed-only fractions as zero", () => {
+      expect(parseAmountBuffer("21")).toBe(21);
+      expect(parseAmountBuffer("21.")).toBe(21);
+      expect(parseAmountBuffer("0.05")).toBe(0.05);
+      expect(parseAmountBuffer(".")).toBe(0);
+      expect(parseAmountBuffer("")).toBe(0);
+    });
+  });
+
+  describe("displayAmountToBaseUnits", () => {
+    it("rounds instead of flooring so float dust cannot drop a base unit", () => {
+      // Math.floor(4.1 * 100) === 409
+      expect(displayAmountToBaseUnits(4.1, 100)).toBe(410);
+      expect(displayAmountToBaseUnits(0.29, 100)).toBe(29);
+      expect(displayAmountToBaseUnits(21, 100)).toBe(2100);
+      expect(displayAmountToBaseUnits(21, 1)).toBe(21);
+    });
+  });
+});

--- a/src/js/amount-entry.ts
+++ b/src/js/amount-entry.ts
@@ -1,0 +1,87 @@
+/*
+ * Amount entry grammar shared with the native wallets (cashubtc/wallet#307).
+ *
+ * Digits build the integer part left to right and the decimal key arms the
+ * fraction, so "21" means twenty-one, not twenty-one hundredths. The raw
+ * buffer keeps a canonical "." separator; locale separators are applied at
+ * display time only.
+ *
+ *   raw  := "" | INT | INT "." | INT "." FRAC
+ *   INT  := "0" | [1-9][0-9]{0,11}
+ *   FRAC := [0-9]{0,decimals}
+ *
+ * The trailing "." is the "fraction armed" state.
+ */
+
+/** Hard cap for any entered amount (in display units), mirrors native apps. */
+export const AMOUNT_ENTRY_MAX = 999_999_999;
+
+/** Maximum digits of the integer part. */
+export const MAX_INTEGER_DIGITS = 12;
+
+/**
+ * Normalize a raw entry buffer to the grammar above.
+ * `fractionDigits` caps the fraction length (0 makes the unit indivisible,
+ * e.g. sat/msat: any separator is dropped).
+ */
+export function sanitizeAmountBuffer(
+  rawBuf: string,
+  fractionDigits: number
+): string {
+  const cleaned = String(rawBuf).replace(/,/g, ".");
+  const dotIndex = cleaned.indexOf(".");
+  let intPart: string;
+  let fracPart = "";
+  if (dotIndex === -1 || fractionDigits <= 0) {
+    intPart = cleaned.replace(/\./g, "");
+  } else {
+    intPart = cleaned.slice(0, dotIndex);
+    fracPart = cleaned
+      .slice(dotIndex + 1)
+      .replace(/\./g, "")
+      .slice(0, fractionDigits);
+  }
+  intPart = intPart
+    .replace(/\D/g, "")
+    .replace(/^0+(?=\d)/, "")
+    .slice(0, MAX_INTEGER_DIGITS);
+  if (intPart === "") intPart = "0";
+  return dotIndex !== -1 && fractionDigits > 0
+    ? `${intPart}.${fracPart}`
+    : intPart;
+}
+
+/**
+ * Canonical raw buffer for a numeric value (used when seeding the buffer from
+ * the current amount): no forced fraction, no trailing fraction zeros.
+ */
+export function canonicalAmountBuffer(
+  value: number,
+  fractionDigits = 2
+): string {
+  // parents may pass ""/null before the user types anything — tolerate it
+  const num = Number(value);
+  if (!isFinite(num) || num === 0) return "0";
+  const fixed = num.toFixed(Math.max(0, Math.min(fractionDigits, 8)));
+  const trimmed = fixed.replace(/(\.\d*?)0+$/, "$1").replace(/\.$/, "");
+  return sanitizeAmountBuffer(trimmed, fractionDigits);
+}
+
+/** Parse an entry buffer to a number (0 when empty or fraction-armed only). */
+export function parseAmountBuffer(buf: string): number {
+  const num = Number(String(buf).replace(/,/g, "."));
+  return isNaN(num) ? 0 : num;
+}
+
+/**
+ * Convert a display-unit amount (as typed, e.g. dollars or sats) to base
+ * units (e.g. cents). Rounded, never floored: buffers carry at most
+ * `fractionDigits` decimals, so rounding cancels binary float dust while
+ * Math.floor would silently drop a base unit (Math.floor(4.1 * 100) === 409).
+ */
+export function displayAmountToBaseUnits(
+  amount: number,
+  multiplyer: number
+): number {
+  return Math.round(amount * multiplyer);
+}

--- a/src/stores/walletOnchain.ts
+++ b/src/stores/walletOnchain.ts
@@ -1,4 +1,5 @@
 import { currentDateStr } from "src/js/utils";
+import { displayAmountToBaseUnits } from "src/js/amount-entry";
 import { useMintsStore, WalletProof } from "./mints";
 import { useProofsStore } from "./proofs";
 import { type MutexPriority, useUiStore } from "src/stores/ui";
@@ -268,8 +269,9 @@ export async function meltQuoteInvoiceDataOnchain(this: any) {
     if (!inputAmount || inputAmount <= 0) {
       throw new Error("no amount provided");
     }
-    const amount = Math.floor(
-      inputAmount * mintStore.activeUnitCurrencyMultiplyer
+    const amount = displayAmountToBaseUnits(
+      inputAmount,
+      mintStore.activeUnitCurrencyMultiplyer
     );
     const data = await mintWallet.createMeltQuoteOnchain(address, amount);
     mintStore.assertMintError(data);


### PR DESCRIPTION
## Summary

Parity with the native wallets: cashubtc/wallet#307.

Entering `21` on a USD mint produced **$0.21**. The keypad was a minor-unit accumulator — every digit shifted in from the right, so the raw string always carried a full fraction. Anyone paying $21 sent 21¢, and the wrong value reached the mint.

Digits now build the integer part left to right, and the decimal key — in the bottom-left slot that was already a blank spacer — arms the fraction. One grammar, shared by fiat mode and unit entry:

```
raw  := "" | INT | INT "." | INT "." FRAC
INT  := "0" | [1-9][0-9]{0,11}
FRAC := [0-9]{0,decimals}
```

The trailing `"."` is the "fraction armed" state, and the raw separator is canonical `"."` with locale formatting applied at display time only (`formatCurrency`). `sat`/`msat` render no decimal key at all: sats are indivisible here, so a fraction could only produce a rounding surprise. (The dialogs were *already* passing a `hide-comma` prop that didn't exist — it's now wired up.)

## Details

**Entry grammar** lives in new `src/js/amount-entry.ts` (pure functions, unit-tested): `sanitizeAmountBuffer`, `canonicalAmountBuffer`, `parseAmountBuffer`. `AmountInputComponent` collapses its two identical accumulators (fiat mode vs fiat-priced units) into one code path, as the native PR did on iOS.

**Load-bearing conversion**: call sites fed by keypad entry — send ecash ×3 (`SendTokenDialog`), create invoice (`CreateInvoiceDialog`), on-chain melt quote (`walletOnchain`) — now use `displayAmountToBaseUnits`, which rounds instead of flooring. Buffers carry at most 2 fraction digits, so rounding cancels binary float dust while `Math.floor(4.1 * 100) === 409` silently dropped a base unit. Price-conversion flooring elsewhere (bolt12 offers, melt price math) is deliberate and untouched.

**Entry caps**, mirroring two bugs fixed in the native PR:
- holding a digit stops at the integer cap / `MAX_AMOUNT` instead of overflowing and silently zeroing the amount
- the cap is enforced against the final parsed value, and the clamped value is reflected back into the buffer

## Test plan

- [x] New shared entry vectors in `src/js/__tests__/amount-entry.test.ts` (grammar states, leading zeros, armed fractions, comma canonicalization, 12-digit integer cap, coercion of `""`/`null` seeds)
- [x] Full suite: 27 files / 195 tests passing; ESLint clean
- [x] Manual: Receive → Lightning opens correctly (regression found & fixed during review: dialog mounts `AmountInputComponent` with an empty-string amount)
- [x] Manual USD mint: typing `2`,`1` → **21**; decimal key arms fraction (`21.` → `21.5`)
- [x] Manual sat control: unchanged behavior, no decimal key